### PR TITLE
[ADF-1083] added responseType to getProfile image for user api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 </p>
 
 # Alfresco JS API
+<a name="1.8.0"></a>
+# [1.8.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.8.0) (XX-XX-2017)
+## Fix
+- [getProfilePictures returns null](https://github.com/Alfresco/alfresco-js-api/issues/262)
+
+# Alfresco JS API
 <a name="1.7.0"></a>
 # [1.7.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.7.0) (01-08-2017)
 ## Fix

--- a/src/alfresco-activiti-rest-api/src/api/UserApi.js
+++ b/src/alfresco-activiti-rest-api/src/api/UserApi.js
@@ -114,12 +114,14 @@
       var authNames = [];
       var contentTypes = ['application/json'];
       var accepts = ['application/json'];
-      var returnType = null;
+      var returnType = Object;
+      var contextRoot = null;
+      var responseType = 'blob';
 
       return this.apiClient.callApi(
         '/api/enterprise/users/{userId}/picture', 'GET',
         pathParams, queryParams, headerParams, formParams, postBody,
-        authNames, contentTypes, accepts, returnType
+        authNames, contentTypes, accepts, returnType, contextRoot, responseType
       );
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-ap/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-ap/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Nothing is returned for userApi getProfilePicture

**What is the new behavior?**
a blob is returned for the image of getProfilePicture


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
