### PR TITLE
Fix Safari file check

### DIFF
--- a/src/alfresco-core-rest-api/src/ApiClient.js
+++ b/src/alfresco-core-rest-api/src/ApiClient.js
@@ -151,6 +151,10 @@
     if (typeof File === 'function' && param instanceof File) {
       return true;
     }
+    // Safari fix
+    if (typeof File === 'object' && param instanceof File) {
+      return true;
+    }
     return false;
   };
 


### PR DESCRIPTION
Ref Cannot upload file in Safari 660
