### PR TITLE
[ADF-4810] no implicit login on silent login true

### DIFF
--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -244,10 +244,6 @@ export class Oauth2Auth extends AlfrescoApiClient {
                 },                                 (error) => {
                     reject('Validation JWT error' + error);
                 });
-            } else {
-                if (this.config.oauth2.silentLogin) {
-                    this.implicitLogin();
-                }
             }
         });
 


### PR DESCRIPTION
- allows ADF AuthGuard to do its job

**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4810


**What is the new behavior?**
Remove restriction in order to
allow the ADF AuthGuard to call the implicit login when needed.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
