### PR TITLE
make AlfrescoApiConfig parameters optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Alfresco JS API
 
+<a name="1.1.1"></a>
+# [1.1.1](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.1.1) (27-01-2017)
+## Fix
+- [AlfrescoApiConfig make optional parameters in the declaration file #174](https://github.com/Alfresco/alfresco-js-api/pull/174)
+
 _This project provides a JavaScript client API into the v1 Alfresco REST API_
 <a name="1.1.0"></a>
 # [1.1.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.1.0) (26-01-2017)

--- a/index.d.ts
+++ b/index.d.ts
@@ -485,14 +485,14 @@ declare namespace AlfrescoApi {
     }
 
     export interface AlfrescoApiConfig {
-        hostEcm: string;
-        hostBpm: string;
-        contextRoot: string;
-        contextRootBpm: string;
-        provider: string;
-        ticketEcm: string;
-        ticketBpm: string;
-        disableCsrf: boolean;
+        hostEcm?: string;
+        hostBpm?: string;
+        contextRoot?: string;
+        contextRootBpm?: string;
+        provider?: string;
+        ticketEcm?: string;
+        ticketBpm?: string;
+        disableCsrf?: boolean;
     }
 
     export interface ContentApi {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-ap/wiki/Commit-format)
[x ] Tests for the changes have been added (for bug fixes / features)
[ x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-ap/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

The parameter in the object AlfrescoApiConfig are not optional in the declaration file that make tslint unhappy.



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
