### PR TITLE
[ADF-1523] preserve username between page reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ## Fix
 
 - [Wrong StatusEnum implementation for Rendition](https://issues.alfresco.com/jira/browse/ADF-1535)
+- [APS task form remains disabled when no custom outcome is provided in ADF 1.8.0](https://issues.alfresco.com/jira/browse/ADF-1523)
 
 # [1.8.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.8.0) (05-09-2017)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alfresco-js-api",
-  "version": "1.6.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "dependencies": {
     "abbrev": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-ap/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-ap/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Upon page reload the username is lost and all the code that relies on that stops working.

**What is the new behavior?**

Preserve the username value between page reloads.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
