### PR TITLE
[ADF-2288] Auth2 endpoint - Use parameForm instead of queryForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 # Alfresco JS API
 
+<a name="2.2.0"></a>
+# [2.2.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/2.2.0) (XX-02-2018)
+
+## Features
+
+## Fix
+- [Auth2 - Use the paramForm instead of queryForm](https://issues.alfresco.com/jira/browse/ADF-2288)
+
 <a name="2.1.0"></a>
 # [2.1.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/2.1.0) (26-01-2018)
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Property | Description  | default value|
 ------------- | ------------- | -------------|
 hostEcm| (Optional value The Ip or Name of the host where your Alfresco instance is running )|http://127.0.0.1:8080 |
 hostBpm| (Optional value The Ip or Name of the host where your Activiti instance is running )|http://127.0.0.1:9999 |
-oauth2|  (Optional configuration object for alfresco authorization server {host:'HOST_OAUTH2_SERVER', clientId:'YOUR_CLIENT_ID', secret:'SECRET'} ||
+oauth2|  (Optional configuration object for alfresco authorization server {host:'HOST_OAUTH2_SERVER', clientId:'YOUR_CLIENT_ID', secret:'SECRET', authPath:'my-custom-auth-endpoint/token'} ||
 contextRoot| (Optional value that define the context Root of the Alfresco ECM API default value is alfresco )|alfresco |
 contextRootBpm| (Optional value that define the context Root of the Activiti API default value is activiti-app )|alfresco |
 provider| (Optional value default value is ECM. This parameter can accept as value ECM BPM or ALL to use the API and Login in the ECM, Activiti BPM or Both )|alfresco |
@@ -301,6 +301,7 @@ this.alfrescoJsApi.login('admin', 'admin').then(function (data) {
 ### Login with OAUTH2 Alfresco authorization server
 
 If you have installed the Alfresco authorization server you can login with this option.
+If your auth endpoint is different from the standard one "/oauth/token" you can override it through the property authPath
 
 ### Example
 ```javascript
@@ -308,7 +309,8 @@ this.alfrescoJsApi = new AlfrescoApi({
         oauth2: {
             host: 'HOST_OAUTH2_SERVER',
             clientId: 'YOUR_CLIENT_ID',
-            secret: 'SECRET'
+            secret: 'SECRET',
+            authPath:'my-custom-auth-endpoint/token'
         },
         provider: 'OAUTH'
     });

--- a/src/alfrescoApi.js
+++ b/src/alfrescoApi.js
@@ -394,8 +394,12 @@ class AlfrescoApi {
      * @param {String} TicketBpm
      * */
     setTicket(ticketEcm, TicketBpm) {
-        this.ecmAuth && this.ecmAuth.setTicket(ticketEcm);
-        this.bpmAuth && this.bpmAuth.setTicket(TicketBpm);
+        if (this.ecmAuth) {
+            this.ecmAuth.setTicket(ticketEcm);
+        }
+        if (this.bpmAuth) {
+            this.bpmAuth.setTicket(TicketBpm);
+        }
     }
 
     /**

--- a/src/alfrescoApi.js
+++ b/src/alfrescoApi.js
@@ -383,6 +383,10 @@ class AlfrescoApi {
         return this.oauth2Auth.refreshToken();
     }
 
+    getTicketAuth() {
+        return this.oauth2Auth && this.oauth2Auth.getToken();
+    }
+
     /**
      * Set the current Ticket
      *
@@ -413,7 +417,7 @@ class AlfrescoApi {
      * @returns {String} Ticket
      * */
     getTicketBpm() {
-        return this.bpmAuth.getTicket();
+        return this.bpmAuth && this.bpmAuth.getTicket();
     }
 
     /**
@@ -422,7 +426,7 @@ class AlfrescoApi {
      * @returns {String} Ticket
      * */
     getTicketEcm() {
-        return this.ecmAuth.getTicket();
+        return this.ecmAuth && this.ecmAuth.getTicket();
     }
 
     /**

--- a/src/alfrescoApi.js
+++ b/src/alfrescoApi.js
@@ -394,8 +394,8 @@ class AlfrescoApi {
      * @param {String} TicketBpm
      * */
     setTicket(ticketEcm, TicketBpm) {
-        this.ecmAuth.setTicket(ticketEcm);
-        this.bpmAuth.setTicket(TicketBpm);
+        this.ecmAuth && this.ecmAuth.setTicket(ticketEcm);
+        this.bpmAuth && this.bpmAuth.setTicket(TicketBpm);
     }
 
     /**

--- a/src/oauth2Auth.js
+++ b/src/oauth2Auth.js
@@ -53,23 +53,24 @@ class oauth2Auth extends AlfrescoApiClient {
 
         var headerParams = {
             'Content-Type': 'application/x-www-form-urlencoded',
-            'Cache-Control': 'no-cache',
             'Authorization': auth
         };
 
-        queryParams = {
+        formParams = {
             username: username,
             password: password,
-            grant_type: 'password'
+            grant_type: 'password',
+            client_id: this.config.oauth2.clientId
         };
 
         var authNames = [];
         var contentTypes = ['application/x-www-form-urlencoded'];
         var accepts = ['application/json'];
 
+        var url = this.config.oauth2.authPath || '/oauth/token';
         this.promise = new Promise((resolve, reject) => {
             this.callApi(
-                '/oauth/token', 'POST',
+                url, 'POST',
                 pathParams, queryParams, headerParams, formParams, postBody,
                 authNames, contentTypes, accepts, {}
             ).then(
@@ -150,6 +151,14 @@ class oauth2Auth extends AlfrescoApiClient {
         this.authentications.basicAuth.refreshToken = refreshToken;
         this.authentications.basicAuth.password = null;
         this.token = token;
+    }
+
+    /**
+     * Get the current Token
+     *
+     * */
+    getToken() {
+        return this.token;
     }
 
     /**

--- a/test/mockObjects/oauth2/authResponseMock.js
+++ b/test/mockObjects/oauth2/authResponseMock.js
@@ -25,6 +25,19 @@ class AuthResponseMock extends BaseMock {
             });
     }
 
+    get200CustomResponse(path) {
+        nock(this.host, {'encodedQueryParams': true})
+            .post(path)
+            .query({'username': this.username, 'password': this.password, 'grant_type': 'password'})
+            .reply(200, {
+                'access_token': '5c37e781-40a7-4957-adcc-2b171c770a5c',
+                'token_type': 'bearer',
+                'refresh_token': '15d66b26-3cf7-446a-8db8-1345f2f4485a',
+                'expires_in': 604603,
+                'scope': 'openid',
+                'legacyToken': 'LegacyToken{legacyTokenBpm=\'Basic YWRtaW46YWRtaW4=\', tokenId=\'null\', legacyTokenEcm=\'TICKET_bbead3a54dbe141f77e442e6703f7fa29671107a\'}'
+            });
+    }
 
     get200RefreshTokenResponse(refreshToken) {
         nock(this.host, {'encodedQueryParams': true})

--- a/test/oauth2Auth.spec.js
+++ b/test/oauth2Auth.spec.js
@@ -73,6 +73,28 @@ describe('Oauth2  test', function () {
             });
         });
 
+        it('Should return the access token with a custom auth endpoint', function (done) {
+
+            this.oauth2Mock.get200CustomResponse('/my-custom-auth/token');
+
+            this.alfrescoJsApi = new AlfrescoApi({
+                oauth2: {
+                    host: this.hostOauth2,
+                    clientId: 'alfrescoapp',
+                    secret: 'secret',
+                    authPath: '/my-custom-auth/token'
+                },
+                provider: 'OAUTH'
+            });
+
+            this.alfrescoJsApi.login('admin', 'admin').then(() => {
+                expect(this.alfrescoJsApi.ecmClient.authentications.basicAuth.accessToken).to.be.equal('5c37e781-40a7-4957-adcc-2b171c770a5c');
+                expect(this.alfrescoJsApi.ecmClient.authentications.basicAuth.refreshToken).to.be.equal('15d66b26-3cf7-446a-8db8-1345f2f4485a');
+                done();
+            }, ()=> {
+            });
+        });
+
         it('login password should be removed after login', function (done) {
 
             this.oauth2Mock.get200Response();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-ap/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-ap/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The auth2 API is passing the value through the queryParam




**What is the new behavior?**
The auth2 API is passing the value through the formParam




**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
