### PR TITLE
Adding a couple of missing semicolons and Activiti types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2146,7 +2146,7 @@ declare namespace AlfrescoApi {
 
         pagination?: Pagination;
         context?: ResultSetContext;
-        entries?: ResultSetRowEntry[]
+        entries?: ResultSetRowEntry[];
     }
 
     export class ResultSetContext {
@@ -2240,7 +2240,7 @@ declare namespace AlfrescoApi {
     export class ResultSetRowEntry {
         constructor(obj?: any);
 
-        entry?: ResultNode
+        entry?: ResultNode;
     }
 
     export class ResultNode extends Node {
@@ -2613,11 +2613,11 @@ declare namespace AlfrescoApi {
 
         deleteProcessInstance(processInstanceId?: string): Promise<any>;
 
-        filterProcessInstances(filterRequest?: ProcessInstanceFilterRequestRepresentation): Promise<any>;
+        filterProcessInstances(filterRequest?: ProcessInstanceFilterRequestRepresentation): Promise<ResultListDataRepresentation>;
 
         getProcessDefinitionStartForm(processDefinitionId?: string): Promise<FormDefinitionRepresentation>;
 
-        getProcessDefinitions(opts?: { latest?: boolean, appDefinitionId?: number }): Promise<any>;
+        getProcessDefinitions(opts?: { latest?: boolean, appDefinitionId?: number }): Promise<ResultListDataRepresentation>;
 
         getProcessInstanceContent(processInstanceId?: string): Promise<any>;
 
@@ -3143,7 +3143,7 @@ declare namespace AlfrescoApi {
 
         className?: string;
         customFieldTemplates?: any;
-        fields?: FormFieldRepresentation;
+        fields?: FormFieldRepresentation[];
         gridsterForm?: boolean;
         id?: number;
         javascriptEvents?: FormJavascriptEventRepresentation;
@@ -3177,7 +3177,7 @@ declare namespace AlfrescoApi {
         minValue?: string;
         name?: string;
         optionType?: string;
-        options?: OptionRepresentation;
+        options?: OptionRepresentation[];
         overrideId?: boolean;
         params?: any;
         placeholder?: string;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

In index.d.ts:
* The `FormDefinitionRepresentation.fields` and `FormFieldRepresentation.options` types are not arrays.
* The return type of `ProcessApi.filterProcessInstances` and `ProcessApi.getProcessDefinitions` is `Promise<any>`.
* There were two lines with missing semicolons.

**What is the new behavior?**

In index.d.ts:
* The `FormDefinitionRepresentation.fields` and `FormFieldRepresentation.options` types are arrays.
* The return type of `ProcessApi.filterProcessInstances` and `ProcessApi.getProcessDefinitions` is `Promise<ResultListDataRepresentation>`.
* Two missing semicolons have been added.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
