### PR TITLE
Add Audit task logs endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [APS ContentApi is not present on index.d.ts and SitesApi is not complete](https://github.com/Alfresco/alfresco-js-api/issues/249)
 
 ## Features
+- [Audit Log API - The end points are missing] (https://github.com/Alfresco/alfresco-js-api/issues/256)
 - [Allow providing "attachment" option value when generating content links](https://issues.alfresco.com/jira/browse/ADF-1086)
 
 <a name="1.6.0"></a>

--- a/index.d.ts
+++ b/index.d.ts
@@ -96,7 +96,7 @@ declare namespace AlfrescoApi {
         search: any;
         nodes: NodesApi;
         content: ContentApi;
-        upload:  UploadApi;
+        upload: UploadApi;
         webScript: WebscriptApi;
 
         ecmClient: EcmClient;
@@ -419,22 +419,22 @@ declare namespace AlfrescoApi {
     export interface ChildAssociationsApi {
         new(client: ApiClient): ChildAssociationsApi;
 
-        addNode(nodeld?: string, nodeBody?: NodeBody, opts?: {autoRename?:  boolean, include?: Array<string>, fields?: Array<string>}): Promise<{}>;
+        addNode(nodeld?: string, nodeBody?: NodeBody, opts?: { autoRename?: boolean, include?: Array<string>, fields?: Array<string> }): Promise<{}>;
         addSecondaryChildAssoc(parentld?: string, assocChildBody?: AssocChildBody): Promise<{}>;
-        deleteNode(nodeld?: string, opts?: {permanent?:  boolean}): Promise<{}>;
-        getNodeChildren(nodeld?: string, opts?: {skipCount?: number, maxltems?: number, orderBy?:  string, where?:  string, include?: Array<string>, relativePath?:  string, includeSource?:  boolean, fields?: Array<string>}): Promise<{}>;
-        listParents(childld?: string, opts?: {where?:  string, include?:  string, fields?: Array<string>}): Promise<{}>;
-        listSecondaryChildAssociations(parentld?: string, opts?: {assocType?:  string, where?:  string, include?:  string, fields?: Array<string>}): Promise<{}>;
-        moveNode(nodeld?: string, moveBody?: MoveBody, opts?: {include?: Array<string>, fields?: Array<string>}): Promise<{}>;
+        deleteNode(nodeld?: string, opts?: { permanent?: boolean }): Promise<{}>;
+        getNodeChildren(nodeld?: string, opts?: { skipCount?: number, maxltems?: number, orderBy?: string, where?: string, include?: Array<string>, relativePath?: string, includeSource?: boolean, fields?: Array<string> }): Promise<{}>;
+        listParents(childld?: string, opts?: { where?: string, include?: string, fields?: Array<string> }): Promise<{}>;
+        listSecondaryChildAssociations(parentld?: string, opts?: { assocType?: string, where?: string, include?: string, fields?: Array<string> }): Promise<{}>;
+        moveNode(nodeld?: string, moveBody?: MoveBody, opts?: { include?: Array<string>, fields?: Array<string> }): Promise<{}>;
     }
 
     export interface AssociationsApi {
         new(client: ApiClient): AssociationsApi;
 
         addAssoc(sourceld?: string, assocTargetBody?: AssocTargetBody): Promise<{}>;
-        listSourceNodeAssociations(targetld?: string, opts?: {where?: string, include?: string, fields?: Array<string>}): Promise<{}>;
-        listTargetAssociations(sourceld?: string, opts?: {where?: string, include?: string, fields?: Array<string>}): Promise<{}>;
-        removeAssoc(sourceld?: string, targetld?: string, opts?: {assocType?: string}): Promise<{}>;
+        listSourceNodeAssociations(targetld?: string, opts?: { where?: string, include?: string, fields?: Array<string> }): Promise<{}>;
+        listTargetAssociations(sourceld?: string, opts?: { where?: string, include?: string, fields?: Array<string> }): Promise<{}>;
+        removeAssoc(sourceld?: string, targetld?: string, opts?: { assocType?: string }): Promise<{}>;
 
     }
 
@@ -458,43 +458,43 @@ declare namespace AlfrescoApi {
     export interface NodesApi {
         new(client: ApiClient): NodesApi;
 
-        addNode(nodeld?: string, nodeBody?: NodeBody, opts?: {autoRename?: boolean, include?: Array<string>, fields?: Array<string>}): Promise<NodeEntry>;
-        copyNode(nodeld?: string, copyBody?: CopyBody, opts?: {include?: Array<string>, fields?: Array<string>}): Promise<NodeEntry>;
-        deleteNode(nodeld?: string, opts?: {permanent?: boolean}): Promise<{}>;
-        getDeletedNode(nodeld?: string, opts?: {include?: Array<string>}): Promise<DeletedNodeEntry>;
-        getDeletedNodes(opts?: {skipCount?: number, maxltems?: number, include?: Array<string>}): Promise<DeletedNodeEntry>;
-        getFileContent(nodeld?: string, opts?: {attachment?: boolean, ifModifiedSince?: Date}): Promise<{}>;
-        getNode(nodeld?: string, opts?: {include?: Array<string>, relativePath?: string, fields?: Array<string>}): Promise<{}>;
+        addNode(nodeld?: string, nodeBody?: NodeBody, opts?: { autoRename?: boolean, include?: Array<string>, fields?: Array<string> }): Promise<NodeEntry>;
+        copyNode(nodeld?: string, copyBody?: CopyBody, opts?: { include?: Array<string>, fields?: Array<string> }): Promise<NodeEntry>;
+        deleteNode(nodeld?: string, opts?: { permanent?: boolean }): Promise<{}>;
+        getDeletedNode(nodeld?: string, opts?: { include?: Array<string> }): Promise<DeletedNodeEntry>;
+        getDeletedNodes(opts?: { skipCount?: number, maxltems?: number, include?: Array<string> }): Promise<DeletedNodeEntry>;
+        getFileContent(nodeld?: string, opts?: { attachment?: boolean, ifModifiedSince?: Date }): Promise<{}>;
+        getNode(nodeld?: string, opts?: { include?: Array<string>, relativePath?: string, fields?: Array<string> }): Promise<{}>;
         getNodeContent(nodeId?: string, opts?: any): Promise<{}>;
-        getNodeChildren(nodeld?: string, opts?: {skipCount?: number, maxltems?: number, orderBy?: string, where?: string, include?: Array<string>, relativePath?: string, includeSource?: boolean, fields?: Array<string>}): Promise<{}>;
-        getParents(nodeld?: string, opts?: {where?: string, include?: Array<string>, skipCount?: number, maxltems?: number, includeSource?: boolean, fields?: Array<string>}): Promise<{}>;
-        getSecondaryChildren(nodeld?: string, opts?: {where?: string, include?: Array<string>, skipCount?: number, maxltems?: number, includeSource?: boolean, fields?: Array<string>}): Promise<{}>;
-        getSourceAssociations(nodeld?: string, opts?: {where?: string, include?: Array<string>, fields?: Array<string>}): Promise<{}>;
-        getTargetAssociations(nodeld?: string, opts?: {where?: string, include?: Array<string>, fields?: Array<string>}): Promise<{}>;
-        lockNode(nodeld?: string, nodeBodyLock?: NodeBodyLock, opts?: {include?: Array<string>, fields?: Array<string>}): Promise<{}>;
-        unlockNode(nodeld?: string, opts?: {include?: Array<string>, fields?: Array<string>}): Promise<{}>;
-        moveNode(nodeld?: string, moveBody?: MoveBody, opts?: {include?: Array<string>, fields?: Array<string>}): Promise<{}>;
+        getNodeChildren(nodeld?: string, opts?: { skipCount?: number, maxltems?: number, orderBy?: string, where?: string, include?: Array<string>, relativePath?: string, includeSource?: boolean, fields?: Array<string> }): Promise<{}>;
+        getParents(nodeld?: string, opts?: { where?: string, include?: Array<string>, skipCount?: number, maxltems?: number, includeSource?: boolean, fields?: Array<string> }): Promise<{}>;
+        getSecondaryChildren(nodeld?: string, opts?: { where?: string, include?: Array<string>, skipCount?: number, maxltems?: number, includeSource?: boolean, fields?: Array<string> }): Promise<{}>;
+        getSourceAssociations(nodeld?: string, opts?: { where?: string, include?: Array<string>, fields?: Array<string> }): Promise<{}>;
+        getTargetAssociations(nodeld?: string, opts?: { where?: string, include?: Array<string>, fields?: Array<string> }): Promise<{}>;
+        lockNode(nodeld?: string, nodeBodyLock?: NodeBodyLock, opts?: { include?: Array<string>, fields?: Array<string> }): Promise<{}>;
+        unlockNode(nodeld?: string, opts?: { include?: Array<string>, fields?: Array<string> }): Promise<{}>;
+        moveNode(nodeld?: string, moveBody?: MoveBody, opts?: { include?: Array<string>, fields?: Array<string> }): Promise<{}>;
         purgeDeletedNode(nodeld?: string): Promise<{}>;
         restoreNode(nodeld?: string): Promise<NodeEntry>;
-        updateFileContent(nodeld?: string, contentBody?: string, opts?: {majorVersion?: boolean, comment?: string, include?: Array<string>, fields?: Array<string>}): Promise<NodeEntry>;
+        updateFileContent(nodeld?: string, contentBody?: string, opts?: { majorVersion?: boolean, comment?: string, include?: Array<string>, fields?: Array<string> }): Promise<NodeEntry>;
         updateNodeContent(nodeId?: string, contentBody?: string, opts?: any): Promise<NodeEntry>;
-        updateNode(nodeld?: string, nodeBody?: NodeBody, opts?: {include?: Array<string>, fields?: Array<string>}): Promise<NodeEntry>;
+        updateNode(nodeld?: string, nodeBody?: NodeBody, opts?: { include?: Array<string>, fields?: Array<string> }): Promise<NodeEntry>;
     }
 
     export interface SitesApi {
-        new(client?: ApiClient):SitesApi;
+        new(client?: ApiClient): SitesApi;
 
-        addSiteMember(siteld?: string, siteMemberBody?: SiteMemberBody):Promise<{}>;
-        createSite(siteBody?: SiteBody, opts?: {skipConfiguration?:Boolean, skipAddToFavorites?:Boolean}):Promise<{}>;
-        deleteSite(siteld?: string, opts?: {permanent?:Boolean}):Promise<{}>;
-        getSite(siteld?: string, opts?: {relations?:Array<string>, fields?:Array<string>}):Promise<{}>;
-        getSiteContainer(siteld?: string, containerld?: string, opts?: Array<string>):Promise<{}>;
-        getSiteContainers(siteld?: string, opts?: {skipCount?:number, maxltems?:number, fields?:Array<string>}):Promise<{}>;
-        getSiteMember(siteld?: string, personld?: string, opts?: {fields?:Array<string>}):Promise<{}>;
-        getSiteMembers(siteld?: string, opts?: {skipCount?:number, maxltems?:number, fields?:Array<string>}):Promise<{}>;
-        getSites(opts?: {skipCount?:number, maxltems?:number, orderBy?:string, relations?:Array<string>, fields?:Array<string>}):Promise<{}>;
-        removeSiteMember(siteld?: string, personld?: string):Promise<{}>;
-        updateSiteMember(siteld?: string, personld?: string, siteMemberRoleBody?: SiteMemberRoleBody):Promise<{}>;
+        addSiteMember(siteld?: string, siteMemberBody?: SiteMemberBody): Promise<{}>;
+        createSite(siteBody?: SiteBody, opts?: { skipConfiguration?: Boolean, skipAddToFavorites?: Boolean }): Promise<{}>;
+        deleteSite(siteld?: string, opts?: { permanent?: Boolean }): Promise<{}>;
+        getSite(siteld?: string, opts?: { relations?: Array<string>, fields?: Array<string> }): Promise<{}>;
+        getSiteContainer(siteld?: string, containerld?: string, opts?: Array<string>): Promise<{}>;
+        getSiteContainers(siteld?: string, opts?: { skipCount?: number, maxltems?: number, fields?: Array<string> }): Promise<{}>;
+        getSiteMember(siteld?: string, personld?: string, opts?: { fields?: Array<string> }): Promise<{}>;
+        getSiteMembers(siteld?: string, opts?: { skipCount?: number, maxltems?: number, fields?: Array<string> }): Promise<{}>;
+        getSites(opts?: { skipCount?: number, maxltems?: number, orderBy?: string, relations?: Array<string>, fields?: Array<string> }): Promise<{}>;
+        removeSiteMember(siteld?: string, personld?: string): Promise<{}>;
+        updateSiteMember(siteld?: string, personld?: string, siteMemberRoleBody?: SiteMemberRoleBody): Promise<{}>;
     }
 
     export interface PeopleApi {
@@ -504,28 +504,28 @@ declare namespace AlfrescoApi {
         addSiteMembershipRequest(personld?: string, siteMembershipBody?: SiteMembershipRequestBody): Promise<SiteMembershipRequestEntry>;
         deleteFavoriteSite(personld?: string, siteld?: string): Promise<{}>;
         favoriteSite(personld?: string, favoriteSiteBody?: FavoriteSiteBody): Promise<FavoriteEntry>;
-        getActivities(personld?: string, opts?: {skipCount?: number, maxltems?: number, who?: string, siteld?: string, fields?: Array<string>}): Promise<ActivityPaging>;
-        getFavorite(personld?: string, favoriteld?: string, opts?: {fields?: Array<string>}): Promise<FavoriteEntry>;
-        getFavoriteSite(personld?: string, siteld?: string, opts?: {fields?: Array<string>}): Promise<SiteEntry>;
-        getFavoriteSites(personld?: string, opts?: {skipCount?: number, maxltems?: number, fields?: Array<string>}): Promise<SitePaging>;
-        getFavorites(personld?: string, opts?: {skipCount?: number, maxltems?: number, where?: string, fields?: Array<string>}): Promise<FavoritePaging>;
-        getPerson(personld?: string, opts?: {fields?: Array<string>}): Promise<PersonEntry>;
-        getPersonNetwork(personld?: string, networkld?: string, opts?: {fields?: Array<string>}): Promise<PersonNetworkEntry>;
-        getPersonNetworks(personld?: string, opts?: {skipCount?: number, maxltems?: number, fields?: Array<string>}): Promise<PersonNetworkPaging>;
-        getPreference(personld?: string, preferenceName?: string, opts?: {fields?: Array<string>}): Promise<PreferenceEntry>;
-        getPreferences(personld?: string, opts?: {skipCount?: number, maxltems?: number, fields?: Array<string>}): Promise<PreferencePaging>;
-        getSiteMembership(personld?: string, opts?: {skipCount?: number, maxltems?: number, orderBy?: string, relations?: Array<string>, fields?: Array<string>}): Promise<SiteMembershipRequestEntry>;
-        getSiteMembershipRequest(personld?: string, siteld?: string, opts?: {fields?: Array<string>}): Promise<SiteMembershipRequestEntry>;
-        getSiteMembershipRequests(personld?: string, opts?: {skipCount?: number, maxltems?: number, fields?: Array<string>}): Promise<SiteMembershipRequestPaging>;
+        getActivities(personld?: string, opts?: { skipCount?: number, maxltems?: number, who?: string, siteld?: string, fields?: Array<string> }): Promise<ActivityPaging>;
+        getFavorite(personld?: string, favoriteld?: string, opts?: { fields?: Array<string> }): Promise<FavoriteEntry>;
+        getFavoriteSite(personld?: string, siteld?: string, opts?: { fields?: Array<string> }): Promise<SiteEntry>;
+        getFavoriteSites(personld?: string, opts?: { skipCount?: number, maxltems?: number, fields?: Array<string> }): Promise<SitePaging>;
+        getFavorites(personld?: string, opts?: { skipCount?: number, maxltems?: number, where?: string, fields?: Array<string> }): Promise<FavoritePaging>;
+        getPerson(personld?: string, opts?: { fields?: Array<string> }): Promise<PersonEntry>;
+        getPersonNetwork(personld?: string, networkld?: string, opts?: { fields?: Array<string> }): Promise<PersonNetworkEntry>;
+        getPersonNetworks(personld?: string, opts?: { skipCount?: number, maxltems?: number, fields?: Array<string> }): Promise<PersonNetworkPaging>;
+        getPreference(personld?: string, preferenceName?: string, opts?: { fields?: Array<string> }): Promise<PreferenceEntry>;
+        getPreferences(personld?: string, opts?: { skipCount?: number, maxltems?: number, fields?: Array<string> }): Promise<PreferencePaging>;
+        getSiteMembership(personld?: string, opts?: { skipCount?: number, maxltems?: number, orderBy?: string, relations?: Array<string>, fields?: Array<string> }): Promise<SiteMembershipRequestEntry>;
+        getSiteMembershipRequest(personld?: string, siteld?: string, opts?: { fields?: Array<string> }): Promise<SiteMembershipRequestEntry>;
+        getSiteMembershipRequests(personld?: string, opts?: { skipCount?: number, maxltems?: number, fields?: Array<string> }): Promise<SiteMembershipRequestPaging>;
         removeFavoriteSite(personld?: string, favoriteld?: string): Promise<{}>;
         removeSiteMembershipRequest(personld?: string, siteld?: string): Promise<{}>;
         updateSiteMembershipRequest(personld?: string, siteld?: string, siteMembershipBody?: SiteMembershipRequestBody): Promise<{}>;
     }
 
-// export interface PreferencesApi {
-//     getPreference(personId?: string, opts?: any): Promise<PreferenceEntry>;
-//     getPreferences(personId?: string, opts?: any): Promise<PreferencePaging>;
-// }
+    // export interface PreferencesApi {
+    //     getPreference(personId?: string, opts?: any): Promise<PreferenceEntry>;
+    //     getPreferences(personId?: string, opts?: any): Promise<PreferencePaging>;
+    // }
 
     export interface QueriesApi {
         new(client: ApiClient): QueriesApi;
@@ -583,20 +583,20 @@ declare namespace AlfrescoApi {
         executeWebScript(httpMethod?: string, scriptPath?: string, scriptArgs?: any, contextRoot?: string, servicePat?: string, postBody?: string): Promise<{}>;
     }
 
-// export interface TrashcanApi {
-//     deleteremovedNode(nodeId?: string, opts?: any): Promise<{}>;
-//     getremovedNode(nodeId?: string, include?: Array<string>, opts?: any): Promise<removedNodeEntry>;
-//     listremovedNodes(skipCount?: number, maxItems?: number, include?: Array<string>, opts?: any): Promise<removedNodesPaging>;
-//     restoreremovedNode(nodeId?: string, fields?: Array<string>, opts?: any): Promise<NodeEntry>;
-// }
+    // export interface TrashcanApi {
+    //     deleteremovedNode(nodeId?: string, opts?: any): Promise<{}>;
+    //     getremovedNode(nodeId?: string, include?: Array<string>, opts?: any): Promise<removedNodeEntry>;
+    //     listremovedNodes(skipCount?: number, maxItems?: number, include?: Array<string>, opts?: any): Promise<removedNodesPaging>;
+    //     restoreremovedNode(nodeId?: string, fields?: Array<string>, opts?: any): Promise<NodeEntry>;
+    // }
 
-// export interface VersionsApi {
-//     removeVersion(nodeId?: string, versionId?: string, opts?: any): Promise<{}>;
-//     getVersion(nodeId?: string, versionId?: string, opts?: any): Promise<VersionEntry>;
-//     getVersionContent(nodeId?: string, versionId?: string, attachment?: boolean, ifModifiedSince?: Date, opts?: any): Promise<{}>;
-//     listVersionHistory(nodeId?: string, include?: Array<string>, fields?: Array<string>, skipCount?: number, maxItems?: number, opts?: any): Promise<VersionPaging>;
-//     revertVersion(nodeId?: string, versionId?: string, revertBody?: RevertBody, fields?: Array<string>, opts?: any): Promise<VersionEntry>;
-// }
+    // export interface VersionsApi {
+    //     removeVersion(nodeId?: string, versionId?: string, opts?: any): Promise<{}>;
+    //     getVersion(nodeId?: string, versionId?: string, opts?: any): Promise<VersionEntry>;
+    //     getVersionContent(nodeId?: string, versionId?: string, attachment?: boolean, ifModifiedSince?: Date, opts?: any): Promise<{}>;
+    //     listVersionHistory(nodeId?: string, include?: Array<string>, fields?: Array<string>, skipCount?: number, maxItems?: number, opts?: any): Promise<VersionPaging>;
+    //     revertVersion(nodeId?: string, versionId?: string, revertBody?: RevertBody, fields?: Array<string>, opts?: any): Promise<VersionEntry>;
+    // }
 
     export interface Activity {
         postPersonId?: string;
@@ -1815,8 +1815,8 @@ declare namespace AlfrescoApi {
     export interface UploadApi {
         new(config: AlfrescoApiConfig): UploadApi;
 
-        uploadFile(fileDefinition?: any, relativePath?: any, nodeId?: any, nodeBody?: any, opts?: any) : any;
-        addNodeUpload(nodeId?: any, nodeBody?: any, opts?: any, formParams?: any) : any;
+        uploadFile(fileDefinition?: any, relativePath?: any, nodeId?: any, nodeBody?: any, opts?: any): any;
+        addNodeUpload(nodeId?: any, nodeBody?: any, opts?: any, formParams?: any): any;
     }
 
     export interface BpmAuthApi extends AuthApi {

--- a/src/alfresco-activiti-rest-api/README.md
+++ b/src/alfresco-activiti-rest-api/README.md
@@ -203,6 +203,8 @@ Class | Method | HTTP request | Description
 *ActivitiPublicRestApi.TaskApi* | [**deleteTask**](docs/TaskApi.md#deleteTask) | **DELETE** /api/enterprise/tasks/{taskId} | Delete a Task
 *ActivitiPublicRestApi.TaskApi* | [**filterTasks**](docs/TaskApi.md#filterTasks) | **POST** /api/enterprise/tasks/filter | Filter list of Task
 *ActivitiPublicRestApi.TaskApi* | [**getChecklist**](docs/TaskApi.md#getChecklist) | **GET** /api/enterprise/tasks/{taskId}/checklist | Retrieve Checklist added to a task
+*ActivitiPublicRestApi.TaskApi* | [**getTaskAuditJson**](docs/TaskApi.md#getTaskAuditJson) | **GET** /api/enterprise/tasks/{taskId}/audit | Retrieve audit infromation in json format
+*ActivitiPublicRestApi.TaskApi* | [**getTaskAuditPdf**](docs/TaskApi.md#getTaskAuditPdf) | **GET** /app/rest/tasks/{taskId}/audit | Retrieve the task audit infromation in pdf format
 *ActivitiPublicRestApi.TaskApi* | [**getRelatedContentForTask**](docs/TaskApi.md#getRelatedContentForTask) | **GET** /api/enterprise/tasks/{taskId}/content | Retrieve which content is attached to a task
 *ActivitiPublicRestApi.TaskApi* | [**getRestFieldValuesColumn**](docs/TaskApi.md#getRestFieldValuesColumn) | **GET** /api/enterprise/task-forms/{taskId}/form-values/{field}/{column} | Retrieve Column Field Values
 *ActivitiPublicRestApi.TaskApi* | [**getRestFieldValues**](docs/TaskApi.md#getRestFieldValues) | **GET** /api/enterprise/task-forms/{taskId}/form-values/{field} | Retrieve Populated Field Values

--- a/src/alfresco-activiti-rest-api/docs/TaskApi.md
+++ b/src/alfresco-activiti-rest-api/docs/TaskApi.md
@@ -17,6 +17,8 @@ Method | HTTP request | Description
 [**deleteTask**](TaskApi.md#deleteTask) | **DELETE** /api/enterprise/tasks/{taskId} | Delete a Task
 [**filterTasks**](TaskApi.md#filterTasks) | **POST** /api/enterprise/tasks/filter | Filter list of Task
 [**getChecklist**](TaskApi.md#getChecklist) | **GET** /api/enterprise/tasks/{taskId}/checklist | Retrieve Checklist added to a task
+[**getTaskAuditJson**](TaskApi.md#getTaskAuditJson) | **GET** /api/enterprise/tasks/{taskId}/audit | Retrieve audit infromation in json format
+[**getTaskAuditPdf**](TaskApi.md#getTaskAuditPdf) | **GET** /app/rest/tasks/{taskId}/audit | Retrieve the task audit infromation in pdf format
 [**getRelatedContentForTask**](TaskApi.md#getRelatedContentForTask) | **GET** /api/enterprise/tasks/{taskId}/content | Retrieve which content is attached to a task
 [**getRestFieldValuesColumn**](TaskApi.md#getRestFieldValuesColumn) | **GET** /api/enterprise/task-forms/{taskId}/form-values/{field}/{column} | Retrieve Column Field Values
 [**getRestFieldValues**](TaskApi.md#getRestFieldValues) | **GET** /api/enterprise/task-forms/{taskId}/form-values/{field} | Retrieve Populated Field Values
@@ -493,6 +495,40 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**ResultListDataRepresentation**](ResultListDataRepresentation.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+<a name="getTaskAuditJson"></a>
+# **getTaskAuditJson**
+> TaskAuditRepresentation getTaskAuditJson(taskId)
+
+Retrieve audit infromation in json format
+
+### Example
+```javascript
+
+var taskId = "taskId_example"; // String | taskId
+
+
+this.alfrescoJsApi.activiti.taskApi.getTaskAuditJson(taskId);
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **taskId** | **String**| taskId | 
+
+### Return type
+
+[**TaskAuditRepresentation**](TaskAuditRepresentation.md)
 
 ### Authorization
 

--- a/src/alfresco-activiti-rest-api/docs/TaskAuditRepresentation.md
+++ b/src/alfresco-activiti-rest-api/docs/TaskAuditRepresentation.md
@@ -1,0 +1,18 @@
+# ActivitiPublicRestApi.TaskAuditRepresentation
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**taskId** | **String** |  | [optional] 
+**taskName | **String** |  | [optional] 
+**processInstanceId** | **String** |  | [optional] 
+**processDefinitionName** | **String** |  | [optional] 
+**processDefinitionVersion** | **Integer** |  | [optional] 
+**assignee** | [**LightUserRepresentation**](LightUserRepresentation.md) |  | [optional] 
+**startTime** | **Date** |  | [optional] 
+**endTime** | **Date** |  | [optional] 
+**formData** | **Object** |  | [optional] 
+**selectedOutcome** | **String** |  | [optional] 
+**comments** | **Object** |  | [optional] 
+
+

--- a/src/alfresco-activiti-rest-api/src/api/TaskApi.js
+++ b/src/alfresco-activiti-rest-api/src/api/TaskApi.js
@@ -1,18 +1,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['../../../alfrescoApiClient', '../model/TaskRepresentation', '../model/CommentRepresentation', '../model/ObjectNode', '../model/CompleteFormRepresentation', '../model/RelatedContentRepresentation', '../model/TaskFilterRequestRepresentation', '../model/ResultListDataRepresentation', '../model/FormValueRepresentation', '../model/FormDefinitionRepresentation', '../model/ChecklistOrderRepresentation', '../model/SaveFormRepresentation', '../model/TaskUpdateRepresentation'], factory);
+    define(['../../../alfrescoApiClient', '../model/TaskRepresentation', '../model/TaskAuditRepresentation', '../model/CommentRepresentation', '../model/ObjectNode', '../model/CompleteFormRepresentation', '../model/RelatedContentRepresentation', '../model/TaskFilterRequestRepresentation', '../model/ResultListDataRepresentation', '../model/FormValueRepresentation', '../model/FormDefinitionRepresentation', '../model/ChecklistOrderRepresentation', '../model/SaveFormRepresentation', '../model/TaskUpdateRepresentation'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('../../../alfrescoApiClient'), require('../model/TaskRepresentation'), require('../model/CommentRepresentation'), require('../model/ObjectNode'), require('../model/CompleteFormRepresentation'), require('../model/RelatedContentRepresentation'), require('../model/TaskFilterRequestRepresentation'), require('../model/ResultListDataRepresentation'), require('../model/FormValueRepresentation'), require('../model/FormDefinitionRepresentation'), require('../model/ChecklistOrderRepresentation'), require('../model/SaveFormRepresentation'), require('../model/TaskUpdateRepresentation'));
+    module.exports = factory(require('../../../alfrescoApiClient'), require('../model/TaskRepresentation'), require('../model/TaskAuditRepresentation'), require('../model/CommentRepresentation'), require('../model/ObjectNode'), require('../model/CompleteFormRepresentation'), require('../model/RelatedContentRepresentation'), require('../model/TaskFilterRequestRepresentation'), require('../model/ResultListDataRepresentation'), require('../model/FormValueRepresentation'), require('../model/FormDefinitionRepresentation'), require('../model/ChecklistOrderRepresentation'), require('../model/SaveFormRepresentation'), require('../model/TaskUpdateRepresentation'));
   } else {
     // Browser globals (root is window)
     if (!root.ActivitiPublicRestApi) {
       root.ActivitiPublicRestApi = {};
     }
-    root.ActivitiPublicRestApi.TaskApi = factory(root.ActivitiPublicRestApi.ApiClient, root.ActivitiPublicRestApi.TaskRepresentation, root.ActivitiPublicRestApi.CommentRepresentation, root.ActivitiPublicRestApi.ObjectNode, root.ActivitiPublicRestApi.CompleteFormRepresentation, root.ActivitiPublicRestApi.RelatedContentRepresentation, root.ActivitiPublicRestApi.TaskFilterRequestRepresentation, root.ActivitiPublicRestApi.ResultListDataRepresentation, root.ActivitiPublicRestApi.FormValueRepresentation, root.ActivitiPublicRestApi.FormDefinitionRepresentation, root.ActivitiPublicRestApi.ChecklistOrderRepresentation, root.ActivitiPublicRestApi.SaveFormRepresentation, root.ActivitiPublicRestApi.TaskUpdateRepresentation);
+    root.ActivitiPublicRestApi.TaskApi = factory(root.ActivitiPublicRestApi.ApiClient, root.ActivitiPublicRestApi.TaskRepresentation, root.ActivitiPublicRestApi.TaskAuditRepresentation, root.ActivitiPublicRestApi.CommentRepresentation, root.ActivitiPublicRestApi.ObjectNode, root.ActivitiPublicRestApi.CompleteFormRepresentation, root.ActivitiPublicRestApi.RelatedContentRepresentation, root.ActivitiPublicRestApi.TaskFilterRequestRepresentation, root.ActivitiPublicRestApi.ResultListDataRepresentation, root.ActivitiPublicRestApi.FormValueRepresentation, root.ActivitiPublicRestApi.FormDefinitionRepresentation, root.ActivitiPublicRestApi.ChecklistOrderRepresentation, root.ActivitiPublicRestApi.SaveFormRepresentation, root.ActivitiPublicRestApi.TaskUpdateRepresentation);
   }
-}(this, function(ApiClient, TaskRepresentation, CommentRepresentation, ObjectNode, CompleteFormRepresentation, RelatedContentRepresentation, TaskFilterRequestRepresentation, ResultListDataRepresentation, FormValueRepresentation, FormDefinitionRepresentation, ChecklistOrderRepresentation, SaveFormRepresentation, TaskUpdateRepresentation) {
+}(this, function(ApiClient, TaskRepresentation, TaskAuditRepresentation, CommentRepresentation, ObjectNode, CompleteFormRepresentation, RelatedContentRepresentation, TaskFilterRequestRepresentation, ResultListDataRepresentation, FormValueRepresentation, FormDefinitionRepresentation, ChecklistOrderRepresentation, SaveFormRepresentation, TaskUpdateRepresentation) {
   'use strict';
 
   /**
@@ -628,6 +628,76 @@
         '/api/enterprise/tasks/{taskId}/checklist', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
         authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Retrieve the task audit in the JSON format
+     * @param {String} taskId taskId
+     */
+    this.getTaskAuditJson = function(taskId) {
+      var postBody = null;
+
+      // verify the required parameter 'taskId' is set
+      if (taskId == undefined || taskId == null) {
+        throw "Missing the required parameter 'taskId' when calling getTaskAuditPdf";
+      }
+
+      var pathParams = {
+        'taskId': taskId
+      };
+      var queryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = [];
+      var contentTypes = ['application/json'];
+      var accepts = ['application/json'];
+      var returnType = TaskAuditRepresentation;
+
+      return this.apiClient.callApi(
+        '/api/enterprise/tasks/{taskId}/audit', 'GET',
+        pathParams, queryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType
+      );
+    }
+
+    /**
+     * Retrieve the task audit in the JSON format
+     * @param {String} taskId taskId
+     */
+    this.getTaskAuditPdf = function(taskId) {
+      var postBody = null;
+
+      // verify the required parameter 'taskId' is set
+      if (taskId == undefined || taskId == null) {
+        throw "Missing the required parameter 'taskId' when calling getTaskAuditPdf";
+      }
+
+      var pathParams = {
+        'taskId': taskId
+      };
+      var queryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = [];
+      var contentTypes = ['application/json'];
+      var accepts = ['application/json'];
+      var returnType = Object;
+      var contextRoot = null;
+      var responseType = 'blob';
+
+      return this.apiClient.callApi(
+        '/app/rest/tasks/{taskId}/audit', 'GET',
+        pathParams, queryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType, contextRoot, responseType
       );
     }
 

--- a/src/alfresco-activiti-rest-api/src/model/TaskAuditRepresentation.js
+++ b/src/alfresco-activiti-rest-api/src/model/TaskAuditRepresentation.js
@@ -1,0 +1,129 @@
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['../../../alfrescoApiClient', '../model/LightUserRepresentation'], factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // CommonJS-like environments that support module.exports, like Node.
+    module.exports = factory(require('../../../alfrescoApiClient'), require('./LightUserRepresentation'));
+  } else {
+    // Browser globals (root is window)
+    if (!root.ActivitiPublicRestApi) {
+      root.ActivitiPublicRestApi = {};
+    }
+    root.ActivitiPublicRestApi.TaskAuditRepresentation = factory(root.ActivitiPublicRestApi.ApiClient, root.ActivitiPublicRestApi.LightUserRepresentation);
+  }
+}(this, function(ApiClient, LightUserRepresentation) {
+  'use strict';
+
+  /**
+   * The TaskAuditRepresentation model module.
+   * @module model/TaskAuditRepresentation
+   * @version 1.4.0
+   */
+
+  /**
+   * Constructs a new <code>TaskAuditRepresentation</code>.
+   * @alias module:model/TaskAuditRepresentation
+   * @class
+   */
+  var exports = function() {
+    var _this = this;
+  };
+
+  /**
+   * Constructs a <code>TaskAuditRepresentation</code> from a plain JavaScript object, optionally creating a new instance.
+   * Copies all relevant properties from <code>data</code> to <code>obj</code> if supplied or a new instance if not.
+   * @param {Object} data The plain JavaScript object bearing properties of interest.
+   * @param {module:model/TaskAuditRepresentation} obj Optional instance to populate.
+   * @return {module:model/TaskAuditRepresentation} The populated <code>TaskAuditRepresentation</code> instance.
+   */
+  exports.constructFromObject = function(data, obj) {
+    if (data) {
+      obj = data || new exports();
+
+      if (data.hasOwnProperty('taskId')) {
+        obj['taskId'] = ApiClient.convertToType(data['taskId'], 'String');
+      }
+      if (data.hasOwnProperty('taskName')) {
+        obj['taskName'] = ApiClient.convertToType(data['taskName'], 'String');
+      }
+      if (data.hasOwnProperty('processInstanceId')) {
+        obj['processInstanceId'] = ApiClient.convertToType(data['processInstanceId'], 'String');
+      }
+      if (data.hasOwnProperty('processDefinitionName')) {
+        obj['processDefinitionName'] = ApiClient.convertToType(data['processDefinitionName'], 'String');
+      }
+      if (data.hasOwnProperty('processDefinitionVersion')) {
+        obj['processDefinitionVersion'] = ApiClient.convertToType(data['processDefinitionVersion'], 'Integer');
+      }
+      if (data.hasOwnProperty('assignee')) {
+        obj['assignee'] = LightUserRepresentation.constructFromObject(data['assignee']);
+      }
+      if (data.hasOwnProperty('startTime')) {
+        obj['startTime'] = ApiClient.convertToType(data['startTime'], 'Date');
+      }
+      if (data.hasOwnProperty('endTime')) {
+        obj['endTime'] = ApiClient.convertToType(data['endTime'], 'Date');
+      }
+      if (data.hasOwnProperty('formData')) {
+        obj['formData'] = ApiClient.convertToType(data['formData'], [Object]);
+      }
+      if (data.hasOwnProperty('selectedOutcome')) {
+        obj['selectedOutcome'] = ApiClient.convertToType(data['selectedOutcome'], 'String');
+      }
+      if (data.hasOwnProperty('comments')) {
+        obj['comments'] = ApiClient.convertToType(data['comments'], [Object]);
+      }
+    }
+    return obj;
+  }
+
+  /**
+   * @member {String} taskId
+   */
+  exports.prototype['taskId'] = undefined;
+  /**
+   * @member {String} taskName
+   */
+  exports.prototype['taskName'] = undefined;
+  /**
+   * @member {String} processDefinitionId
+   */
+  exports.prototype['processDefinitionId'] = undefined;
+  /**
+   * @member {String} processDefinitionName
+   */
+  exports.prototype['processDefinitionName'] = undefined;
+  /**
+   * @member {Integer} processDefinitionVersion
+   */
+  exports.prototype['processDefinitionVersion'] = undefined;
+  /**
+   * @member {String} assignee
+   */
+  exports.prototype['assignee'] = undefined;
+  /**
+   * @member {String} startTime
+   */
+  exports.prototype['startTime'] = undefined;
+  /**
+   * @member {String} endTime
+   */
+  exports.prototype['endTime'] = undefined;
+  /**
+   * @member {String} formData
+   */
+  exports.prototype['formData'] = undefined;
+  /**
+   * @member {String} selectedOutcome
+   */
+  exports.prototype['selectedOutcome'] = undefined;
+  /**
+   * @member {String} comments
+   */
+  exports.prototype['comments'] = undefined;
+
+  return exports;
+}));
+
+


### PR DESCRIPTION
 -getTaskAuditJson
 -getTaskAuditPdf

**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-ap/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-ap/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The Audit task logs endpoints are missing


**What is the new behavior?**
Add the Audit task logs endpoints


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
