### PR TITLE
#199 - move from rest to enterprise task-forms variables api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 # Alfresco JS API
 
+<a name="1.6.0"></a>
+# [1.6.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.6.0) (xx-06-2017)
+## Fix
+- [Move /task-forms/{task-id}/variables from rest to enterprise](https://github.com/Alfresco/alfresco-js-api/issues/199)
+
 <a name="1.5.0"></a>
 # [1.5.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.5.0) (25-05-2017)
 ## Features

--- a/src/alfresco-activiti-rest-api/src/api/TaskFormsApi.js
+++ b/src/alfresco-activiti-rest-api/src/api/TaskFormsApi.js
@@ -265,7 +265,7 @@
       var returnType = [ProcessInstanceVariableRepresentation];
 
       return this.apiClient.callApi(
-        '/app/rest/task-forms/{taskId}/variables', 'GET',
+        '/api/enterprise/task-forms/{taskId}/variables', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
       );

--- a/test/mockObjects/activiti/taskFormMock.js
+++ b/test/mockObjects/activiti/taskFormMock.js
@@ -11,7 +11,7 @@ class TaskFormMock extends BaseMock {
 
     get200getTaskFormVariables() {
         nock(this.host, {'encodedQueryParams': true})
-            .get('/activiti-app/app/rest/task-forms/5028/variables')
+            .get('/activiti-app/api/enterprise/task-forms/5028/variables')
             .reply(200, [{'id':'initiator','type':'string','value':'1001'}], [ 'Server',
                 'Apache-Coyote/1.1',
                 'set-cookie',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-ap/wiki/Commit-format)
[ x] Tests for the changes have been added (for bug fixes / features)
[ x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-ap/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
move from rest to enterprise task-forms variables api


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
