### PR TITLE
Fixing exchange ticket based on provider

### DIFF
--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -94,7 +94,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
 
             this.discoveryUrls();
 
-            if(this.hasContentProvider()) {
+            if (this.hasContentProvider()) {
                 this.exchangeTicketListener(alfrescoApi);
             }
 
@@ -120,7 +120,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
 
     }
 
-    hasContentProvider() {
+    hasContentProvider(): boolean {
         return !this.config.provider || this.config.provider === 'ECM' || this.config.provider === 'ALL';
     }
 

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -121,7 +121,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
     }
 
     hasContentProvider(): boolean {
-        return !this.config.provider || this.config.provider === 'ECM' || this.config.provider === 'ALL';
+        return this.config.provider === 'ECM' || this.config.provider === 'ALL';
     }
 
     checkFragment(externalHash?: any): any {// jshint ignore:line

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -94,7 +94,9 @@ export class Oauth2Auth extends AlfrescoApiClient {
 
             this.discoveryUrls();
 
-            this.exchangeTicketListener(alfrescoApi);
+            if(this.hasContentProvider()) {
+                this.exchangeTicketListener(alfrescoApi);
+            }
 
             this.initOauth(); // jshint ignore:line
         }
@@ -116,6 +118,10 @@ export class Oauth2Auth extends AlfrescoApiClient {
         this.discovery.logoutUrl = `${this.host}/protocol/openid-connect/logout`;
         this.discovery.tokenEndpoint = `${this.host}/protocol/openid-connect/token`;
 
+    }
+
+    hasContentProvider() {
+        return !this.config.provider || this.config.provider === 'ECM' || this.config.provider === 'ALL';
     }
 
     checkFragment(externalHash?: any): any {// jshint ignore:line

--- a/test/oauth2Auth.spec.ts
+++ b/test/oauth2Auth.spec.ts
@@ -80,6 +80,74 @@ describe('Oauth2  test', function () {
             this.oauth2Auth.login('admin', 'admin');
         });
 
+        it('should not emit a token_issued if provider is BPM', function () {
+
+            const exchangeTicketListenerSpy = chai.spy.on(this.oauth2Auth, 'exchangeTicketListener');
+
+            this.oauth2Auth = new Oauth2Auth(<AlfrescoApiConfig>{
+                provider: 'BPM',
+                oauth2: {
+                    'host': 'http://myOauthUrl:30081/auth/realms/springboot',
+                    'clientId': 'activiti',
+                    'scope': 'openid',
+                    'secret': '',
+                    'redirectUri': '/',
+                    'redirectUriLogout': '/logout'
+                },
+                authType: 'OAUTH'
+            }, this.alfrescoJsApi);
+
+            expect(exchangeTicketListenerSpy).not.to.have.been.called();
+        });
+
+        it('should emit a token_issued if provider is ECM', function (done) {
+
+            this.oauth2Mock.get200Response();
+            this.authResponseMock.get200ValidTicket();
+            this.oauth2Auth = new Oauth2Auth(<AlfrescoApiConfig>{
+                provider: 'ECM',
+                oauth2: {
+                    'host': 'http://myOauthUrl:30081/auth/realms/springboot',
+                    'clientId': 'activiti',
+                    'scope': 'openid',
+                    'secret': '',
+                    'redirectUri': '/',
+                    'redirectUriLogout': '/logout'
+                },
+                authType: 'OAUTH'
+            }, this.alfrescoJsApi);
+
+            this.oauth2Auth.once('token_issued', () => {
+                done();
+            });
+
+            this.oauth2Auth.login('admin', 'admin');
+        });
+
+        it('should emit a token_issued if provider is ALL', function (done) {
+
+            this.oauth2Mock.get200Response();
+            this.authResponseMock.get200ValidTicket();
+            this.oauth2Auth = new Oauth2Auth(<AlfrescoApiConfig>{
+                provider: 'ALL',
+                oauth2: {
+                    'host': 'http://myOauthUrl:30081/auth/realms/springboot',
+                    'clientId': 'activiti',
+                    'scope': 'openid',
+                    'secret': '',
+                    'redirectUri': '/',
+                    'redirectUriLogout': '/logout'
+                },
+                authType: 'OAUTH'
+            }, this.alfrescoJsApi);
+
+            this.oauth2Auth.once('token_issued', () => {
+                done();
+            });
+
+            this.oauth2Auth.login('admin', 'admin');
+        });
+
         it('should after token_issued event exchange the access_token for the alf_ticket', function (done) {
 
             this.oauth2Mock.get200Response();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
We try to always retrieve the ECM ticket on OAUTH2 even when Content is not available.


**What is the new behavior?**
We prevent the retrieving of ECM ticket if the provider is not configured with ECM


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
