### PR TITLE
[ADF-3531] Fix the silent refresh login

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ implicitFlow| true/false | false |
 redirectUri|  url to be redirect after login| null|
 redirectLogout|  url to be redirect after logout optional, if is nor present the redirectUri will be used| null|
 refreshTokenTimeout|  millisecond value, after how many millisecond youw ant refresh the token| 40000|
+redirectSilentIframeUri|  url to be redirect after silent refresh login| /assets/silent-refresh.html |
 silentLogin|  direct execute the implicit login without the need od call this.alfrescoJsApi.implicitLogin() method|   false|
 
 

--- a/src/oauth2Auth.js
+++ b/src/oauth2Auth.js
@@ -12,6 +12,7 @@ class Oauth2Auth extends AlfrescoApiClient {
         super();
         this.config = config;
         this.init = false;
+        this.isSilentRefreshIframeAttached = false;
 
         if (this.config.oauth2) {
             if (this.config.oauth2.host === undefined || this.config.oauth2.host === null) {
@@ -160,6 +161,7 @@ class Oauth2Auth extends AlfrescoApiClient {
             if (externalHash === undefined && this.isValidAccessToken()) {
                 let accessToken = this.storage.getItem('access_token');
                 this.setToken(accessToken, null);
+                this.silentRefresh();
                 resolve(accessToken);
             }
 
@@ -455,14 +457,17 @@ class Oauth2Auth extends AlfrescoApiClient {
     }
 
     silentRefresh() {
-        if (typeof document === 'undefined') {
-            throw new Error('Silent refresh supported only on browsers');
-        }
+        if (!this.isSilentRefreshIframeAttached) {
+            this.isSilentRefreshIframeAttached = true;
+            if (typeof document === 'undefined') {
+                throw new Error('Silent refresh supported only on browsers');
+            }
 
-        setTimeout(() => {
-            this.destroyIframe();
-            this.createIframe();
-        }, this.config.oauth2.refreshTokenTimeout);
+            setTimeout(() => {
+                this.destroyIframe();
+                this.createIframe();
+            }, this.config.oauth2.refreshTokenTimeout);
+        }
     }
 
     createIframe() {

--- a/src/oauth2Auth.js
+++ b/src/oauth2Auth.js
@@ -43,7 +43,7 @@ class Oauth2Auth extends AlfrescoApiClient {
                 if (typeof window !== 'undefined') {
                     context = window.location.origin;
                 }
-                this.config.oauth2.redirectSilentIframeUri = context + '/assets/adf-core/silent-refresh.html';
+                this.config.oauth2.redirectSilentIframeUri = context + '/assets/silent-refresh.html';
             }
 
             this.basePath = this.config.oauth2.host; //Auth Call

--- a/src/oauth2Auth.js
+++ b/src/oauth2Auth.js
@@ -364,6 +364,29 @@ class Oauth2Auth extends AlfrescoApiClient {
 
     }
 
+    composeIframeLoginUrl() {
+        var nonce = this.genNonce();
+
+        this.storage.setItem('nonce', nonce);
+
+        var separation = this.discovery.loginUrl.indexOf('?') > -1 ? '&' : '?';
+
+        return this.discovery.loginUrl +
+            separation +
+            'client_id=' +
+            encodeURIComponent(this.config.oauth2.clientId) +
+            '&redirect_uri=' +
+            encodeURIComponent(this.config.oauth2.redirectSilentIframeUri) +
+            '&scope=' +
+            encodeURIComponent(this.config.oauth2.scope) +
+            '&response_type=' +
+            encodeURIComponent('id_token token') +
+            '&nonce=' +
+            encodeURIComponent(nonce) +
+            '&prompt=none';
+
+    }
+
     hasHashCharacter(hash) {
         return hash.indexOf('#') === 0;
     }
@@ -445,7 +468,7 @@ class Oauth2Auth extends AlfrescoApiClient {
     createIframe() {
         const iframe = document.createElement('iframe');
         iframe.id = 'silent_refresh_token_iframe';
-        let loginUrl = this.composeImplicitLoginUrl();
+        let loginUrl = this.composeIframeLoginUrl();
         iframe.setAttribute('src', loginUrl);
         iframe.style.display = 'none';
         document.body.appendChild(iframe);

--- a/src/oauth2Auth.js
+++ b/src/oauth2Auth.js
@@ -157,7 +157,7 @@ class Oauth2Auth extends AlfrescoApiClient {
 
             this.hashFragmentParams = this.getHashFragmentParams(externalHash);
 
-            if (this.isValidAccessToken()) {
+            if (externalHash === undefined && this.isValidAccessToken()) {
                 let accessToken = this.storage.getItem('access_token');
                 this.setToken(accessToken, null);
                 resolve(accessToken);
@@ -169,7 +169,6 @@ class Oauth2Auth extends AlfrescoApiClient {
                 let sessionState = this.hashFragmentParams.session_state;
                 let expiresIn = this.hashFragmentParams.expires_in;
 
-                window.location.hash = '';
                 if (!sessionState) {
                     reject('session state not present');
                 }
@@ -403,6 +402,7 @@ class Oauth2Auth extends AlfrescoApiClient {
 
             if (!externalHash) {
                 hash = decodeURIComponent(window.location.hash);
+                window.location.hash = '';
             } else {
                 hash = decodeURIComponent(externalHash);
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When the silent login is enabled the app is freezing 


**What is the new behavior?**
The app should be able to renew the token through the silent refresh iframe


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3531