### PR TITLE
[ADF-2448] fixed type for RequestPagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 </p>
 
 # Alfresco JS API
+<a name="2.3.0"></a>
+# [2.3.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/2.3.0) (XX-XX-XXXX)
+
+## Fix
+
+[Wrong type definition for RequestPagination](https://issues.alfresco.com/jira/browse/ADF-2448)
 
 <a name="2.2.0"></a>
 # [2.2.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/2.2.0) (05-03-2018)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1511,8 +1511,8 @@ declare namespace AlfrescoApi {
     export class RequestPagination {
         constructor(obj?: any);
 
-        maxItems?: string;
-        skipCount?: string;
+        maxItems?: number;
+        skipCount?: number;
     }
 
     export class RequestDefaults {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-ap/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-ap/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
RequestPagination had the wrong types for skipCount and maxItems


**What is the new behavior?**
Changed the types from string to number



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
