### PR TITLE
[ADF-793] The ability to retrieve a rendition's url from the content API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 <a name="1.6.0"></a>
 # [1.6.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.6.0) (xx-06-2017)
+## Features
+- [Get rendition URL for a given nodeId from content API](https://github.com/Alfresco/alfresco-js-api/issues/237)
 ## Fix
 - [Move /task-forms/{task-id}/variables from rest to enterprise](https://github.com/Alfresco/alfresco-js-api/issues/199)
 - [Added query param for get related contents](https://issues.alfresco.com/jira/browse/ADF-684)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,13 @@
 
 <a name="1.6.0"></a>
 # [1.6.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.6.0) (xx-06-2017)
-## Features
-- [Get rendition URL for a given nodeId from content API](https://github.com/Alfresco/alfresco-js-api/issues/237)
 ## Fix
 - [Move /task-forms/{task-id}/variables from rest to enterprise](https://github.com/Alfresco/alfresco-js-api/issues/199)
 - [Added query param for get related contents](https://issues.alfresco.com/jira/browse/ADF-684)
 
 ## Features
 - [Complete TypeScript definitions for JS-API](https://github.com/Alfresco/alfresco-js-api/issues/228)
+- [Get rendition URL for a given nodeId from content API](https://github.com/Alfresco/alfresco-js-api/issues/237)
 
 <a name="1.5.0"></a>
 # [1.5.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.5.0) (25-05-2017)

--- a/src/alfrescoContent.js
+++ b/src/alfrescoContent.js
@@ -46,6 +46,19 @@ class AlfrescoContent {
             '/content' + '?attachment=false&alf_ticket=' + this.ecmAuth.getTicket();
     }
 
+    /**
+     * Get rendition URL for the given nodeId
+     *
+     * @param {String} nodeId of the document
+     * @param {String} encoding of the document
+     *
+     * @returns {String}  content URL  address.
+     */
+    getRenditionUrl(nodeId, encoding) {
+        return this.ecmClient.basePath + '/nodes/' + nodeId +
+                '/renditions/' + encoding +
+            '/content' + '?attachment=false&alf_ticket=' + this.ecmAuth.getTicket();
+    }
 }
 
 module.exports = AlfrescoContent;

--- a/test/contet.spec.js
+++ b/test/contet.spec.js
@@ -43,4 +43,14 @@ describe('Content', function () {
             '1a0b110f-1e09-4ca2-b367-fe25e4964a4/content?attachment=false' +
             '&alf_ticket=TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1');
     });
+
+    it('get Rendition Url', function () {
+        const encoding = 'pdf';
+        var contentUrl = this.alfrescoJsApi.content.getRenditionUrl('1a0b110f-1e09-4ca2-b367-fe25e4964a4', encoding);
+
+        expect(contentUrl).to.be.equal(this.hostEcm + '/alfresco/api/-default-/public/alfresco/versions/1/nodes/' +
+            '1a0b110f-1e09-4ca2-b367-fe25e4964a4/renditions/' + encoding +
+            '/content?attachment=false' +
+            '&alf_ticket=TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1');
+    });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-ap/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-ap/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
No possible option to retrieve a rendition's url from the content API.


**What is the new behavior?**
getRenditionUrl of the AlfrescoContent class returns the rendition URL for the given nodeId


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
