### PR TITLE
fix upload properties for multipart data

### DIFF
--- a/src/alfrescoUpload.js
+++ b/src/alfrescoUpload.js
@@ -22,7 +22,7 @@ class AlfrescoUpload extends AlfrescoCoreRestApi.NodesApi {
 
         nodeBody = Object.assign(nodeBodyRequired, nodeBody);
 
-        var formParam = {};
+        var formParam = Object.assign({}, nodeBody.properties || {});
         formParam.filedata = fileDefinition;
         formParam.relativePath = relativePath;
         if (opts.name) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

It is not possible to provide custom metadata properties together with uploaded file

**What is the new behavior?**

When using multipart data, transform "properties" object to form params

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
