### PR TITLE
Fix type definition for TaskFormsApi.getTaskFormVariables

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3010,7 +3010,7 @@ declare namespace AlfrescoApi {
 
         getTaskForm(taskId?: string): Promise<FormDefinitionRepresentation>;
 
-        getTaskFormVariables(taskId?: string): Promise<FormDefinitionRepresentation>;
+        getTaskFormVariables(taskId?: string): Promise<ProcessInstanceVariableRepresentation[]>;
 
         saveTaskForm(taskId?: string, saveTaskFormRepresentation?: SaveFormRepresentation): Promise<any>;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The type definition for `TaskFormsApi.getTaskFormVariables` has `FormDefinitionRepresentation` as a return type.

**What is the new behavior?**

The type definition for `TaskFormsApi.getTaskFormVariables` has `ProcessInstanceVariableRepresentation[]` as a return type.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
