### PR TITLE
[ADF-4457] Extend domainPrefix to the whole JS-API

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ provider| (Optional value default value is ECM. This parameter can accept as val
 ticket| (Optional only if you want login with the ticket see example below)| |
 disableCsrf| To disable CSRF Token to be submitted. Only for Activiti call.| false |
 withCredentials| (Optional configuration for SSO, requires CORS on ECM) |false
+domainPrefix| (Optional add a prefix in all the info stored in the local storage) |''
 
 ### Login with Username and Password BPM and ECM
 

--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -68,7 +68,12 @@ export class AlfrescoApi {
             config = {};
         }
 
+        if (config.domainPrefix) {
+            Storage.setPrefix(config.domainPrefix);
+        }
+
         this.storage = new Storage();
+
         this.config = new AlfrescoApiConfig(config);
 
         this.clientsFactory();

--- a/src/api/activiti-rest-api/api/content.api.ts
+++ b/src/api/activiti-rest-api/api/content.api.ts
@@ -314,7 +314,7 @@ export class ContentApi extends BaseApi {
             return this.apiClient.callApi(
                 '/api/enterprise/content/{contentId}/raw', 'GET',
                 pathParams, queryParams, headerParams, formParams, postBody,
-                contentTypes, accepts,undefined, undefined,  'blob');
+                contentTypes, accepts, undefined, undefined,  'blob');
         }
     }
 

--- a/src/authentication/contentAuth.ts
+++ b/src/authentication/contentAuth.ts
@@ -29,7 +29,6 @@ export class ContentAuth extends AlfrescoApiClient {
 
     config: AlfrescoApiConfig;
     basePath: string;
-    ticketStorageLabel: string;
     storage: Storage;
     ticket: string;
     static authentications: Authentication = new Authentication({
@@ -53,16 +52,10 @@ export class ContentAuth extends AlfrescoApiClient {
 
         this.basePath = this.config.hostEcm + '/' + this.config.contextRoot + '/api/-default-/public/authentication/versions/1'; //Auth Call
 
-        if (this.config.domainPrefix) {
-            this.ticketStorageLabel = this.config.domainPrefix.concat('-ticket-ECM');
-        } else {
-            this.ticketStorageLabel = 'ticket-ECM';
-        }
-
         if (this.config.ticketEcm) {
             this.setTicket(config.ticketEcm);
-        } else if (this.storage.getItem(this.ticketStorageLabel)) {
-            this.setTicket(this.storage.getItem(this.ticketStorageLabel));
+        } else if (this.storage.getItem('ticket-ECM')) {
+            this.setTicket(this.storage.getItem('ticket-ECM'));
         }
 
     }
@@ -180,7 +173,7 @@ export class ContentAuth extends AlfrescoApiClient {
         this.authentications.basicAuth.username = 'ROLE_TICKET';
         this.authentications.basicAuth.password = ticket;
         this.config.ticketEcm = ticket;
-        this.storage.setItem(this.ticketStorageLabel, ticket);
+        this.storage.setItem('ticket-ECM', ticket);
         this.ticket = ticket;
     }
 
@@ -192,7 +185,7 @@ export class ContentAuth extends AlfrescoApiClient {
     }
 
     invalidateSession() {
-        this.storage.removeItem(this.ticketStorageLabel);
+        this.storage.removeItem('ticket-ECM');
         this.authentications.basicAuth.username = null;
         this.authentications.basicAuth.password = null;
         this.config.ticketEcm = null;

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -159,7 +159,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
                     this.emit('discovery', this.discovery);
                     this.storage.setItem('discovery', JSON.stringify(this.discovery));
                     resolve(discovery);
-                }, (error) => {
+                },     (error) => {
                     this.emit('error', error);
                     this.storage.removeItem('discovery');
                     reject(error.error);
@@ -195,7 +195,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
                         this.emit('jwks', jwks);
                         this.storage.setItem('jwks', JSON.stringify(jwks));
                         resolve(jwks);
-                    }, (error) => {
+                    },     (error) => {
                         reject(error.error);
                     });
                 } else {
@@ -239,7 +239,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
                         this.silentRefresh();
                         resolve(accessToken);
                     }
-                }, (error) => {
+                },                                 (error) => {
                     reject('Validation JWT error' + error);
                 });
             } else {
@@ -523,7 +523,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
         setTimeout(() => {
             this.destroyIframe();
             this.createIframe();
-        }, this.config.oauth2.refreshTokenTimeout);
+        },         this.config.oauth2.refreshTokenTimeout);
     }
 
     removeHashFromSilentIframe() {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -18,6 +18,7 @@
 export class Storage {
 
     _storage: any;
+    static _prefix: string = '';
 
     constructor() {
         if (this.supportsStorage()) {
@@ -39,19 +40,23 @@ export class Storage {
 
     setItem(key: string, value: any) {
         if (this.supportsStorage()) {
-            this._storage.setItem(key, value);
+            this._storage.setItem(Storage._prefix + key, value);
         }
     }
 
     removeItem(key: string) {
         if (this.supportsStorage()) {
-            this._storage.removeItem(key);
+            this._storage.removeItem(Storage._prefix + key);
         }
     }
 
     getItem(key: string) {
         if (this.supportsStorage()) {
-            return this._storage.getItem(key);
+            return this._storage.getItem(Storage._prefix + key);
         }
+    }
+
+    static setPrefix(prefix: string) {
+        Storage._prefix = prefix;
     }
 }

--- a/test/alfrescoApiClient.spec.ts
+++ b/test/alfrescoApiClient.spec.ts
@@ -84,12 +84,12 @@ describe('Alfresco Core API Client', function () {
             const data = {
                 body: [
                     {
-                        id: "1",
-                        name: "test1"
+                        id: '1',
+                        name: 'test1'
                     },
                     {
-                        id: "2",
-                        name: "test2"
+                        id: '2',
+                        name: 'test2'
                     }
                 ]
             };
@@ -98,7 +98,7 @@ describe('Alfresco Core API Client', function () {
             const isObject = (result[0] instanceof (FormValueRepresentation));
             expect(isArray).to.equal(true);
             expect(isObject).to.equal(true);
-        })
+        });
     });
 
 });

--- a/test/auth.spec.ts
+++ b/test/auth.spec.ts
@@ -44,7 +44,7 @@ describe('Auth', function () {
                     });
 
                     this.alfrescoJsApi.login('wrong', 'name').then(() => {
-                    }, (error) => {
+                    },                                             (error) => {
                         expect(error.status).to.be.equal(403);
                         done();
                     });
@@ -59,7 +59,7 @@ describe('Auth', function () {
 
                     this.alfrescoJsApi.login(null, null).then(function () {
 
-                    }, (error) => {
+                    },                                        (error) => {
                         expect(error.status).to.be.equal(400);
                         done();
                     });
@@ -196,7 +196,7 @@ describe('Auth', function () {
                     });
 
                     this.alfrescoJsApi.loginTicket(ticket).then((data) => {
-                    }, () => {
+                    },                                          () => {
                         done();
                     });
                 });
@@ -212,7 +212,7 @@ describe('Auth', function () {
 
                     this.alfrescoJsApi.login('admin', 'admin').then(() => {
                         done();
-                    }, () => {
+                    },                                              () => {
                     });
                 });
 
@@ -223,14 +223,14 @@ describe('Auth', function () {
                         expect(this.alfrescoJsApi.config.ticket).to.be.equal(undefined);
                         expect(data).to.be.equal('logout');
                         done();
-                    }, () => {
+                    },                               () => {
                     });
                 });
 
                 it('should Logout be rejected if the Ticket is already expired', function (done) {
                     this.authResponseEcmMock.get404ResponseLogout();
                     this.alfrescoJsApi.logout().then(() => {
-                    }, (error) => {
+                    },                               (error) => {
                         expect(error.error.toString()).to.be.equal('Error: Not Found');
                         done();
                     });
@@ -247,14 +247,14 @@ describe('Auth', function () {
 
                     this.alfrescoJsApi.login('admin', 'admin').then(() => {
                         done();
-                    }, () => {
+                    },                                              () => {
                     });
                 });
 
                 it('should 401 invalidate the ticket', function (done) {
                     this.nodeMock.get401CreationFolder();
                     this.alfrescoJsApi.nodes.createFolder('newFolder').then(() => {
-                    }, () => {
+                    },                                                      () => {
                         expect(this.alfrescoJsApi.contentAuth.authentications.basicAuth.password).to.be.equal(null);
                         done();
                     });
@@ -265,7 +265,7 @@ describe('Auth', function () {
                     this.nodeMock.get401CreationFolder();
 
                     this.alfrescoJsApi.nodes.createFolder('newFolder').then(() => {
-                    }, () => {
+                    },                                                      () => {
                         expect(this.alfrescoJsApi.isLoggedIn()).to.be.equal(false);
                         done();
                     });
@@ -310,7 +310,7 @@ describe('Auth', function () {
                     this.alfrescoJsApi.login('admin', 'admin').then((data) => {
                         expect(data).to.be.equal('Basic YWRtaW46YWRtaW4=');
                         done();
-                    }, function (error) {
+                    },                                              function (error) {
                         console.log('error' + JSON.stringify(error));
                     });
                 });
@@ -325,7 +325,7 @@ describe('Auth', function () {
 
                     this.alfrescoJsApi.login('wrong', 'name').then(() => {
 
-                    }, (error) => {
+                    },                                             (error) => {
                         expect(error.status).to.be.equal(401);
                         done();
                     });
@@ -341,7 +341,7 @@ describe('Auth', function () {
 
                     this.alfrescoJsApi.login(null, null).then(function () {
 
-                    }, function (error) {
+                    },                                        function (error) {
                         expect(error.status).to.be.equal(400);
                         done();
                     });
@@ -362,7 +362,7 @@ describe('Auth', function () {
                     this.alfrescoJsApi.login('admin', 'admin').then(() => {
                         expect(this.alfrescoJsApi.isLoggedIn()).to.be.equal(true);
                         done();
-                    }, function () {
+                    },                                              function () {
                     });
                 });
 
@@ -382,7 +382,7 @@ describe('Auth', function () {
                     this.alfrescoJsApi.logout().then(() => {
                         expect(this.alfrescoJsApi.isLoggedIn()).to.be.equal(false);
                         done();
-                    }, function () {
+                    },                               function () {
                     });
                 });
             });
@@ -460,7 +460,7 @@ describe('Auth', function () {
 
                     this.alfrescoJsApi.login('admin', 'admin').then(() => {
                         done();
-                    }, () => {
+                    },                                              () => {
                     });
                 });
 
@@ -468,7 +468,7 @@ describe('Auth', function () {
                     this.profileMock.get401getProfile();
 
                     this.alfrescoJsApi.activiti.profileApi.getProfile().then((data) => {
-                    }, () => {
+                    },                                                       () => {
                         expect(this.alfrescoJsApi.processAuth.authentications.basicAuth.ticket).to.be.equal(null);
                         done();
                     });
@@ -479,7 +479,7 @@ describe('Auth', function () {
                     this.profileMock.get401getProfile();
 
                     this.alfrescoJsApi.activiti.profileApi.getProfile().then((data) => {
-                    }, () => {
+                    },                                                       () => {
                         expect(this.alfrescoJsApi.isLoggedIn()).to.be.equal(false);
                         done();
                     });
@@ -535,7 +535,7 @@ describe('Auth', function () {
                         expect(data[0]).to.be.equal('TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1');
                         expect(data[1]).to.be.equal('Basic YWRtaW46YWRtaW4=');
                         done();
-                    }, function () {
+                    },                                              function () {
                     });
                 });
 
@@ -551,7 +551,7 @@ describe('Auth', function () {
                     });
 
                     this.alfrescoJsApi.login('admin', 'admin').then(function () {
-                    }, function () {
+                    },                                              function () {
                         done();
                     });
 
@@ -570,7 +570,7 @@ describe('Auth', function () {
                     });
 
                     this.alfrescoJsApi.login('admin', 'admin').then(function () {
-                    }, function () {
+                    },                                              function () {
                         done();
                     });
 
@@ -599,7 +599,7 @@ describe('Auth', function () {
                     this.alfrescoJsApi.logout().then(() => {
                         expect(this.alfrescoJsApi.isLoggedIn()).to.be.equal(false);
                         done();
-                    }, function () {
+                    },                               function () {
                     });
                 });
 
@@ -616,7 +616,7 @@ describe('Auth', function () {
 
                     this.alfrescoJsApi.login('wrong', 'name').then(function () {
 
-                    }, function (error) {
+                    },                                             function (error) {
                         expect(error.status).to.be.equal(401);
                         done();
                     });
@@ -634,7 +634,7 @@ describe('Auth', function () {
 
                     this.alfrescoJsApi.login(null, null).then(function () {
 
-                    }, function (error) {
+                    },                                        function (error) {
                         expect(error.status).to.be.equal(400);
                         done();
                     });
@@ -656,7 +656,7 @@ describe('Auth', function () {
                 this.alfrescoJsApi.login('admin', 'admin').then(() => {
                     expect(this.alfrescoJsApi.isLoggedIn()).to.be.equal(true);
                     done();
-                }, function () {
+                },                                              function () {
                 });
             });
 

--- a/test/ecmAuth.spec.ts
+++ b/test/ecmAuth.spec.ts
@@ -37,7 +37,7 @@ describe('Ecm Auth test', function () {
         auth.logout().then(() => {
             expect(auth.authentications.basicAuth.username).to.be.equal(null);
             done();
-        }, (error) => {
+        },                 (error) => {
             console.log(JSON.stringify(error));
         });
     });
@@ -51,11 +51,11 @@ describe('Ecm Auth test', function () {
             this.contentAuth = new ContentAuth({
                 contextRoot: 'alfresco',
                 hostEcm: this.hostEcm
-            }, alfrescoJsApi);
+            },                                 alfrescoJsApi);
             this.contentAuth.login('admin', 'admin').then((data) => {
                 expect(data).to.be.equal('TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1');
                 done();
-            }, () => {
+            },                                            () => {
             });
 
         });
@@ -67,11 +67,11 @@ describe('Ecm Auth test', function () {
             this.contentAuth = new ContentAuth({
                 contextRoot: 'alfresco',
                 hostEcm: this.hostEcm
-            }, alfrescoJsApi);
+            },                                 alfrescoJsApi);
             this.contentAuth.login('admin', 'admin').then((data) => {
                 expect(this.contentAuth.authentications.basicAuth.password).to.be.not.equal('admin');
                 done();
-            }, () => {
+            },                                            () => {
             });
 
         });
@@ -83,11 +83,11 @@ describe('Ecm Auth test', function () {
             this.contentAuth = new ContentAuth({
                 contextRoot: 'alfresco',
                 hostEcm: this.hostEcm
-            }, alfrescoJsApi);
+            },                                 alfrescoJsApi);
             this.contentAuth.login('admin', 'admin').then(() => {
                 expect(this.contentAuth.isLoggedIn()).to.be.equal(true);
                 done();
-            }, function () {
+            },                                            function () {
             });
         });
 
@@ -98,13 +98,13 @@ describe('Ecm Auth test', function () {
             this.contentAuth = new ContentAuth({
                 contextRoot: 'alfresco',
                 hostEcm: this.hostEcm
-            }, alfrescoJsApi);
+            },                                 alfrescoJsApi);
             this.contentAuth.login('admin', 'admin').then(() => {
                 expect(this.contentAuth.isLoggedIn()).to.be.equal(true);
                 this.contentAuth.changeHost('anyhost');
                 expect(this.contentAuth.isLoggedIn()).to.be.equal(false);
                 done();
-            }, () => {
+            },                                            () => {
             });
 
         });
@@ -116,7 +116,7 @@ describe('Ecm Auth test', function () {
             this.contentAuth = new ContentAuth({
                 contextRoot: 'alfresco',
                 hostEcm: this.hostEcm
-            }, alfrescoJsApi);
+            },                                 alfrescoJsApi);
             this.contentAuth.login('admin', 'admin');
 
             authEcmMock.get204ResponseLogout();
@@ -124,7 +124,7 @@ describe('Ecm Auth test', function () {
             this.contentAuth.logout().then(() => {
                 expect(this.contentAuth.isLoggedIn()).to.be.equal(false);
                 done();
-            }, () => {
+            },                             () => {
             });
         });
 
@@ -134,10 +134,10 @@ describe('Ecm Auth test', function () {
             this.contentAuth = new ContentAuth({
                 contextRoot: 'alfresco',
                 hostEcm: this.hostEcm
-            }, alfrescoJsApi);
+            },                                 alfrescoJsApi);
             this.contentAuth.login('wrong', 'name').then(function () {
 
-            }, (error) => {
+            },                                           (error) => {
                 expect(error.status).to.be.equal(403);
                 done();
             });
@@ -149,10 +149,10 @@ describe('Ecm Auth test', function () {
             this.contentAuth = new ContentAuth({
                 contextRoot: 'alfresco',
                 hostEcm: this.hostEcm
-            }, alfrescoJsApi);
+            },                                 alfrescoJsApi);
             this.contentAuth.login(null, null).then(function () {
 
-            }, (error) => {
+            },                                      (error) => {
                 expect(error.status).to.be.equal(400);
                 done();
             });
@@ -165,7 +165,7 @@ describe('Ecm Auth test', function () {
                 this.contentAuth = new ContentAuth({
                     contextRoot: 'alfresco',
                     hostEcm: this.hostEcm
-                }, alfrescoJsApi);
+                },                                 alfrescoJsApi);
 
                 let loginPromise = this.contentAuth.login('wrong', 'name');
 
@@ -183,7 +183,7 @@ describe('Ecm Auth test', function () {
                 this.contentAuth = new ContentAuth({
                     contextRoot: 'alfresco',
                     hostEcm: this.hostEcm
-                }, alfrescoJsApi);
+                },                                 alfrescoJsApi);
 
                 let loginPromise = this.contentAuth.login('wrong', 'name');
 
@@ -201,7 +201,7 @@ describe('Ecm Auth test', function () {
                 this.contentAuth = new ContentAuth({
                     contextRoot: 'alfresco',
                     hostEcm: this.hostEcm
-                }, alfrescoJsApi);
+                },                                 alfrescoJsApi);
 
                 let loginPromise = this.contentAuth.login('admin', 'admin');
 
@@ -219,7 +219,7 @@ describe('Ecm Auth test', function () {
                 this.contentAuth = new ContentAuth({
                     contextRoot: 'alfresco',
                     hostEcm: this.hostEcm
-                }, alfrescoJsApi);
+                },                                 alfrescoJsApi);
 
                 this.contentAuth.login('admin', 'admin');
 
@@ -239,7 +239,7 @@ describe('Ecm Auth test', function () {
                 this.contentAuth = new ContentAuth({
                     ticketEcm: 'TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1',
                     hostEcm: this.hostEcm
-                }, alfrescoJsApi);
+                },                                 alfrescoJsApi);
 
                 expect('TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1').to.be.equal(this.contentAuth.authentications.basicAuth.password);
             });
@@ -252,7 +252,7 @@ describe('Ecm Auth test', function () {
                 this.contentAuth = new ContentAuth({
                     contextRoot: 'alfresco',
                     hostEcm: this.hostEcm
-                }, alfrescoJsApi);
+                },                                 alfrescoJsApi);
 
                 this.contentAuth.login('admin', 'admin').then(() => {
                     done();
@@ -266,14 +266,14 @@ describe('Ecm Auth test', function () {
                     expect(this.contentAuth.config.ticket).to.be.equal(undefined);
                     expect(data).to.be.equal('logout');
                     done();
-                }, function () {
+                },                             function () {
                 });
             });
 
             it('Logout should be rejected if the Ticket is already expired', function (done) {
                 authEcmMock.get404ResponseLogout();
                 this.contentAuth.logout().then(() => {
-                }, (error) => {
+                },                             (error) => {
                     expect(error.error.toString()).to.be.equal('Error: Not Found');
                     done();
                 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The domainPrefix is used inly for the content Token


**What is the new behavior?**
Extend domainPrefix to the whole JS-API


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
