### PR TITLE
oauth2  should not be static

### DIFF
--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -71,7 +71,13 @@ export class AlfrescoApi implements EventEmitter.Emitter {
         this.errorListeners();
 
         if (this.isOauthConfiguration()) {
-            this.oauth2Auth = Oauth2Auth.getInstance(this.config);
+
+            if (!this.oauth2Auth) {
+                this.oauth2Auth = new Oauth2Auth(this.config);
+            } else {
+                this.oauth2Auth.setConfig(this.config);
+            }
+
             this.exchangeTokenForAlfTicket();
 
             this.setAuthenticationClientECMBPM(this.oauth2Auth.getAuthentication(), this.oauth2Auth.getAuthentication());

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -28,8 +28,6 @@ declare let window: Window;
 
 export class Oauth2Auth extends AlfrescoApiClient {
 
-    static instance: Oauth2Auth = null;
-
     private iFrameTimeOut: any;
 
     hashFragmentParams: any;
@@ -48,16 +46,6 @@ export class Oauth2Auth extends AlfrescoApiClient {
         this.className = 'Oauth2Auth';
 
         this.setConfig(config);
-    }
-
-    static getInstance(config: AlfrescoApiConfig): Oauth2Auth {
-        if (!Oauth2Auth.instance) {
-            Oauth2Auth.instance = new Oauth2Auth(config);
-        } else {
-            Oauth2Auth.instance.setConfig(config);
-        }
-
-        return Oauth2Auth.instance;
     }
 
     setConfig(config: AlfrescoApiConfig) {

--- a/test/oauth2Auth.spec.ts
+++ b/test/oauth2Auth.spec.ts
@@ -32,7 +32,7 @@ describe('Oauth2  test', function () {
             this.oauth2Mock.get200Response();
             this.oauth2Mock.get200Discovery();
 
-            this.oauth2Auth = Oauth2Auth.getInstance(<AlfrescoApiConfig>{
+            this.oauth2Auth = new Oauth2Auth(<AlfrescoApiConfig>{
                 oauth2: {
                     'host': 'http://myOauthUrl:30081/auth/realms/springboot',
                     'clientId': 'activiti',
@@ -59,7 +59,7 @@ describe('Oauth2  test', function () {
             this.oauth2Mock.get200Response();
             this.oauth2Mock.get200Discovery();
 
-            this.oauth2Auth = Oauth2Auth.getInstance(<AlfrescoApiConfig>{
+            this.oauth2Auth = new Oauth2Auth(<AlfrescoApiConfig>{
                 oauth2: {
                     'host': 'http://myOauthUrl:30081/auth/realms/springboot',
                     'clientId': 'activiti',
@@ -146,7 +146,7 @@ describe('Oauth2  test', function () {
             this.oauth2Mock.get200Response();
             this.oauth2Mock.get200Discovery();
 
-            this.oauth2Auth = Oauth2Auth.getInstance(<AlfrescoApiConfig>{
+            this.oauth2Auth = new Oauth2Auth(<AlfrescoApiConfig>{
                 oauth2: {
                     'host': 'http://myOauthUrl:30081/auth/realms/springboot',
                     'clientId': 'activiti',
@@ -170,7 +170,7 @@ describe('Oauth2  test', function () {
             this.oauth2Mock.get200Response();
             this.oauth2Mock.get200Discovery();
 
-            this.oauth2Auth = Oauth2Auth.getInstance(<AlfrescoApiConfig>{
+            this.oauth2Auth = new Oauth2Auth(<AlfrescoApiConfig>{
                 oauth2: {
                     'host': 'http://myOauthUrl:30081/auth/realms/springboot',
                     'clientId': 'activiti',

--- a/test/oauth2AuthImplicitFlow.spec.ts
+++ b/test/oauth2AuthImplicitFlow.spec.ts
@@ -10,7 +10,6 @@ const globalAny: any = global;
 describe('Oauth2 Implicit flow test', function () {
 
     beforeEach(function () {
-        Oauth2Auth.instance = null;
         delete this.oauth2Auth;
         this.hostOauth2 = 'http://myOauthUrl:30081';
         this.oauth2Mock = new Oauth2Mock(this.hostOauth2);
@@ -19,7 +18,7 @@ describe('Oauth2 Implicit flow test', function () {
     it('should discovery URL', function (done) {
         this.oauth2Mock.get200Discovery();
 
-        this.oauth2Auth = Oauth2Auth.getInstance({
+        this.oauth2Auth = new Oauth2Auth({
             oauth2: {
                 host: 'http://myOauthUrl:30081/auth/realms/springboot',
                 'clientId': 'activiti',
@@ -39,7 +38,7 @@ describe('Oauth2 Implicit flow test', function () {
     it('should throw an error if redirectUri is not present', function (done) {
 
         try {
-            this.oauth2Auth = Oauth2Auth.getInstance(<any>{
+            this.oauth2Auth = new Oauth2Auth(<any>{
                 oauth2: {
                     host: 'http://myOauthUrl:30081/auth/realms/springboot',
                     clientId: 'activiti',
@@ -59,7 +58,7 @@ describe('Oauth2 Implicit flow test', function () {
 
         this.oauth2Mock.get200Discovery();
 
-        this.oauth2Auth = Oauth2Auth.getInstance({
+        this.oauth2Auth = new Oauth2Auth({
             oauth2: {
                 host: 'http://myOauthUrl:30081/auth/realms/springboot',
                 clientId: 'activiti',
@@ -83,7 +82,7 @@ describe('Oauth2 Implicit flow test', function () {
         window = globalAny.window = { location: {} };
         this.oauth2Mock.get200Discovery();
 
-        this.oauth2Auth = Oauth2Auth.getInstance({
+        this.oauth2Auth = new Oauth2Auth({
             oauth2: {
                 host: 'http://myOauthUrl:30081/auth/realms/springboot',
                 clientId: 'activiti',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Different instance of JS-API should have difference instance of the Oauth2 Client


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
