### PR TITLE
getNodeChildren works with proxied users

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,6 +17,5 @@
 *.DS_Store
 /package/
 /webpack-bundle-test.js
-/webpack.config.js
 /.github/
 /.babelrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
   <img title="alfresco" alt='alfresco' src='assets/alfresco.png'  width="280px" height="150px"></img>
 </p>
 
-Alfresco JS API
+# Alfresco JS API
+
+<a name="1.5.0"></a>
+# [1.5.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.5.0) (xx-xx-2017)
+## Fix
+
+## Features
+- [Ability to remember/forget username upon login/logout](https://github.com/Alfresco/alfresco-js-api/pull/225)
 
 <a name="1.4.0"></a>
 # [1.4.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.4.0) (27-04-2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@
 # Alfresco JS API
 
 <a name="1.5.0"></a>
-# [1.5.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.5.0) (xx-xx-2017)
-## Fix
-
+# [1.5.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.5.0) (25-05-2017)
 ## Features
 - [Ability to remember/forget username upon login/logout](https://github.com/Alfresco/alfresco-js-api/pull/225)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -543,6 +543,7 @@ declare namespace AlfrescoApi {
     export interface AuthApi {
         new(config: AlfrescoApiConfig): AuthApi;
 
+        username: string;
         changeHost(host: string): void;
         login(username: string, password: string): Promise<string>;
         logout(): Promise<string>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfresco-js-api",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "JavaScript client library for the Alfresco REST API",
   "author": "Alfresco Software, Ltd.",
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "generate": "mvn clean generate-sources",
     "watchify": "watchify -s AlfrescoApi main.js -o dist/alfresco-js-api.js",
     "tslint": "tslint -c tslint.json index.d.ts",
-    "toc": "markdown-toc -i README.md && markdown-toc -i test/mockObjects/README.md"
+    "toc": "markdown-toc -i README.md && markdown-toc -i test/mockObjects/README.md",
+    "prepublish" : "npm run webpack"
   },
   "repository": {
     "type": "git",

--- a/src/alfresco-core-rest-api/src/api/NodesApi.js
+++ b/src/alfresco-core-rest-api/src/api/NodesApi.js
@@ -359,6 +359,7 @@
      * @param {String} opts.relativePath Return information on children within the folder resolved by this path (relative to specified nodeId as the starting parent folder)
      * @param {Boolean} opts.includeSource Also include \&quot;source\&quot; (in addition to \&quot;entries\&quot;) with folder information on parent node (either the specified parent \&quot;nodeId\&quot; or as resolved by \&quot;relativePath\&quot;)
      * @param {Array.<String>} opts.fields A list of field names.\n\nYou can use this parameter to restrict the fields\nreturned within a response if, for example, you want to save on overall bandwidth.\n\nThe list applies to a returned individual\nentity or entries within a collection.\n\nIf the API method also supports the **include**\nparameter, then the fields specified in the **include**\nparameter are returned in addition to those specified in the **fields** parameter.\n
+     * @param {String} opts.proxyUserName The username that this request should proxy as
      * data is of type: {module:model/NodePaging}
      */
     this.getNodeChildren = function(nodeId, opts) {
@@ -397,7 +398,8 @@
       return this.apiClient.callApi(
         '/nodes/{nodeId}/children', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, undefined,
+        undefined, opts.proxyUserName
       );
     }
 

--- a/src/alfrescoApi.js
+++ b/src/alfrescoApi.js
@@ -81,6 +81,18 @@ class AlfrescoApi {
             this.invalidateSession();
         });
 
+        this.ecmClient.on('unauthorized', ()=> {
+            this.invalidateSession();
+        });
+
+        this.ecmPrivateClient.on('unauthorized', ()=> {
+            this.invalidateSession();
+        });
+
+        this.bpmClient.on('unauthorized', ()=> {
+            this.invalidateSession();
+        });
+
         if (this.config.provider === 'OAUTH') {
             this.oauth2Auth = new Oauth2Auth(this.config);
             this.setAuthenticationClientECMBPM(this.oauth2Auth.getAuthentication(), this.oauth2Auth.getAuthentication());

--- a/src/alfrescoApi.js
+++ b/src/alfrescoApi.js
@@ -34,6 +34,7 @@ class AlfrescoApi {
      *        ticketEcm:     // Ticket if you already have a ECM ticket you can pass only the ticket and skip the login, in this case you don't need username and password
      *        ticketBpm:     // Ticket if you already have a BPM ticket you can pass only the ticket and skip the login, in this case you don't need username and password
      *        disableCsrf:   // To disable CSRF Token to be submitted. Only for Activiti call, by default is false.
+     *        proxyHeader:   // The name of the HTTP header that contains the name of a proxied user.  "External Authentication" must be configured for this to work.
      *    };
      */
     constructor(config) {
@@ -52,7 +53,8 @@ class AlfrescoApi {
             ticketEcm: config.ticketEcm,
             ticketBpm: config.ticketBpm,
             accessToken: config.accessToken,
-            disableCsrf: config.disableCsrf || false
+            disableCsrf: config.disableCsrf || false,
+            proxyHeader: config.proxyHeader || 'X-Alfresco-Remote-User'
         };
 
         this.ecmPrivateClient = new EcmPrivateClient(this.config);

--- a/src/alfrescoApiClient.js
+++ b/src/alfrescoApiClient.js
@@ -37,7 +37,7 @@ class AlfrescoApiClient extends ApiClient {
      * constructor for a complex type.   * @returns {Promise} A Promise object.
      */
     callApi(path, httpMethod, pathParams, queryParams, headerParams, formParams, bodyParam, authNames,
-            contentTypes, accepts, returnType, contextRoot, responseType) {
+            contentTypes, accepts, returnType, contextRoot, responseType, proxyUserName) {
 
         var eventEmitter = {};
         Emitter(eventEmitter); // jshint ignore:line
@@ -52,7 +52,7 @@ class AlfrescoApiClient extends ApiClient {
         }
 
         var request = this.buildRequest(httpMethod, url, queryParams, headerParams, formParams, bodyParam,
-            contentTypes, accepts, responseType, eventEmitter);
+            contentTypes, accepts, responseType, eventEmitter, proxyUserName);
 
         this.promise = new Promise((resolve, reject) => {
             request.end((error, response) => {
@@ -193,7 +193,7 @@ class AlfrescoApiClient extends ApiClient {
     }
 
     buildRequest(httpMethod, url, queryParams, headerParams, formParams, bodyParam,
-                  contentTypes, accepts, responseType, eventEmitter) {
+                  contentTypes, accepts, responseType, eventEmitter, proxyUserName) {
         var request = superagent(httpMethod, url);
 
         // apply authentications
@@ -204,6 +204,11 @@ class AlfrescoApiClient extends ApiClient {
 
         // set header parameters
         request.set(this.defaultHeaders).set(this.normalizeParams(headerParams));
+
+        // set the proxy user name if present
+        if (!!proxyUserName) {
+            request.set(this.config.proxyHeader, proxyUserName);
+        }
 
         if (this.isBpmRequest() && this.isCsrfEnabled()) {
             this.setCsrfToken(request);

--- a/src/bpmAuth.js
+++ b/src/bpmAuth.js
@@ -10,6 +10,8 @@ class BpmAuth extends AlfrescoApiClient {
      */
     constructor(config) {
         super();
+
+        this.username = '';
         this.config = config;
         this.ticket = undefined;
 
@@ -43,6 +45,7 @@ class BpmAuth extends AlfrescoApiClient {
      * @returns {Promise} A promise that returns {new authentication ticket} if resolved and {error} if rejected.
      * */
     login(username, password) {
+        this.username = username;
         this.authentications.basicAuth.username = username;
         this.authentications.basicAuth.password = password;
 
@@ -98,6 +101,7 @@ class BpmAuth extends AlfrescoApiClient {
      * @returns {Promise} A promise that returns {new authentication ticket} if resolved and {error} if rejected.
      * */
     logout() {
+        this.username = '';
         var postBody = {}, pathParams = {}, queryParams = {}, headerParams = {}, formParams = {};
 
         var authNames = [];

--- a/src/ecmAuth.js
+++ b/src/ecmAuth.js
@@ -12,6 +12,7 @@ class EcmAuth extends AlfrescoApiClient {
     constructor(config) {
         super();
 
+        this.username = '';
         this.config = config;
 
         this.basePath = this.config.hostEcm + '/' + this.config.contextRoot + '/api/-default-/public/authentication/versions/1'; //Auth Call
@@ -36,6 +37,7 @@ class EcmAuth extends AlfrescoApiClient {
      * @returns {Promise} A promise that returns {new authentication ticket} if resolved and {error} if rejected.
      * */
     login(username, password) {
+        this.username = username;
         this.authentications.basicAuth.username = username;
         this.authentications.basicAuth.password = password;
 
@@ -104,6 +106,7 @@ class EcmAuth extends AlfrescoApiClient {
      * @returns {Promise} A promise that returns { authentication ticket} if resolved and {error} if rejected.
      * */
     logout() {
+        this.username = '';
         var authApi = new AlfrescoAuthRestApi.AuthenticationApi(this);
 
         this.promise = new Promise((resolve, reject) => {

--- a/test/bpmAuth.spec.js
+++ b/test/bpmAuth.spec.js
@@ -12,6 +12,22 @@ describe('Bpm Auth test', function () {
         this.authBpmMock = new AuthBpmMock(this.hostBpm);
     });
 
+    it('should remember username on login', () => {
+        const auth = new BpmAuth({});
+        auth.login('johndoe', 'password');
+        expect(auth.username).to.be.equal('johndoe');
+    });
+
+    it('should forget username on logout', () => {
+        const auth = new BpmAuth({});
+
+        auth.login('johndoe', 'password');
+        expect(auth.username).to.be.equal('johndoe');
+
+        auth.logout();
+        expect(auth.username).to.be.equal('');
+    });
+
     describe('With Authentication', function () {
 
         it('login should return the Ticket if all is ok', function (done) {

--- a/test/ecmAuth.spec.js
+++ b/test/ecmAuth.spec.js
@@ -11,6 +11,22 @@ describe('Ecm Auth test', function () {
         this.authEcmMock = new AuthEcmMock(this.hostEcm);
     });
 
+    it('should remember username on login', () => {
+        const auth = new EcmAuth({});
+        auth.login('johndoe', 'password');
+        expect(auth.username).to.be.equal('johndoe');
+    });
+
+    it('should forget username on logout', () => {
+        const auth = new EcmAuth({});
+
+        auth.login('johndoe', 'password');
+        expect(auth.username).to.be.equal('johndoe');
+
+        auth.logout();
+        expect(auth.username).to.be.equal('');
+    });
+
     describe('With Authentication', function () {
 
         it('login should return the Ticket if all is ok', function (done) {

--- a/test/mockObjects/alfresco/nodeMock.js
+++ b/test/mockObjects/alfresco/nodeMock.js
@@ -92,6 +92,90 @@ class NodeMock extends BaseMock {
 
     }
 
+    get200ResponseChildrenProxiedUser() {
+        nock(this.host)
+            .matchHeader('X-Alfresco-Remote-User', 'proxiedUserGoesHere')
+            .get('/alfresco/api/-default-/public/alfresco/versions/1/nodes/a4cff62a-664d-4d45-9302-98723eac1319/children')
+            .reply(200, {
+                'list': {
+                    'pagination': {
+                        'count': 5,
+                        'hasMoreItems': false,
+                        'totalItems': 5,
+                        'skipCount': 0,
+                        'maxItems': 100
+                    },
+                    'entries': [{
+                        'entry': {
+                            'createdAt': '2011-02-15T20:19:00.007+0000',
+                            'isFolder': true,
+                            'isFile': false,
+                            'createdByUser': {'id': 'mjackson', 'displayName': 'Mike Jackson'},
+                            'modifiedAt': '2011-02-15T20:19:00.007+0000',
+                            'modifiedByUser': {'id': 'mjackson', 'displayName': 'Mike Jackson'},
+                            'name': 'dataLists',
+                            'id': '64f69e69-f61e-42a3-8697-95eea1f2bda2',
+                            'nodeType': 'cm:folder',
+                            'parentId': 'b4cff62a-664d-4d45-9302-98723eac1319'
+                        }
+                    }, {
+                        'entry': {
+                            'createdAt': '2011-02-15T22:04:54.290+0000',
+                            'isFolder': true,
+                            'isFile': false,
+                            'createdByUser': {'id': 'mjackson', 'displayName': 'Mike Jackson'},
+                            'modifiedAt': '2011-02-15T22:04:54.290+0000',
+                            'modifiedByUser': {'id': 'mjackson', 'displayName': 'Mike Jackson'},
+                            'name': 'discussions',
+                            'id': '059c5bc7-2d38-4dc5-96b8-d09cd3c69b4c',
+                            'nodeType': 'cm:folder',
+                            'parentId': 'b4cff62a-664d-4d45-9302-98723eac1319'
+                        }
+                    }, {
+                        'entry': {
+                            'createdAt': '2011-02-15T20:16:28.292+0000',
+                            'isFolder': true,
+                            'isFile': false,
+                            'createdByUser': {'id': 'mjackson', 'displayName': 'Mike Jackson'},
+                            'modifiedAt': '2016-06-27T14:31:10.007+0000',
+                            'modifiedByUser': {'id': 'admin', 'displayName': 'Administrator'},
+                            'name': 'documentLibrary',
+                            'id': '8f2105b4-daaf-4874-9e8a-2152569d109b',
+                            'nodeType': 'cm:folder',
+                            'parentId': 'b4cff62a-664d-4d45-9302-98723eac1319'
+                        }
+                    }, {
+                        'entry': {
+                            'createdAt': '2011-02-15T20:18:59.808+0000',
+                            'isFolder': true,
+                            'isFile': false,
+                            'createdByUser': {'id': 'mjackson', 'displayName': 'Mike Jackson'},
+                            'modifiedAt': '2011-02-15T20:18:59.808+0000',
+                            'modifiedByUser': {'id': 'mjackson', 'displayName': 'Mike Jackson'},
+                            'name': 'links',
+                            'id': '0e24b99c-41f0-43e1-a55e-fb9f50d73820',
+                            'nodeType': 'cm:folder',
+                            'parentId': 'b4cff62a-664d-4d45-9302-98723eac1319'
+                        }
+                    }, {
+                        'entry': {
+                            'createdAt': '2011-02-15T21:46:01.603+0000',
+                            'isFolder': true,
+                            'isFile': false,
+                            'createdByUser': {'id': 'mjackson', 'displayName': 'Mike Jackson'},
+                            'modifiedAt': '2011-02-15T21:46:01.603+0000',
+                            'modifiedByUser': {'id': 'mjackson', 'displayName': 'Mike Jackson'},
+                            'name': 'wiki',
+                            'id': 'cdefb3a9-8f55-4771-a9e3-06fa370250f6',
+                            'nodeType': 'cm:folder',
+                            'parentId': 'b4cff62a-664d-4d45-9302-98723eac1319'
+                        }
+                    }]
+                }
+            });
+
+    }
+
     get200ResponseSingleFileFolder() {
         nock(this.host, {'encodedQueryParams': true})
             .get('/alfresco/api/-default-/public/alfresco/versions/1/nodes/80a94ac8-3ece-47ad-864e-5d939424c47c')

--- a/test/nodeApi.spec.js
+++ b/test/nodeApi.spec.js
@@ -125,6 +125,16 @@ describe('Node', function () {
             });
 
         });
+
+        it('should proxy a user if instructed', function (done) {
+            this.nodeMock.get200ResponseChildrenProxiedUser();
+
+            this.alfrescoJsApi.nodes.getNodeChildren('a4cff62a-664d-4d45-9302-98723eac1319', { 'proxyUserName': 'proxiedUserGoesHere' }).then(function (data) {
+                expect(data.list.pagination.count).to.be.equal(5);
+                expect(data.list.entries[0].entry.name).to.be.equal('dataLists');
+                done();
+            });
+        });
     });
 
     describe('Delete', function () {


### PR DESCRIPTION
This is a POC for an approach that we might use for implementing this
across all APIs.  See #229.

**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-ap/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-ap/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

External Authentication is not usable. #229 

**What is the new behavior?**

`getNodeChildren` supports External Authentication.  This is just one proposal for how to implement this, hopefully spurring more conversation.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
