### PR TITLE
Add double possibility to configure the JS-API also in the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,7 @@ withCredentials| (Optional configuration for SSO, requires CORS on ECM) |false
 
 #### Example
 ```javascript
-this.alfrescoApi = new AlfrescoApi();
-this.alfrescoApi.setConfig({ provider:'ALL' });
+this.alfrescoApi = new AlfrescoApi({ provider:'ALL' });
         
 this.alfrescoJsApi.login('admin', 'admin').then(function (data) {
     console.log('API called successfully Login in  BPM and ECM performed ');
@@ -180,24 +179,20 @@ With this authentication the ticket is not validated against the server
 ```javascript
 
 //Login ticket ECM
-this.alfrescoApi = new AlfrescoApi();
-this.alfrescoApi.setConfig({ ticketEcm:'TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1',  hostEcm:'http://127.0.0.1:8080'});
+this.alfrescoApi = new AlfrescoApi({ ticketEcm:'TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1',  hostEcm:'http://127.0.0.1:8080'});
 
 //Login ticket BPM
-this.alfrescoApi = new AlfrescoApi();
-this.alfrescoApi.setConfig({ ticketBpm: 'Basic YWRtaW46YWRtaW4=',  hostBpm:'http://127.0.0.1:9999'});
+this.alfrescoApi = new AlfrescoApi({ ticketBpm: 'Basic YWRtaW46YWRtaW4=',  hostBpm:'http://127.0.0.1:9999'});
 
 //Login ticket ECM and BPM
-this.alfrescoApi = new AlfrescoApi();
-this.alfrescoApi.setConfig({ ticketEcm:'TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1', ticketBpm: 'Basic YWRtaW46YWRtaW4=',  hostEcm:'http://127.0.0.1:8080',  hostBpm:'http://127.0.0.1:9999'});
+this.alfrescoApi = new AlfrescoApi({ ticketEcm:'TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1', ticketBpm: 'Basic YWRtaW46YWRtaW4=',  hostEcm:'http://127.0.0.1:8080',  hostBpm:'http://127.0.0.1:9999'});
 ```
 
 ### Login with Username and Password BPM
 
 #### Example
 ```javascript
-this.alfrescoApi = new AlfrescoApi();
-this.alfrescoApi.setConfig({ provider:'BPM' });
+this.alfrescoApi = new AlfrescoApi({ provider:'BPM' });
 
 this.alfrescoJsApi.login('admin', 'admin').then(function () {
     console.log('API called successfully Login in Activiti BPM performed ');
@@ -244,8 +239,7 @@ The api/js-api will automatically redirect you to the login page anf refresh the
 ##### Example
 
 ```javascript
-this.alfrescoApi = new AlfrescoApi();
-this.alfrescoApi.setConfig({
+this.alfrescoApi = new AlfrescoApi({
         oauth2: {
             host: 'HOST_OAUTH2_SERVER',
             clientId: 'YOUR_CLIENT_ID',
@@ -266,8 +260,7 @@ this.alfrescoJsApi.implicitLogin();
 ##### Example skip login form (implicitFlow)
 
 ```javascript
-this.alfrescoApi = new AlfrescoApi();
-this.alfrescoApi.setConfig({
+this.alfrescoApi = new AlfrescoApi({
         oauth2: {
             host: 'HOST_OAUTH2_SERVER',
             clientId: 'YOUR_CLIENT_ID',
@@ -291,8 +284,7 @@ If your auth endpoint is different from the standard one "/oauth/token" you can 
 
 ##### Example
 ```javascript
-this.alfrescoApi = new AlfrescoApi();
-this.alfrescoApi.setConfig({
+this.alfrescoApi = new AlfrescoApi({
         oauth2: {
             host: 'HOST_OAUTH2_SERVER',
             clientId: 'YOUR_CLIENT_ID',

--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -50,13 +50,17 @@ export class AlfrescoApi {
     once = Emitter.once;
     emit = Emitter.emit;
 
-    constructor() {
+    constructor(config?: AlfrescoApiConfig) {
         this.on = (new Emitter()).on;
         this.off = (new Emitter()).off;
         this.once = (new Emitter()).once;
         this.emit = (new Emitter()).emit;
 
         Emitter.call(this);
+
+        if(config){
+            this.setConfig(config);
+        }
     }
 
     setConfig(config: AlfrescoApiConfig) {

--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -58,7 +58,7 @@ export class AlfrescoApi {
 
         Emitter.call(this);
 
-        if(config){
+        if (config) {
             this.setConfig(config);
         }
     }
@@ -248,7 +248,7 @@ export class AlfrescoApi {
 
             oauth2AuthPromise.then((accessToken) => {
                 this.config.accessToken = accessToken;
-            },                     () => {
+            }, () => {
                 console.log('login OAUTH error');
             });
 
@@ -261,7 +261,7 @@ export class AlfrescoApi {
 
                 processPromise.then((ticketBpm) => {
                     this.config.ticketBpm = ticketBpm;
-                },                  () => {
+                }, () => {
                     console.log('login BPM error');
                 });
 
@@ -273,7 +273,7 @@ export class AlfrescoApi {
                     this.setAuthenticationClientECMBPM(this.contentAuth.getAuthentication(), null);
 
                     this.config.ticketEcm = ticketEcm;
-                },                  () => {
+                }, () => {
                     console.log('login ECM error');
                 });
 
@@ -366,7 +366,7 @@ export class AlfrescoApi {
                 let contentPromise = this.contentAuth.logout();
                 contentPromise.then(() => {
                     this.config.ticket = undefined;
-                },                  () => {
+                }, () => {
                 });
 
                 return contentPromise;

--- a/src/alfrescoApiCompatibility.ts
+++ b/src/alfrescoApiCompatibility.ts
@@ -108,9 +108,8 @@ export class AlfrescoApiCompatibility extends AlfrescoApi {
     ecmClient: ContentClient;
 
     constructor(config: AlfrescoApiConfig) {
-        super();
+        super(config);
 
-        this.setConfig(config);
         this.initObjects();
     }
 

--- a/test/oauth2Auth.spec.ts
+++ b/test/oauth2Auth.spec.ts
@@ -76,9 +76,7 @@ describe('Oauth2  test', function () {
             this.oauth2Mock.get200Response();
             this.oauth2Mock.get200Discovery();
             this.authResponseMock.get200ValidTicket();
-            let alfrescoApi = new AlfrescoApi();
-
-            alfrescoApi.setConfig(<AlfrescoApiConfig>{
+            let alfrescoApi = new AlfrescoApi(<AlfrescoApiConfig>{
                 hostEcm: 'http://myOauthUrl:30081',
                 oauth2: {
                     'host': 'http://myOauthUrl:30081/auth/realms/springboot',

--- a/test/peopleApi.spec.ts
+++ b/test/peopleApi.spec.ts
@@ -11,8 +11,7 @@ describe('PeopleApi', function () {
     beforeEach(function () {
         this.peopleMock = new PeopleMock();
 
-        this.alfrescoApi = new AlfrescoApi();
-        this.alfrescoApi.setConfig({
+        this.alfrescoApi = new AlfrescoApi({
             hostEcm: 'http://127.0.0.1:8080'
         });
     });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
With the new version of the JS-API we have lost the possibility to configure the JS-API during the construction.
With this PR I have added a double possibility to configure the JS-API in the constructor or using the setconfig:


```javascript
        this.alfrescoApi = new AlfrescoApi({
            hostEcm: 'http://127.0.0.1:8080'
        });
```
or

```javascript
        this.alfrescoApi = new AlfrescoApi();
        this.alfrescoApi.setConfig({
            hostEcm: 'http://127.0.0.1:8080'
        });
```


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
