### PR TITLE
[ADF-1963] content api fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - [Update superagent to 3.7.0 ](https://issues.alfresco.com/jira/browse/ADF-1833)
 - [NodesApi.getNodeChildren has wrong return type](https://issues.alfresco.com/jira/browse/ADF-1860)
 - [diagrams.service.ts is not using the alfresco-js-api](https://issues.alfresco.com/jira/browse/ADF-1800)
+- [getContentThumbnailUrl returns file data instead or URL](https://issues.alfresco.com/jira/browse/ADF-1962)
+- [ContentApi is missing the preview rendition API](https://issues.alfresco.com/jira/browse/ADF-1963)
 
 # [1.9.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/1.9.0) (09-10-2017)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2201,10 +2201,11 @@ declare namespace AlfrescoApi {
         getProcessInstanceContent(processInstanceId?: string): Promise<any>;
 
         getRawContent(contentId?: number): Promise<any>;
+        getContentPreview(contentId?: number): Promise<any>;
 
         getRawContentUrl(contentId?: number): string;
 
-        getContentThumbnailUrl(contentId?: number): string;
+        getContentThumbnail(contentId?: number): Promise<any>;
 
         getRelatedContentForProcessInstance(processInstanceId?: string, isRelated?: boolean): Promise<any>;
 

--- a/src/alfresco-activiti-rest-api/src/api/ContentApi.js
+++ b/src/alfresco-activiti-rest-api/src/api/ContentApi.js
@@ -491,6 +491,40 @@
       );
     }
 
+    this.getContentPreview = function(contentId) {
+      var postBody = null;
+
+      // verify the required parameter 'contentId' is set
+      if (contentId == undefined || contentId == null) {
+        throw "Missing the required parameter 'contentId' when calling getRawContent";
+      }
+
+
+      var pathParams = {
+        'contentId': contentId
+      };
+      var queryParams = {
+      };
+      var headerParams = {
+      };
+      var formParams = {
+      };
+
+      var authNames = [];
+      var contentTypes = ['application/json'];
+      var accepts = ['application/json'];
+      var returnType = Object;
+      var contextRoot = null;
+      var responseType = 'blob';
+
+      return this.apiClient.callApi(
+        '/api/enterprise/content/{contentId}/rendition/preview', 'GET',
+        pathParams, queryParams, headerParams, formParams, postBody,
+        authNames, contentTypes, accepts, returnType, contextRoot, responseType
+      );
+    }
+
+
     /**
      * Get content Raw URL for the given contentId
      * @param {Integer} contentId contentId
@@ -500,10 +534,10 @@
     }
 
     /**
-     * Get thumbnail URL for the given contentId
+     * Get thumbnail for the given contentId
      * @param {Integer} contentId contentId
      */
-    this.getContentThumbnailUrl = function(contentId) {
+    this.getContentThumbnail = function(contentId) {
       var postBody = null;
 
       // verify the required parameter 'contentId' is set


### PR DESCRIPTION
Addresses bugs:

- [ADF-1962: getContentThumbnailUrl returns file data instead or URL](https://issues.alfresco.com/jira/browse/ADF-1962)
- [ADF-1963: ContentApi is missing the preview rendition API](https://issues.alfresco.com/jira/browse/ADF-1963)