### PR TITLE
[ADF-3538] added access token storaging for no implicit flow behaviour

### DIFF
--- a/src/oauth2Auth.js
+++ b/src/oauth2Auth.js
@@ -65,6 +65,10 @@ class Oauth2Auth extends AlfrescoApiClient {
     }
 
     initOauth() {
+        if (!this.config.oauth2.implicitFlow && this.isValidAccessToken()) {
+            const accessToken = this.storage.getItem('access_token');
+            this.setToken(accessToken, null);
+        }
         return Promise.resolve()
             .then(() => {
                 return this.discoveryUrls();
@@ -560,6 +564,7 @@ class Oauth2Auth extends AlfrescoApiClient {
             (data) => {
                 this.saveUsername(username);
                 this.setToken(data.access_token, data.refresh_token);
+                this.storeAccessToken(data.access_token, data.expires_in);
                 resolve(data);
             },
             (error) => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
When not enabled implicit flow access token is never stored in the local storage. This makes the guard considering you not logged in when a refresh of the page happen


**What is the new behavior?**
We have added the store and retrieve of the access token when implict flow is disabled.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
