### PR TITLE
[ADF-3155] "versionComment" is missing in typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Fixes
 - ['cm:lockOwner' when requesting it via the nodesApi](https://issues.alfresco.com/jira/browse/ADF-3495)
+- ["versionComment" is missing in typings](https://issues.alfresco.com/jira/browse/ADF-31555)
 
 <a name="2.5.0"></a>
 # [2.5.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/2.5.0) (15-08-2018)

--- a/index.d.ts
+++ b/index.d.ts
@@ -2210,7 +2210,7 @@ declare namespace AlfrescoApi {
         constructor(obj?: any);
 
         id?: string;
-        // versionComment?: string;
+        versionComment?: string;
         name?: string;
         nodeType?: string;
         isFolder?: boolean;
@@ -2218,10 +2218,10 @@ declare namespace AlfrescoApi {
         modifiedAt?: Date;
         modifiedByUser?: UserInfo;
         content?: ContentInfo;
-        // aspectNames?: Array<string>;
-        // properties?: {
-        //     [key: string]: string;
-        // };
+        aspectNames?: Array<string>;
+        properties?: {
+            [key: string]: string;
+        };
     }
 
     export class VersionEntry {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
"versionComment" is missing in typings


**What is the new behavior?**
"versionComment" is present in typings

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
