### PR TITLE
[ADF-3499] added domainPrefix for ecm ticket to be saved on local sto…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 # [2.6.0](https://github.com/Alfresco/alfresco-js-api/releases/tag/2.6.0) (xx-xxx-2018)
 
 ## Features
+- ['Added domain prefix for saving multilpe ECM tickets'](https://issues.alfresco.com/jira/browse/ADF-3499)
 
 ## Fixes
 - ['cm:lockOwner' when requesting it via the nodesApi](https://issues.alfresco.com/jira/browse/ADF-3495)

--- a/src/alfrescoApi.js
+++ b/src/alfrescoApi.js
@@ -34,6 +34,7 @@ class AlfrescoApi {
      *        ticketEcm:     // Ticket if you already have a ECM ticket you can pass only the ticket and skip the login, in this case you don't need username and password
      *        ticketBpm:     // Ticket if you already have a BPM ticket you can pass only the ticket and skip the login, in this case you don't need username and password
      *        disableCsrf:   // To disable CSRF Token to be submitted. Only for Activiti call, by default is false.
+     *        domainPrefix: // An optional prefix to append to ticket saved by the storage service.
      *    };
      */
     constructor(config) {
@@ -60,7 +61,8 @@ class AlfrescoApi {
             ticketEcm: config.ticketEcm,
             ticketBpm: config.ticketBpm,
             accessToken: config.accessToken,
-            disableCsrf: config.disableCsrf || false
+            disableCsrf: config.disableCsrf || false,
+            domainPrefix: config.domainPrefix || ''
         };
 
         this.ecmPrivateClient = new EcmClient(this.config, '/api/-default-/private/alfresco/versions/1');

--- a/src/ecmAuth.js
+++ b/src/ecmAuth.js
@@ -16,10 +16,16 @@ class EcmAuth extends AlfrescoApiClient {
 
         this.basePath = this.config.hostEcm + '/' + this.config.contextRoot + '/api/-default-/public/authentication/versions/1'; //Auth Call
 
+        if (this.config.domainPrefix) {
+            this.ticketStorageLabel = this.config.domainPrefix.concat('-ticket-ECM');
+        } else {
+            this.ticketStorageLabel = 'ticket-ECM';
+        }
+
         if (this.config.ticketEcm) {
             this.setTicket(config.ticketEcm);
-        } else if (this.storage.getItem('ticket-ECM')) {
-            this.setTicket(this.storage.getItem('ticket-ECM'));
+        } else if (this.storage.getItem(this.ticketStorageLabel)) {
+            this.setTicket(this.storage.getItem(this.ticketStorageLabel));
         }
 
         Emitter.call(this);
@@ -147,7 +153,7 @@ class EcmAuth extends AlfrescoApiClient {
     setTicket(ticket) {
         this.authentications.basicAuth.username = 'ROLE_TICKET';
         this.authentications.basicAuth.password = ticket;
-        this.storage.setItem('ticket-ECM', ticket);
+        this.storage.setItem(this.ticketStorageLabel, ticket);
         this.ticket = ticket;
     }
 
@@ -161,7 +167,7 @@ class EcmAuth extends AlfrescoApiClient {
     }
 
     invalidateSession() {
-        this.storage.removeItem('ticket-ECM');
+        this.storage.removeItem(this.ticketStorageLabel);
         this.authentications.basicAuth.username = null;
         this.authentications.basicAuth.password = null;
         this.ticket = null;


### PR DESCRIPTION
…rage

**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Handling multiple connections for ecm will overwrite the ticket saved in the local storage


**What is the new behavior?**
We have added a domain prefix to be added via config so multiple ECM tickets could be saved on the local storage


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3499