### PR TITLE
[ADF-3289] AppsDefinitionApi contains two methods with same name and different firms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 # Alfresco JS API
 
+<a name="2.5.0"></a>
+# [2.5.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/2.4.0) (xx-xx-2018)
+
+## Features
+
+## Fixes
+[AppsDefinitionApi contains two methods with same name and different firms](https://issues.alfresco.com/jira/browse/ADF-3289)
+
+
 <a name="2.4.0"></a>
 # [2.4.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/2.4.0) (25-06-2018)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2527,6 +2527,8 @@ declare namespace AlfrescoApi {
 
         importAppDefinition(file?: File): Promise<AppDefinitionRepresentation>;
 
+        importNewAppDefinition(modelId?: number, file?: File): Promise<AppDefinitionRepresentation>;
+
         publishAppDefinition(modelId?: number, publishModel?: AppDefinitionPublishRepresentation): Promise<AppDefinitionUpdateResultRepresentation>;
     }
 
@@ -2553,7 +2555,7 @@ declare namespace AlfrescoApi {
 
         importAppDefinition(file?: File): Promise<AppDefinitionRepresentation>;
 
-        importAppDefinition(modelId?: number, file?: File): Promise<AppDefinitionRepresentation>;
+        importNewAppDefinition(modelId?: number, file?: File): Promise<AppDefinitionRepresentation>;
 
         publishAppDefinition(modelId?: number, publishModel?: AppDefinitionPublishRepresentation): Promise<AppDefinitionUpdateResultRepresentation>;
     }

--- a/scripts/test-demo-shell-adf.sh
+++ b/scripts/test-demo-shell-adf.sh
@@ -16,7 +16,7 @@ rm -rf $TEMP_ADF_DIR;
 echo "====== CLONE ADF ====="
 
 git clone https://$TOKEN@github.com/Alfresco/alfresco-ng2-components.git $TEMP_ADF_DIR
-cd $TEMP_ADF_DIR/demo-shell/
+cd $TEMP_ADF_DIR/
 git checkout master
 
 echo "====== INSTALL Demo Shell ====="

--- a/src/alfresco-activiti-rest-api/src/api/AppsApi.js
+++ b/src/alfresco-activiti-rest-api/src/api/AppsApi.js
@@ -212,7 +212,7 @@
      * @param {File} file file
      * data is of type: {module:model/AppDefinitionRepresentation}
      */
-    this.importAppDefinition = function(modelId, file) {
+    this.importNewAppDefinition = function(modelId, file) {
       var postBody = null;
 
       // verify the required parameter 'modelId' is set

--- a/src/alfresco-activiti-rest-api/src/api/AppsDefinitionApi.js
+++ b/src/alfresco-activiti-rest-api/src/api/AppsDefinitionApi.js
@@ -132,7 +132,7 @@
      * @param {File} file file
      * data is of type: {module:model/AppDefinitionRepresentation}
      */
-    this.importAppDefinition = function(modelId, file) {
+    this.importNewAppDefinition = function(modelId, file) {
       var postBody = null;
 
       // verify the required parameter 'modelId' is set

--- a/src/alfresco-core-rest-api/src/ApiClient.js
+++ b/src/alfresco-core-rest-api/src/ApiClient.js
@@ -133,7 +133,7 @@
    */
   exports.prototype.isFileParam = function(param) {
     // fs.ReadStream in Node.js (but not in runtime like browserify)
-    if(typeof require('fs').ReadStream === 'object') {
+    if(typeof require('fs').ReadStream) {
       if (typeof window === 'undefined' &&
         typeof require === 'function' &&
         require('fs') &&


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3289


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
