### PR TITLE
[ADF-2136] generating shared link content url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,18 @@
 </p>
 
 # Alfresco JS API
-<a name="2.0.0"></a>
+
+<a name="2.1.0"></a>
 # [2.1.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/2.1.0) (xx-xx-2017)
 
 ## Governance api
+
 - [Governance api](https://issues.alfresco.com/jira/browse/ADF-282)
 
 ## Features
+
 - [Classes end point](https://issues.alfresco.com/jira/browse/ADF-1986)
+- [Generating shared link content url](https://issues.alfresco.com/jira/browse/ADF-2136)
 
 <a name="2.0.0"></a>
 # [2.0.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/2.0.0) (28-11-2017)

--- a/index.d.ts
+++ b/index.d.ts
@@ -4938,6 +4938,8 @@ declare namespace AlfrescoApi {
         getContentUrl(nodeId: string, attachment?: boolean, ticket?: string): string;
 
         getRenditionUrl(nodeId: string, encoding: string, attachment?: boolean, ticket?: string): string;
+
+        getSharedLinkContentUrl(linkId: string, attachment?: boolean): string;
     }
 
     export interface AuthApi {

--- a/src/alfrescoContent.js
+++ b/src/alfrescoContent.js
@@ -73,6 +73,19 @@ class AlfrescoContent {
             '?attachment=' + (attachment ? 'true' : 'false') +
             '&alf_ticket=' + (ticket || this.ecmAuth.getTicket());
     }
+
+    /**
+     * Get content url for the given shared link id
+     *
+     * @param {String} linkId - The ID of the shared link
+     * @param {Boolean} [attachment=false] Retrieve content as an attachment for download
+     * @returns {String} The URL address pointing to the content.
+     */
+    getSharedLinkContentUrl(linkId, attachment) {
+        return this.ecmClient.basePath + '/shared-links/' + linkId +
+            '/content' +
+            '?attachment=' + (attachment ? 'true' : 'false');
+    }
 }
 
 module.exports = AlfrescoContent;

--- a/test/alfrescoContent.spec.js
+++ b/test/alfrescoContent.spec.js
@@ -8,6 +8,7 @@ describe('AlfrescoContent', function () {
     beforeEach(function (done) {
         this.hostEcm = 'http://127.0.0.1:8080';
         this.nodesUrl = this.hostEcm + '/alfresco/api/-default-/public/alfresco/versions/1/nodes/';
+        this.sharedLinksUrl = this.hostEcm + '/alfresco/api/-default-/public/alfresco/versions/1/shared-links/';
         this.nodeId = '1a0b110f-1e09-4ca2-b367-fe25e4964a4';
 
         this.authResponseMock = new AuthResponseMock(this.hostEcm);
@@ -123,5 +124,15 @@ describe('AlfrescoContent', function () {
             '/renditions/' + encoding +
             '/content?attachment=true' +
             '&alf_ticket=custom_ticket');
+    });
+
+    it('should output shared link content url', function () {
+        const url = this.content.getSharedLinkContentUrl(this.nodeId);
+        expect(url).to.be.equal(this.sharedLinksUrl + this.nodeId + '/content?attachment=false');
+    });
+
+    it('should output shared link content as attachment', function () {
+        const url = this.content.getSharedLinkContentUrl(this.nodeId, true);
+        expect(url).to.be.equal(this.sharedLinksUrl + this.nodeId + '/content?attachment=true');
     });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-ap/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-ap/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

provides utility method to generate content url for a shared link

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
