### PR TITLE
[ADF-3735] clean discovery storage over an error

### DIFF
--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -161,7 +161,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
                     resolve(discovery);
                 }, (error) => {
                     this.emit('error', error);
-                    this.storage.setItem('discovery', null);
+                    this.storage.removeItem('discovery');
                     reject(error.error);
                 });
             } else {

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -159,7 +159,9 @@ export class Oauth2Auth extends AlfrescoApiClient {
                     this.emit('discovery', this.discovery);
                     this.storage.setItem('discovery', JSON.stringify(this.discovery));
                     resolve(discovery);
-                },     (error) => {
+                }, (error) => {
+                    this.emit('error', error);
+                    this.storage.setItem('discovery', null);
                     reject(error.error);
                 });
             } else {
@@ -192,7 +194,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
                         this.emit('jwks', jwks);
                         this.storage.setItem('jwks', JSON.stringify(jwks));
                         resolve(jwks);
-                    },     (error) => {
+                    }, (error) => {
                         reject(error.error);
                     });
                 } else {
@@ -236,7 +238,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
                         this.silentRefresh();
                         resolve(accessToken);
                     }
-                },                                 (error) => {
+                }, (error) => {
                     reject('Validation JWT error' + error);
                 });
             } else {
@@ -520,7 +522,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
         setTimeout(() => {
             this.destroyIframe();
             this.createIframe();
-        },         this.config.oauth2.refreshTokenTimeout);
+        }, this.config.oauth2.refreshTokenTimeout);
     }
 
     removeHashFromSilentIframe() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The discovery SSO configuration is not deleted over a server discovery error

I discovered it meanwhile I was trying to add some meaningful help in the ADF login component

**What is the new behavior?**
The discovery SSO configuration is deleted over a server discovery error



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
