### PR TITLE
[ADF-3552] OAuth - Should not remove the hash part if is a valid route

### DIFF
--- a/src/oauth2Auth.js
+++ b/src/oauth2Auth.js
@@ -399,8 +399,8 @@ class Oauth2Auth extends AlfrescoApiClient {
         return hash.indexOf('#') === 0;
     }
 
-    isHashRoute(hash) {
-        return hash.indexOf('#/') === 0;
+    startWithHashRoute(hash) {
+        return hash.startsWith('#/') === 0;
     }
 
     getHashFragmentParams(externalHash) {
@@ -411,14 +411,16 @@ class Oauth2Auth extends AlfrescoApiClient {
 
             if (!externalHash) {
                 hash = decodeURIComponent(window.location.hash);
-                window.location.hash = '';
+                if (!this.startWithHashRoute(hash)) {
+                    window.location.hash = '';
+                }
             } else {
                 hash = decodeURIComponent(externalHash);
                 this.removeHashFromSilentIframe();
                 this.destroyIframe();
             }
 
-            if (this.hasHashCharacter(hash) && !this.isHashRoute(hash)) {
+            if (this.hasHashCharacter(hash) && !this.startWithHashRoute(hash)) {
                 const questionMarkPosition = hash.indexOf('?');
 
                 if (questionMarkPosition > -1) {

--- a/src/oauth2Auth.js
+++ b/src/oauth2Auth.js
@@ -400,7 +400,7 @@ class Oauth2Auth extends AlfrescoApiClient {
     }
 
     startWithHashRoute(hash) {
-        return hash.startsWith('#/') === 0;
+        return hash.startsWith('#/');
     }
 
     getHashFragmentParams(externalHash) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
we remove always the hash part but it could be a valid angular route


**What is the new behavior?**
we remove the hash only if is not a valid route


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3552