### PR TITLE
[ADF-5056] use user agent only in aps auth

### DIFF
--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -60,7 +60,6 @@ export class AlfrescoApiClient implements ee.Emitter {
      * The default HTTP headers to be included for all API calls.
      */
     defaultHeaders = {
-        'user-agent': 'superagent'
     };
 
     /**

--- a/src/authentication/processAuth.ts
+++ b/src/authentication/processAuth.ts
@@ -32,6 +32,10 @@ export class ProcessAuth extends AlfrescoApiClient {
         'basicAuth': { ticket: '' }, type: 'activiti'
     };
 
+    defaultHeaders = {
+        'user-agent': 'superagent'
+    };
+
     constructor(config: AlfrescoApiConfig) {
         super();
         this.storage = new Storage();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Log in to ADF Process services and create a new Task in the Task app.
Check the browser console.

Current behaviour:
There is an error in the Console => 'Refused to set unsafe header "user-agent"'


**What is the new behavior?**
use user agent only in aps auth authentication because required


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
