### PR TITLE
2.3.0 bump version (#325)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfresco-js-api",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "JavaScript client library for the Alfresco REST API",
   "author": "Alfresco Software, Ltd.",
   "main": "dist/alfresco-js-api.js",


### PR DESCRIPTION
<a name="2.3.0"></a>
# [2.3.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/2.3.0) (17-04-2018)

## Features

[Update search api](https://issues.alfresco.com/jira/browse/ADF-2493)
[Add groups api](https://issues.alfresco.com/jira/browse/ADF-2570)
[Upate version api with missing endpoint](https://issues.alfresco.com/jira/browse/ADF-2558)

## Fixes

[Wrong type definition for RequestPagination](https://issues.alfresco.com/jira/browse/ADF-2448)
[Not able to log-in into BPM with production mode and CSRF token enable](https://github.com/Alfresco/alfresco-js-api/issues/315)
[Search api type definition is not defined](https://issues.alfresco.com/jira/browse/ADF-2450)
[Incorrect definitions for Enums](https://issues.alfresco.com/jira/browse/ADF-2604)
[Search API implementation is incomplete](https://issues.alfresco.com/jira/browse/ADF-2470)

