### PR TITLE
3.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: trusty
 node_js:
-  - "10"
+  - "12.14.0"
 
 addons:
     chrome: stable

--- a/api-codegen/src/main/resources/api-code-gen/api.service.mustache
+++ b/api-codegen/src/main/resources/api-code-gen/api.service.mustache
@@ -4,6 +4,7 @@
 import { {{classname}} } from '../{{filename}}';
 {{/imports}}
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 {{#operations}}/**
 * {{baseName}} service.
@@ -21,32 +22,32 @@ export class {{classname}} extends BaseApi {
     * @return Promise<{{#returnType}}{{&returnType}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}{}{{/returnType}}>
     */
     {{nickname}}({{&vendorExtensions.x-codegen-argList}}) : Promise<{{#returnType}}{{&returnType}}{{#isResponseTypeFile}}|undefined{{/isResponseTypeFile}}{{/returnType}}{{^returnType}}any{{/returnType}}{{#canReturnError}} | {{&canReturnError}}{{/canReturnError}}> {
-        {{#hasOptionalParams}}opts = opts || {};{{/hasOptionalParams}}
-        let postBody = {{#bodyParam}}{{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
         {{#allParams}}{{#required}}
-        if ({{paramName}} === undefined || {{paramName}} === null) {
-            throw new Error("Required param '{{paramName}}' in {{operationId}}");
-        }
+        throwIfNotDefined({{paramName}}, '{{paramName}}');
         {{/required}}{{/allParams}}
-        let pathParams = {
+        
+        {{#hasOptionalParams}}opts = opts || {};{{/hasOptionalParams}}
+        const postBody = {{#bodyParam}}{{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}};
+        
+        const pathParams = {
             {{#pathParams}}
             '{{baseName}}': {{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}{{#hasMore}},{{/hasMore}}{{/pathParams}}
         };
 
-        let queryParams = { {{#queryParams}}
+        const queryParams = { {{#queryParams}}
             '{{baseName}}': {{#collectionFormat}}this.apiClient.buildCollectionParam({{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}, '{{collectionFormat}}'){{/collectionFormat}}{{^collectionFormat}}{{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}{{/collectionFormat}}{{#hasMore}},{{/hasMore}}{{/queryParams}}
         };
 
-        let headerParams = {
+        const headerParams = {
             {{#headerParams}}
             '{{baseName}}': {{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}{{#hasMore}},{{/hasMore}}{{/headerParams}}
         };
-        let formParams = { {{#formParams}}
+        const formParams = { {{#formParams}}
         '{{baseName}}': {{#collectionFormat}}this.apiClient.buildCollectionParam({{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}, '{{collectionFormat}}'){{/collectionFormat}}{{^collectionFormat}}{{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}{{/collectionFormat}}{{#hasMore}},{{/hasMore}}{{/formParams}}
         };
 
-        let contentTypes = [{{#consumes}}'{{& mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}];
-        let accepts = [{{#produces}}'{{& mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}}];
+        const contentTypes = [{{#consumes}}'{{& mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}];
+        const accepts = [{{#produces}}'{{& mediaType}}'{{#hasMore}}, {{/hasMore}}{{/produces}}];
 
         return this.apiClient.callApi(
         '{{&path}}', '{{httpMethod}}',

--- a/api-codegen/src/main/resources/api-code-gen/api.service.mustache
+++ b/api-codegen/src/main/resources/api-code-gen/api.service.mustache
@@ -5,6 +5,7 @@ import { {{classname}} } from '../{{filename}}';
 {{/imports}}
 import { BaseApi } from './base.api';
 import { throwIfNotDefined } from '../../../assert';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
 
 {{#operations}}/**
 * {{baseName}} service.
@@ -35,7 +36,7 @@ export class {{classname}} extends BaseApi {
         };
 
         const queryParams = { {{#queryParams}}
-            '{{baseName}}': {{#collectionFormat}}this.apiClient.buildCollectionParam({{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}, '{{collectionFormat}}'){{/collectionFormat}}{{^collectionFormat}}{{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}{{/collectionFormat}}{{#hasMore}},{{/hasMore}}{{/queryParams}}
+            '{{baseName}}': {{#collectionFormat}}buildCollectionParam({{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}, '{{collectionFormat}}'){{/collectionFormat}}{{^collectionFormat}}{{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}{{/collectionFormat}}{{#hasMore}},{{/hasMore}}{{/queryParams}}
         };
 
         const headerParams = {
@@ -43,7 +44,7 @@ export class {{classname}} extends BaseApi {
             '{{baseName}}': {{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}{{#hasMore}},{{/hasMore}}{{/headerParams}}
         };
         const formParams = { {{#formParams}}
-        '{{baseName}}': {{#collectionFormat}}this.apiClient.buildCollectionParam({{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}, '{{collectionFormat}}'){{/collectionFormat}}{{^collectionFormat}}{{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}{{/collectionFormat}}{{#hasMore}},{{/hasMore}}{{/formParams}}
+        '{{baseName}}': {{#collectionFormat}}buildCollectionParam({{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}, '{{collectionFormat}}'){{/collectionFormat}}{{^collectionFormat}}{{#required}}{{paramName}}{{/required}}{{^required}}opts['{{paramName}}']{{/required}}{{/collectionFormat}}{{#hasMore}},{{/hasMore}}{{/formParams}}
         };
 
         const contentTypes = [{{#consumes}}'{{& mediaType}}'{{#hasMore}}, {{/hasMore}}{{/consumes}}];

--- a/cspell.json
+++ b/cspell.json
@@ -237,7 +237,9 @@
     "childassociations",
     "defaultclassificationvalues",
     "Fileplans",
-    "sourcemap"
+    "sourcemap",
+    "facetable",
+    "Tokenisation"
   ],
   "dictionaries": [
     "html",

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,9 +254,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.1.tgz",
-      "integrity": "sha512-7+5S4C4wpug5pzHS+z/63+XUwsH7dtyYELDafoT1QnfruFh7eFjlDWwZXltUB0GLk6y5eMeAt34Bjx8wJ4KfSA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.2.tgz",
+      "integrity": "sha512-z9o4LZUzSD9Hl22zV38aXNykgFeVj8acqfFabCY6FY83n/6s/XwNJyYYldz6/9lBJanpno9h+oL6HTISkviweA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
@@ -4818,24 +4818,24 @@
       }
     },
     "sinon": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.0.4.tgz",
-      "integrity": "sha512-cFsmgmvsgFb87e7SV7IcekogITlHX2KmlplyI9Pda0FH1Z8Ms/kWbpLs25Idp0m6ZJ3HEEjhaYYXbcTtWWUn4w==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.1.0.tgz",
+      "integrity": "sha512-6/05TR+8QhEgTbyMWaConm8iPL609Eno7SqToPq63wC/jS/6NMEI4NxqtzlLkk3r/KcZT9xPXQodH0oJ917Hbg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
         "@sinonjs/formatio": "^4.0.1",
-        "@sinonjs/samsam": "^4.2.1",
-        "diff": "^4.0.1",
+        "@sinonjs/samsam": "^4.2.2",
+        "diff": "^4.0.2",
         "lolex": "^5.1.2",
         "nise": "^3.0.1",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
         "diff": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
         },
         "has-flag": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.0.tgz",
-      "integrity": "sha512-zwrxviZS08kRX40nqBrmERElF2vpw4IUTd5khkhBTfFH8AOaeoLVx48EC4+ZzS2/Iga7NevncqnsUSYjM4OWYA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.1.tgz",
+      "integrity": "sha512-hx6zWtudh3Arsbl3cXay+JnkvVgCKzCWKv42C9J01N2T2np4h8w5X8u6Tpz5mj38kE3M9FM0Pazx8vKFFMnjLQ==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.1.tgz",
-      "integrity": "sha512-hx6zWtudh3Arsbl3cXay+JnkvVgCKzCWKv42C9J01N2T2np4h8w5X8u6Tpz5mj38kE3M9FM0Pazx8vKFFMnjLQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.2.tgz",
+      "integrity": "sha512-B8emQA1qeKerqd1dmIsQYnXi+mmAzTB7flExjmy5X1aVAKFNNNDubkavwR13kR6JnpeLp3aLoJhwn9trWPAyFQ==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3936,12 +3936,6 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
-    "qs": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
-      "integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==",
-      "dev": true
-    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -5002,9 +4996,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
-      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
+      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
       "dev": true
     },
     "typescript-formatter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4587,9 +4587,9 @@
       }
     },
     "rollup": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.30.1.tgz",
-      "integrity": "sha512-Uus8mwQXwaO+ZVoNwBcXKhT0AvycFCBW/W8VZtkpVGsotRllWk9oldfCjqWmTnFRI0y7x6BnEqSqc65N+/YdBw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.31.0.tgz",
+      "integrity": "sha512-9C6ovSyNeEwvuRuUUmsTpJcXac1AwSL1a3x+O5lpmQKZqi5mmrjauLeqIjvREC+yNRR8fPdzByojDng+af3nVw==",
       "dev": true,
       "requires": {
         "@types/estree": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4578,9 +4578,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-      "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.1.tgz",
+      "integrity": "sha512-IQ4ikL8SjBiEDZfk+DFVwqRK8md24RWMEJkdSlgNLkyyAImcjf8SWvU1qFMDOb4igBClbTQ/ugPqXcRwdFTxZw==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1067,9 +1067,9 @@
       }
     },
     "commander": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.0.1.tgz",
-      "integrity": "sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
+      "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
       "dev": true
     },
     "commandpost": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1099,9 +1099,9 @@
       }
     },
     "commander": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-      "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true
     },
     "commandpost": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
-      "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg==",
+      "version": "13.1.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
+      "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
-      "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ==",
+      "version": "13.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
+      "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4672,9 +4672,9 @@
       }
     },
     "sinon-chai": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
-      "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.4.0.tgz",
+      "integrity": "sha512-BpVxsjEkGi6XPbDXrgWUe7Cb1ZzIfxKUbu/MmH5RoUnS7AXpKo3aIYIyQUg0FMvlUL05aPt7VZuAdaeQhEnWxg==",
       "dev": true
     },
     "slash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -197,9 +197,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.18.tgz",
-      "integrity": "sha512-DBkZuIMFuAfjJHiunyRc+aNvmXYNwV1IPMgGKGlwCp6zh6MKrVtmvjSWK/axWcD25KJffkXgkfvFra8ndenXAw==",
+      "version": "12.12.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
+      "integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3497,9 +3497,9 @@
       }
     },
     "nock": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-11.7.1.tgz",
-      "integrity": "sha512-fW+dlMyquAEvgtmGoRHftKrNnJ7yZcbINQDTW7OKRoTYa+11GA0u0UokWHuvCyZrG5TXkplnEv2jmj6R3vvImg==",
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-11.7.2.tgz",
+      "integrity": "sha512-7swr5bL1xBZ5FctyubjxEVySXOSebyqcL7Vy1bx1nS9IUqQWj81cmKjVKJLr8fHhtzI1MV8nyCdENA/cGcY1+Q==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1219,18 +1219,18 @@
       "dev": true
     },
     "cspell": {
-      "version": "4.0.37",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-4.0.37.tgz",
-      "integrity": "sha512-h5cQjE1Mov7TIhgLnpAB5Ld1xnKiqextBe6AX+6yuqTaR5aoZEsrrMQSXw880YDRvllnbbT41omTEuKJjvQ0NQ==",
+      "version": "4.0.43",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-4.0.43.tgz",
+      "integrity": "sha512-msnehTsodBA7XX/lnEdQPC2jqhvdsb7Mqd/Ps2OSNmN0nS1fHYAC9wx2hD5E6wRCfsCmxxcaW0s1VXi0v26ujQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "commander": "^2.20.3",
         "comment-json": "^1.1.3",
-        "cspell-glob": "^0.1.12",
-        "cspell-lib": "^4.1.7",
+        "cspell-glob": "^0.1.13",
+        "cspell-lib": "^4.1.13",
         "fs-extra": "^8.1.0",
-        "gensequence": "^2.1.2",
+        "gensequence": "^3.0.1",
         "get-stdin": "^7.0.0",
         "glob": "^7.1.6",
         "minimatch": "^3.0.4"
@@ -1475,9 +1475,9 @@
       }
     },
     "cspell-glob": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-0.1.12.tgz",
-      "integrity": "sha512-4ogphDPvCAZtFuBBcRZNf8GTmyuWHJ/PN3oH39AnIgjejMN2P0DsWXw0bSDilbbldR2iABWGVwTlLayxXCxTbQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-0.1.13.tgz",
+      "integrity": "sha512-0C4Im4cfFz7oKZjECsnWx9pfk1c1/i8BQr4WMjBokEnTBxA6Idg3S8lff3CdXokK4H0HbO+rxLHx7aQvHA27ag==",
       "dev": true,
       "requires": {
         "micromatch": "^4.0.2"
@@ -1494,9 +1494,9 @@
       }
     },
     "cspell-lib": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-4.1.7.tgz",
-      "integrity": "sha512-b8Tvj1963MqcGz2k0v3gOT5/eERX9VF/KlGwj0heRRHdDBWKfYRjeWq5rWT0AT1RLz5vNWD8orZ3VX1pUjmTNQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-4.1.13.tgz",
+      "integrity": "sha512-s3gdPOQyqOW//bW9efdXWasqaOGjwj7jVoRLvLocN13Ls8Em2TAr33r6+sKTYkiOXBlTdUZuU5tDNWJjqkdrBw==",
       "dev": true,
       "requires": {
         "comment-json": "^1.1.3",
@@ -1526,27 +1526,26 @@
         "cspell-dict-software-terms": "^1.0.5",
         "cspell-dict-typescript": "^1.0.3",
         "cspell-io": "^4.0.19",
-        "cspell-trie-lib": "^4.1.1",
-        "cspell-util-bundle": "^4.0.6",
+        "cspell-trie-lib": "^4.1.7",
+        "cspell-util-bundle": "^4.0.8",
         "fs-extra": "^8.1.0",
-        "gensequence": "^2.1.2",
+        "gensequence": "^3.0.1",
         "vscode-uri": "^2.1.1"
       }
     },
     "cspell-trie-lib": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-4.1.1.tgz",
-      "integrity": "sha512-lyKfiXCLyNYqcLiwwctzQjBV5ZTeeQDWRHC69Qrj16oTFjEGRgY2VkREzRRwy2fj0/D/Q3wQShq5sYTx9DBofg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-4.1.7.tgz",
+      "integrity": "sha512-iO9ntmF4lR1iSoxuLFnhR59Jvf99B2D6D/zgmxV5JmfPTXA4SrU3VjaIBAHmyafAT+qy3akaYOmGoyj8auIHfg==",
       "dev": true,
       "requires": {
-        "gensequence": "^2.1.3",
-        "js-xxhash": "^1.0.4"
+        "gensequence": "^3.0.1"
       }
     },
     "cspell-util-bundle": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/cspell-util-bundle/-/cspell-util-bundle-4.0.6.tgz",
-      "integrity": "sha512-EaKvZOr2vzgYeXvEAX9lXNuUU5fA8E+xsaluA0oOQ7lNsNEMmDEjTuyroPpdes7KNuJSCvZeHjmWHU0YlUly7w==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/cspell-util-bundle/-/cspell-util-bundle-4.0.8.tgz",
+      "integrity": "sha512-sybpmdyE5VZ2jH7q7toAIwXE2w3wp5Db09OXIrdav1t9wy7kCwUaEqYQtn4hqTM5+9HehDkSg0+lDvTuKKbhNg==",
       "dev": true
     },
     "css-selector-tokenizer": {
@@ -2244,9 +2243,9 @@
       }
     },
     "gensequence": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-2.1.3.tgz",
-      "integrity": "sha512-qa/2k1YSyh6TGVtIMtmwv1tXfq7lkhR8pMtOExfZGuwyaqplMhUxyO/Wrw9fV+37B38WE6egpjSMcwyzlNOoHA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-3.0.1.tgz",
+      "integrity": "sha512-7yfgY5sMmsZP74N6eWjX2MPwecbfpYdJS0MmxZz+7iWPV566XunxPlmcNaSXW8BpVsXk36sYQCcEaJxVmFeLnQ==",
       "dev": true
     },
     "get-caller-file": {
@@ -2850,12 +2849,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
-    "js-xxhash": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/js-xxhash/-/js-xxhash-1.0.4.tgz",
-      "integrity": "sha512-S/6Oo7ruxx5k8m4qlMnbpwQdJjRsvvfcIhIk1dA9c5y5GNhYHKYKu9krEK3QgBax6CxJuf4gRL2opgLkdzWIKg==",
       "dev": true
     },
     "js-yaml": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.2.tgz",
-      "integrity": "sha512-Fr6a47c84PRLfd7M7u3/hEknyUdQrrBA6VoPmkze0tcflhU5UnpWEX2kn12ktA/lb+MNHSqFlSiPHIHsaErTPA==",
+      "version": "13.5.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.3.tgz",
+      "integrity": "sha512-ZPnWX9PW992w6DUsz3JIXHaSb5v7qmKCVzC3km6SxcDGxk7zmLfYaCJTbktIa5NeywJkkZDhGldKqDIvC5DRrA==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5302,22 +5302,22 @@
       }
     },
     "ts-node": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.1.tgz",
-      "integrity": "sha512-KqPbO7/UuOPE4ANAOV9geZjk6tet6rK2K+DFeEJq6kIXUi0nLkrOMksozGkIlFopOorkStlwar3DdWYrdl7zCw==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
+      "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
-        "yn": "^4.0.0"
+        "yn": "3.1.1"
       },
       "dependencies": {
         "diff": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
         }
       }
@@ -5768,9 +5768,9 @@
       }
     },
     "yn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-4.0.0.tgz",
-      "integrity": "sha512-huWiiCS4TxKc4SfgmTwW1K7JmXPPAmuXWYy4j9qjQo4+27Kni8mGhAAi1cloRWmBe2EqcLgt3IGqQoRL/MtPgg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -307,9 +307,9 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.1.tgz",
+      "integrity": "sha512-L/Nw/2e5KUaprNJoRA33oly+M8X8n0K+FwLTbYqwTcR14wdPWeRkigBLfSFpN/Asf9ENZTMZwLxjtjeYucAA4Q==",
       "dev": true
     },
     "@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -271,9 +271,9 @@
       "dev": true
     },
     "@types/chai": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.7.tgz",
-      "integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.8.tgz",
+      "integrity": "sha512-U1bQiWbln41Yo6EeHMr+34aUhvrMVyrhn9lYfPSpLTCrZlGxU4Rtn1bocX+0p2Fc/Jkd2FanCEXdw0WNfHHM0w==",
       "dev": true
     },
     "@types/color-name": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5302,16 +5302,16 @@
       }
     },
     "ts-node": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
-      "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.1.tgz",
+      "integrity": "sha512-KqPbO7/UuOPE4ANAOV9geZjk6tet6rK2K+DFeEJq6kIXUi0nLkrOMksozGkIlFopOorkStlwar3DdWYrdl7zCw==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
-        "yn": "^3.0.0"
+        "yn": "^4.0.0"
       },
       "dependencies": {
         "diff": {
@@ -5768,9 +5768,9 @@
       }
     },
     "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-4.0.0.tgz",
+      "integrity": "sha512-huWiiCS4TxKc4SfgmTwW1K7JmXPPAmuXWYy4j9qjQo4+27Kni8mGhAAi1cloRWmBe2EqcLgt3IGqQoRL/MtPgg==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.8.tgz",
-      "integrity": "sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.0.tgz",
+      "integrity": "sha512-Onhn+z72D2O2Pb2ql2xukJ55rglumsVo1H6Fmyi8mlU9SvKdBk/pUSUAiBY/d9bAOF7VVWajX3sths/+g6ZiAQ==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.4.tgz",
-      "integrity": "sha512-Lue/mlp2egZJoHXZr4LndxDAd7i/7SQYhV0EjWfb/a4/OZ6tuVwMCVPiwkU5nsEipxEf7hmkSU7Em5VQ8P5NGA==",
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.5.tgz",
+      "integrity": "sha512-wupvfmtbqRJzjCm1H2diy7wo31Gn1OzvqoxCfQuKM9eSecogzP0WTlrjdq7cf7jgSO2ZX6hxwgRPR8Wt7FA22g==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1070,7 +1070,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -1581,7 +1582,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       },
@@ -1589,8 +1589,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -1950,7 +1949,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "2.0.1",
@@ -1984,6 +1984,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fastparse": {
       "version": "1.1.2",
@@ -2120,12 +2125,12 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
@@ -2593,7 +2598,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -3187,9 +3193,9 @@
       }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
     },
     "mime-db": {
       "version": "1.40.0",
@@ -3938,7 +3944,8 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
     },
     "propagate": {
       "version": "1.0.0",
@@ -3977,7 +3984,8 @@
     "qs": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.0.tgz",
-      "integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA=="
+      "integrity": "sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==",
+      "dev": true
     },
     "randomatic": {
       "version": "3.1.1",
@@ -4041,6 +4049,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -4348,7 +4357,8 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -4634,6 +4644,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -4666,34 +4677,55 @@
       "dev": true
     },
     "superagent": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
-      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.1.2.tgz",
+      "integrity": "sha512-VwPCbi9H02qDtTbdY+e3+cK5XR0YHsJy9hmeCOXLQ8ezjq8+S1Bs4MdNRmpmf2QjDBetD7drG7/nEta7E3E6Sg==",
       "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.1.1",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.0.5"
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.1",
+        "methods": "^1.1.2",
+        "mime": "^2.4.4",
+        "qs": "^6.9.1",
+        "readable-stream": "^3.4.0",
+        "semver": "^6.3.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+        "qs": {
+          "version": "6.9.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1245,15 +1245,15 @@
       "dev": true
     },
     "cspell": {
-      "version": "4.0.44",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-4.0.44.tgz",
-      "integrity": "sha512-xrjsRbAPyx0s4QOdZ7gDiEPlqKQV+ua47FOvFiZqtq16H082P2O/M9vnDdwiEK4j6ypJQT+GkmR5QVdXXp+1qw==",
+      "version": "4.0.46",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-4.0.46.tgz",
+      "integrity": "sha512-1OzY2LGMQmuoe4odLhabDAxQoPMMwYPCGFKSiJXPJIg+w50iSBpUy2fWu4ExLeMjIUt6jOZ9hTQsq6WRMyXq3g==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "commander": "^2.20.3",
         "comment-json": "^1.1.3",
-        "cspell-glob": "^0.1.14",
+        "cspell-glob": "^0.1.17",
         "cspell-lib": "^4.1.14",
         "fs-extra": "^8.1.0",
         "gensequence": "^3.0.3",
@@ -1501,9 +1501,9 @@
       }
     },
     "cspell-glob": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-0.1.14.tgz",
-      "integrity": "sha512-mbGKM/O95U/1V14aDiHS32T36JC1dk7ndvOdJOc2dv7er+Z2PX0Qg6uoklsESTpWAO8zZjJiLiWDx8fgKz9+KA==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-0.1.17.tgz",
+      "integrity": "sha512-gAiKakWJbHay6cobcJnX1+XhNCFYqR7CJM5GPiEpRZ5RFXYR46fYbkVwTdg3sqbFLErJtghQj/0s5Xa0q9NJpQ==",
       "dev": true,
       "requires": {
         "micromatch": "^4.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -334,9 +334,9 @@
       "dev": true
     },
     "@types/superagent": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.4.tgz",
-      "integrity": "sha512-SRH2q6/5/nhOkAuLXm3azRGjBYpoKCZWh138Rt1AxSIyE6/1b9uClIH2V+JfyDtjIvgr5yQqYgNUmdpbneJoZQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.5.tgz",
+      "integrity": "sha512-9loAjd4tUO+I8zsTMRzFMWV0PZYy4ffJ+OnMBBdDI/Pe/Df4IIxSzwsLRc6WF7dMAIfBm1ucYqVZPwwu8pnruA==",
       "dev": true,
       "requires": {
         "@types/cookiejar": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -289,9 +289,9 @@
       "dev": true
     },
     "@types/estree": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.41.tgz",
-      "integrity": "sha512-rIAmXyJlqw4KEBO7+u9gxZZSQHaCNnIzYrnNmYVpgfJhxTqO0brCX0SYpqUTkVI5mwwUwzmtspLBGBKroMeynA==",
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.42.tgz",
+      "integrity": "sha512-K1DPVvnBCPxzD+G51/cxVIoc2X8uUVl1zpJeE6iKcgHMj4+tbat5Xu4TjV7v2QSDbIeAfLi2hIk+u2+s0MlpUQ==",
       "dev": true
     },
     "@types/event-emitter": {
@@ -4587,9 +4587,9 @@
       }
     },
     "rollup": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.29.0.tgz",
-      "integrity": "sha512-V63Iz0dSdI5qPPN5HmCN6OBRzBFhMqNWcvwgq863JtSCTU6Vdvqq6S2fYle/dSCyoPrBkIP3EIr1RVs3HTRqqg==",
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.29.1.tgz",
+      "integrity": "sha512-dGQ+b9d1FOX/gluiggTAVnTvzQZUEkCi/TwZcax7ujugVRHs0nkYJlV9U4hsifGEMojnO+jvEML2CJQ6qXgbHA==",
       "dev": true,
       "requires": {
         "@types/estree": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4617,9 +4617,9 @@
       "dev": true
     },
     "superagent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.1.2.tgz",
-      "integrity": "sha512-VwPCbi9H02qDtTbdY+e3+cK5XR0YHsJy9hmeCOXLQ8ezjq8+S1Bs4MdNRmpmf2QjDBetD7drG7/nEta7E3E6Sg==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.1.3.tgz",
+      "integrity": "sha512-2bno1Nb4uvZPECTJ7NDYlae6Q8LLQoZZZ9Vumd346jU1UGVkNC/lQI42jHwtrqVoepyt0QxNKFty01IRKgD4CA==",
       "requires": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3424,12 +3424,11 @@
       }
     },
     "nock": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-11.7.0.tgz",
-      "integrity": "sha512-7c1jhHew74C33OBeRYyQENT+YXQiejpwIrEjinh6dRurBae+Ei4QjeUaPlkptIF0ZacEiVCnw8dWaxqepkiihg==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-11.7.1.tgz",
+      "integrity": "sha512-fW+dlMyquAEvgtmGoRHftKrNnJ7yZcbINQDTW7OKRoTYa+11GA0u0UokWHuvCyZrG5TXkplnEv2jmj6R3vvImg==",
       "dev": true,
       "requires": {
-        "chai": "^4.1.2",
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4587,9 +4587,9 @@
       }
     },
     "rollup": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.28.0.tgz",
-      "integrity": "sha512-v2J/DmQi9+Nf6frGqzwZRvbiuTTrqH0yzoUF4Eybf8sONT4UpLZzJYnYzW96Zm9X1+4SJmijfnFBWCzHDAXYnQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.29.0.tgz",
+      "integrity": "sha512-V63Iz0dSdI5qPPN5HmCN6OBRzBFhMqNWcvwgq863JtSCTU6Vdvqq6S2fYle/dSCyoPrBkIP3EIr1RVs3HTRqqg==",
       "dev": true,
       "requires": {
         "@types/estree": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.1.tgz",
-      "integrity": "sha512-Jj2W7VWQ2uM83f8Ls5ON9adxN98MvyJsMSASYFuSvrov8RMRY64Ayay7KV35ph1TSGIJ2gG9ZVDdEq3c3zaydA==",
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.2.tgz",
+      "integrity": "sha512-Fr6a47c84PRLfd7M7u3/hEknyUdQrrBA6VoPmkze0tcflhU5UnpWEX2kn12ktA/lb+MNHSqFlSiPHIHsaErTPA==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4818,9 +4818,9 @@
       }
     },
     "sinon": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.1.0.tgz",
-      "integrity": "sha512-6/05TR+8QhEgTbyMWaConm8iPL609Eno7SqToPq63wC/jS/6NMEI4NxqtzlLkk3r/KcZT9xPXQodH0oJ917Hbg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.1.1.tgz",
+      "integrity": "sha512-E+tWr3acRdoe1nXbHMu86SSqA1WGM7Yw3jZRLvlCMnXwTHP8lgFFVn5BnKnF26uc5SfZ3D7pA9sN7S3Y2jG4Ew==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1617,28 +1617,6 @@
         "type-detect": "^4.0.0"
       }
     },
-    "deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
-      "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
-      "dev": true,
-      "requires": {
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "object-is": "^1.0.1",
-        "object-keys": "^1.1.1",
-        "regexp.prototype.flags": "^1.2.0"
-      },
-      "dependencies": {
-        "object-keys": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-          "dev": true
-        }
-      }
-    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -2465,12 +2443,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
-      "dev": true
-    },
-    "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
       "dev": true
     },
     "is-arrayish": {
@@ -3389,28 +3361,17 @@
       }
     },
     "nock": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
-      "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-11.7.0.tgz",
+      "integrity": "sha512-7c1jhHew74C33OBeRYyQENT+YXQiejpwIrEjinh6dRurBae+Ei4QjeUaPlkptIF0ZacEiVCnw8dWaxqepkiihg==",
       "dev": true,
       "requires": {
         "chai": "^4.1.2",
         "debug": "^4.1.0",
-        "deep-equal": "^1.0.0",
         "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.13",
         "mkdirp": "^0.5.0",
-        "propagate": "^1.0.0",
-        "qs": "^6.5.1",
-        "semver": "^5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "propagate": "^2.0.0"
       }
     },
     "node-abi": {
@@ -3612,12 +3573,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
-    "object-is": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
       "dev": true
     },
     "object-keys": {
@@ -3948,9 +3903,9 @@
       "dev": true
     },
     "propagate": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
-      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
     "pseudomap": {
@@ -4074,15 +4029,6 @@
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
       "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
-    },
-    "regexp.prototype.flags": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-      "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2"
-      }
     },
     "regexpu-core": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,33 +235,33 @@
       "dev": true
     },
     "@sinonjs/commons": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
-      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.0.tgz",
+      "integrity": "sha512-qbk9AP+cZUsKdW1GJsBpxPKFmCJ0T8swwzVje3qFd+AkQb74Q/tiuzrdfFg8AD2g5HH/XbE/I8Uc1KYHVYWfhg==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/formatio": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
-      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-4.0.1.tgz",
+      "integrity": "sha512-asIdlLFrla/WZybhm0C8eEzaDNNrzymiTqHMeJl6zPW2881l3uuVRpm0QlRQEjqYWv6CcKMGYME3LbrLJsORBw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^3.1.0"
+        "@sinonjs/samsam": "^4.2.0"
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.0.tgz",
+      "integrity": "sha512-yG7QbUz38ZPIegfuSMEcbOo0kkLGmPa8a0Qlz4dk7+cXYALDScWjIZzAm/u2+Frh+bcdZF6wZJZwwuJjY0WAjA==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.3.0",
+        "@sinonjs/commons": "^1.6.0",
         "array-from": "^2.1.1",
-        "lodash": "^4.17.15"
+        "lodash.get": "^4.4.2"
       }
     },
     "@sinonjs/text-encoding": {
@@ -3104,6 +3104,12 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -3139,10 +3145,13 @@
       }
     },
     "lolex": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
-      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
-      "dev": true
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
     },
     "magic-string": {
       "version": "0.25.4",
@@ -3407,15 +3416,16 @@
       "dev": true
     },
     "nise": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
-      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.0.tgz",
+      "integrity": "sha512-EObFx5tioBMePHpU/gGczaY2YDqL255iwjmZwswu2CiwEW8xIGrr3E2xij+efIppS1nLQo9NyXSIUySGHUOhHQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/formatio": "^4.0.1",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^4.1.0",
+        "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
       }
     },
@@ -3937,9 +3947,9 @@
       "dev": true
     },
     "path-to-regexp": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "dev": true,
       "requires": {
         "isarray": "0.0.1"
@@ -4657,18 +4667,41 @@
       }
     },
     "sinon": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
-      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.0.1.tgz",
+      "integrity": "sha512-vbXMHBszVioyPsuRDLEiPEgvkZnbjfdCFvLYV4jONNJqZNLWTwZ/gYSNh3SuiT1w9MRXUz+S7aX0B4Ar2XI8iw==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.4.0",
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.3.3",
-        "diff": "^3.5.0",
-        "lolex": "^4.2.0",
-        "nise": "^1.5.2",
-        "supports-color": "^5.5.0"
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/formatio": "^4.0.1",
+        "@sinonjs/samsam": "^4.0.1",
+        "diff": "^4.0.1",
+        "lolex": "^5.1.2",
+        "nise": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "sinon-chai": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4660,9 +4660,9 @@
       }
     },
     "sinon": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.0.2.tgz",
-      "integrity": "sha512-8W1S7BnCyvk7SK+Xi15B1QAVLuS81G/NGmWefPb31+ly6xI3fXaug/g5oUdfc8+7ruC4Ay51AxuLlYm8diq6kA==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.0.4.tgz",
+      "integrity": "sha512-cFsmgmvsgFb87e7SV7IcekogITlHX2KmlplyI9Pda0FH1Z8Ms/kWbpLs25Idp0m6ZJ3HEEjhaYYXbcTtWWUn4w==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4656,16 +4656,16 @@
       }
     },
     "rollup-plugin-terser": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.3.tgz",
-      "integrity": "sha512-FuFuXE5QUJ7snyxHLPp/0LFXJhdomKlIx/aK7Tg88Yubsx/UU/lmInoJafXJ4jwVVNcORJ1wRUC5T9cy5yk0wA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.2.0.tgz",
+      "integrity": "sha512-jQI+nYhtDBc9HFRBz8iGttQg7li9klmzR62RG2W2nN6hJ/FI2K2ItYQ7kJ7/zn+vs+BP1AEccmVRjRN989I+Nw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "jest-worker": "^24.6.0",
-        "rollup-pluginutils": "^2.8.1",
+        "@babel/code-frame": "^7.5.5",
+        "jest-worker": "^24.9.0",
+        "rollup-pluginutils": "^2.8.2",
         "serialize-javascript": "^2.1.2",
-        "terser": "^4.1.0"
+        "terser": "^4.6.2"
       }
     },
     "rollup-pluginutils": {
@@ -5145,9 +5145,9 @@
       }
     },
     "terser": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.2.tgz",
-      "integrity": "sha512-Uufrsvhj9O1ikwgITGsZ5EZS6qPokUOkCegS7fYOdGTv+OA90vndUbU6PEjr5ePqHfNUbGyMO7xyIZv2MhsALQ==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
+      "integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5438,9 +5438,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
-      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "typescript-formatter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4587,9 +4587,9 @@
       }
     },
     "rollup": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.29.1.tgz",
-      "integrity": "sha512-dGQ+b9d1FOX/gluiggTAVnTvzQZUEkCi/TwZcax7ujugVRHs0nkYJlV9U4hsifGEMojnO+jvEML2CJQ6qXgbHA==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.30.1.tgz",
+      "integrity": "sha512-Uus8mwQXwaO+ZVoNwBcXKhT0AvycFCBW/W8VZtkpVGsotRllWk9oldfCjqWmTnFRI0y7x6BnEqSqc65N+/YdBw==",
       "dev": true,
       "requires": {
         "@types/estree": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.5.tgz",
-      "integrity": "sha512-wupvfmtbqRJzjCm1H2diy7wo31Gn1OzvqoxCfQuKM9eSecogzP0WTlrjdq7cf7jgSO2ZX6hxwgRPR8Wt7FA22g==",
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
+      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.5.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.5.3.tgz",
-      "integrity": "sha512-ZPnWX9PW992w6DUsz3JIXHaSb5v7qmKCVzC3km6SxcDGxk7zmLfYaCJTbktIa5NeywJkkZDhGldKqDIvC5DRrA==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.0.tgz",
+      "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.2.tgz",
-      "integrity": "sha512-B8emQA1qeKerqd1dmIsQYnXi+mmAzTB7flExjmy5X1aVAKFNNNDubkavwR13kR6JnpeLp3aLoJhwn9trWPAyFQ==",
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.4.tgz",
+      "integrity": "sha512-Lue/mlp2egZJoHXZr4LndxDAd7i/7SQYhV0EjWfb/a4/OZ6tuVwMCVPiwkU5nsEipxEf7hmkSU7Em5VQ8P5NGA==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -459,6 +459,16 @@
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "app-root-path": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
@@ -652,6 +662,12 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "dev": true
     },
     "bl": {
       "version": "1.2.2",
@@ -919,6 +935,22 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
+    },
+    "chokidar": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      }
     },
     "chownr": {
       "version": "1.1.2",
@@ -2214,6 +2246,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -2296,6 +2335,15 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "globals": {
@@ -2518,6 +2566,15 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -2557,6 +2614,12 @@
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -2564,6 +2627,15 @@
       "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
       }
     },
     "is-module": {
@@ -3315,13 +3387,14 @@
       }
     },
     "mocha": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
-      "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.0.0.tgz",
+      "integrity": "sha512-CirsOPbO3jU86YKjjMzFLcXIb5YiGLUrjrXFHoJ3e2z9vWiaZVCZQ2+gtRGMPWF+nFhN6AWwLM/juzAQ6KRkbA==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
         "debug": "3.2.6",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
@@ -3334,7 +3407,7 @@
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "ms": "2.1.1",
-        "node-environment-flags": "1.0.5",
+        "node-environment-flags": "1.0.6",
         "object.assign": "4.1.0",
         "strip-json-comments": "2.0.1",
         "supports-color": "6.0.0",
@@ -3446,9 +3519,9 @@
       }
     },
     "node-environment-flags": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
-      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
       "dev": true,
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
@@ -3489,6 +3562,12 @@
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "npm-run-all": {
       "version": "4.1.5",
@@ -3780,6 +3859,12 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
@@ -3799,13 +3884,72 @@
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
+          "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
       }
     },
     "object.pick": {
@@ -4232,6 +4376,15 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.0.3",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.4"
       }
     },
     "rechoir": {
@@ -4826,6 +4979,26 @@
         "define-properties": "^1.1.2",
         "es-abstract": "^1.4.3",
         "function-bind": "^1.0.2"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3387,9 +3387,9 @@
       }
     },
     "mocha": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.0.0.tgz",
-      "integrity": "sha512-CirsOPbO3jU86YKjjMzFLcXIb5YiGLUrjrXFHoJ3e2z9vWiaZVCZQ2+gtRGMPWF+nFhN6AWwLM/juzAQ6KRkbA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.0.1.tgz",
+      "integrity": "sha512-9eWmWTdHLXh72rGrdZjNbG3aa1/3NRPpul1z0D979QpEnFdCG0Q5tv834N+94QEN2cysfV72YocQ3fn87s70fg==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -3894,9 +3894,9 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
-          "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+          "version": "1.17.4",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+          "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -289,9 +289,9 @@
       "dev": true
     },
     "@types/estree": {
-      "version": "0.0.40",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.40.tgz",
-      "integrity": "sha512-p3KZgMto/JyxosKGmnLDJ/dG5wf+qTRMUjHJcspC2oQKa4jP7mz+tv0ND56lLBu3ojHlhzY33Ol+khLyNmilkA==",
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.41.tgz",
+      "integrity": "sha512-rIAmXyJlqw4KEBO7+u9gxZZSQHaCNnIzYrnNmYVpgfJhxTqO0brCX0SYpqUTkVI5mwwUwzmtspLBGBKroMeynA==",
       "dev": true
     },
     "@types/event-emitter": {
@@ -4433,9 +4433,9 @@
       }
     },
     "rollup": {
-      "version": "1.27.13",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.27.13.tgz",
-      "integrity": "sha512-hDi7M07MpmNSDE8YVwGVFA8L7n8jTLJ4lG65nMAijAyqBe//rtu4JdxjUBE7JqXfdpqxqDTbCDys9WcqdpsQvw==",
+      "version": "1.27.14",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.27.14.tgz",
+      "integrity": "sha512-DuDjEyn8Y79ALYXMt+nH/EI58L5pEw5HU9K38xXdRnxQhvzUTI/nxAawhkAHUQeudANQ//8iyrhVRHJBuR6DSQ==",
       "dev": true,
       "requires": {
         "@types/estree": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,52 @@
         "@babel/highlight": "^7.0.0"
       }
     },
-    "@babel/generator": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.4.tgz",
-      "integrity": "sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==",
+    "@babel/core": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.7.tgz",
+      "integrity": "sha512-jlSjuj/7z138NLZALxVgrx13AOtqip42ATZP7+kYl53GvDV6+4dCek1mVUo8z8c8Xnw/mx2q3d9HWh3griuesQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.6.3",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.7.7",
+        "@babel/helpers": "^7.7.4",
+        "@babel/parser": "^7.7.7",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
+          "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+      "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.7.4",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -40,32 +79,43 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+      "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "^7.7.4",
+        "@babel/template": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+      "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+      "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.4"
+        "@babel/types": "^7.7.4"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
+      "integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/highlight": {
@@ -80,49 +130,109 @@
       }
     },
     "@babel/parser": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.4.tgz",
-      "integrity": "sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==",
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+      "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-      "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+      "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.6.0",
-        "@babel/types": "^7.6.0"
+        "@babel/parser": "^7.7.4",
+        "@babel/types": "^7.7.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.3.tgz",
-      "integrity": "sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+      "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.6.3",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.6.3",
-        "@babel/types": "^7.6.3",
+        "@babel/generator": "^7.7.4",
+        "@babel/helper-function-name": "^7.7.4",
+        "@babel/helper-split-export-declaration": "^7.7.4",
+        "@babel/parser": "^7.7.4",
+        "@babel/types": "^7.7.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
       }
     },
     "@babel/types": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.3.tgz",
-      "integrity": "sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+      "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
+      "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.6.0",
@@ -164,6 +274,12 @@
       "version": "4.2.7",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.7.tgz",
       "integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
+      "dev": true
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
     "@types/cookiejar": {
@@ -285,6 +401,16 @@
         }
       }
     },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -340,12 +466,12 @@
       "dev": true
     },
     "append-transform": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
-      "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "^2.0.0"
+        "default-require-extensions": "^3.0.0"
       }
     },
     "aproba": {
@@ -707,50 +833,15 @@
       "dev": true
     },
     "caching-transform": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
-      "integrity": "sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
       "dev": true,
       "requires": {
-        "hasha": "^3.0.0",
-        "make-dir": "^2.0.0",
-        "package-hash": "^3.0.0",
-        "write-file-atomic": "^2.4.2"
-      },
-      "dependencies": {
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-          "dev": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
-        }
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
       }
     },
     "caller-callsite": {
@@ -845,6 +936,12 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.10.0.tgz",
       "integrity": "sha512-kXGriGO7hW/uxDviPtUUehSG301RudEHUXNhAHeM5JM7iOSb6+tpXh+YqhcfxdCECvtfMNq0J7laOxAV3NsDng==",
+      "dev": true
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
     "cliui": {
@@ -1054,9 +1151,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -1083,43 +1180,6 @@
         "is-directory": "^0.3.1",
         "js-yaml": "^3.13.1",
         "parse-json": "^4.0.0"
-      }
-    },
-    "cp-file": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",
-      "integrity": "sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^2.0.0",
-        "nested-error-stacks": "^2.0.0",
-        "pify": "^4.0.1",
-        "safe-buffer": "^5.0.1"
-      },
-      "dependencies": {
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-          "dev": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "cross-spawn": {
@@ -1630,12 +1690,12 @@
       "dev": true
     },
     "default-require-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
-      "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
       "dev": true,
       "requires": {
-        "strip-bom": "^3.0.0"
+        "strip-bom": "^4.0.0"
       }
     },
     "define-properties": {
@@ -1988,38 +2048,14 @@
       }
     },
     "find-cache-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+      "integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "dependencies": {
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-          "dev": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "make-dir": "^3.0.0",
+        "pkg-dir": "^4.1.0"
       }
     },
     "find-up": {
@@ -2075,23 +2111,54 @@
       "dev": true
     },
     "foreground-child": {
-      "version": "1.5.6",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-      "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^4",
-        "signal-exit": "^3.0.0"
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -2116,6 +2183,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
       "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+    },
+    "fromentries": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
+      "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+      "dev": true
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -2284,18 +2357,6 @@
         "pify": "^3.0.0"
       }
     },
-    "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
-      "dev": true,
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2340,12 +2401,13 @@
       "dev": true
     },
     "hasha": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
-      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.1.0.tgz",
+      "integrity": "sha512-OFPDWmzPN1l7atOV1TgBVmNtBxaIysToK6Ve9DK+vT6pYuklw/nPNT+HJbZi0KDcI6vWB+9tgvZ5YD7fA3CXcA==",
       "dev": true,
       "requires": {
-        "is-stream": "^1.0.1"
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
       }
     },
     "he": {
@@ -2368,6 +2430,12 @@
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
+    },
+    "html-escaper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+      "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2416,6 +2484,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "inflight": {
@@ -2547,9 +2621,9 @@
       }
     },
     "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
       "dev": true
     },
     "is-symbol": {
@@ -2565,6 +2639,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "isarray": {
@@ -2595,33 +2675,33 @@
       "dev": true
     },
     "istanbul-lib-coverage": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
-      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
       "dev": true
     },
     "istanbul-lib-hook": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
-      "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
       "dev": true,
       "requires": {
-        "append-transform": "^1.0.0"
+        "append-transform": "^2.0.0"
       }
     },
     "istanbul-lib-instrument": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
-      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.0.tgz",
+      "integrity": "sha512-Nm4wVHdo7ZXSG30KjZ2Wl5SU/Bw7bDx1PdaiIFzEStdjs0H12mOTncn1GVYuqQSaZxpg87VGBRsVRPGD2cD1AQ==",
       "dev": true,
       "requires": {
-        "@babel/generator": "^7.4.0",
-        "@babel/parser": "^7.4.3",
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.3",
-        "@babel/types": "^7.4.0",
-        "istanbul-lib-coverage": "^2.0.5",
-        "semver": "^6.0.0"
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -2632,103 +2712,111 @@
         }
       }
     },
-    "istanbul-lib-report": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
-      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+    "istanbul-lib-processinfo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "supports-color": "^6.1.0"
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.0",
+        "istanbul-lib-coverage": "^3.0.0-alpha.1",
+        "make-dir": "^3.0.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3"
       },
       "dependencies": {
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
           "dev": true,
           "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
           }
         },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
           "dev": true
         },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         }
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
-      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.5",
-        "make-dir": "^2.1.0",
-        "rimraf": "^2.6.3",
+        "istanbul-lib-coverage": "^3.0.0",
         "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-          "dev": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+      "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
       }
     },
     "iterable-to-stream": {
@@ -2877,6 +2965,15 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "json5": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -3054,16 +3151,6 @@
       "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
     },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
     "magic-string": {
       "version": "0.25.4",
       "resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.25.4.tgz",
@@ -3133,15 +3220,6 @@
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
-    },
-    "merge-source-map": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
-      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.6.1"
-      }
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -3324,18 +3402,6 @@
       "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA==",
       "dev": true
     },
-    "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-      "dev": true
-    },
-    "nested-error-stacks": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
-      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
-      "dev": true
-    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -3399,6 +3465,15 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
+      }
+    },
+    "node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "requires": {
+        "process-on-spawn": "^1.0.0"
       }
     },
     "noop-logger": {
@@ -3492,74 +3567,208 @@
       "dev": true
     },
     "nyc": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
-      "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
+      "integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "caching-transform": "^3.0.2",
-        "convert-source-map": "^1.6.0",
-        "cp-file": "^6.2.0",
-        "find-cache-dir": "^2.1.0",
-        "find-up": "^3.0.0",
-        "foreground-child": "^1.5.6",
-        "glob": "^7.1.3",
-        "istanbul-lib-coverage": "^2.0.5",
-        "istanbul-lib-hook": "^2.0.7",
-        "istanbul-lib-instrument": "^3.3.0",
-        "istanbul-lib-report": "^2.0.8",
-        "istanbul-lib-source-maps": "^3.0.6",
-        "istanbul-reports": "^2.2.4",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.0",
         "js-yaml": "^3.13.1",
-        "make-dir": "^2.1.0",
-        "merge-source-map": "^1.1.0",
-        "resolve-from": "^4.0.0",
-        "rimraf": "^2.6.3",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.0",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
         "signal-exit": "^3.0.2",
-        "spawn-wrap": "^1.4.2",
-        "test-exclude": "^5.2.3",
-        "uuid": "^3.3.2",
-        "yargs": "^13.2.2",
-        "yargs-parser": "^13.0.0"
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "uuid": "^3.3.3",
+        "yargs": "^15.0.2"
       },
       "dependencies": {
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+          "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
           "dev": true,
           "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
         },
         "resolve-from": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
         },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
           }
         },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.0.2.tgz",
+          "integrity": "sha512-GH/X/hYt+x5hOat4LMnCqMd8r5Cv78heOMIJn1hr7QPPBqfeC6p89Y78+WB9yGDvfpCvgasfmWLzNzEioOUD9Q==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^16.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "16.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
@@ -3629,30 +3838,6 @@
         "wrappy": "1"
       }
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
-      }
-    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -3691,6 +3876,15 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -3698,13 +3892,13 @@
       "dev": true
     },
     "package-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
-      "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.15",
-        "hasha": "^3.0.0",
+        "hasha": "^5.0.0",
         "lodash.flattendeep": "^4.4.0",
         "release-zalgo": "^1.0.0"
       }
@@ -3806,12 +4000,48 @@
       "dev": true
     },
     "pkg-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "requires": {
-        "find-up": "^3.0.0"
+        "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
       }
     },
     "pn": {
@@ -3902,6 +4132,15 @@
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
       "dev": true
     },
+    "process-on-spawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+      "dev": true,
+      "requires": {
+        "fromentries": "^1.2.0"
+      }
+    },
     "propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -3982,16 +4221,6 @@
         "load-json-file": "^4.0.0",
         "normalize-package-data": "^2.3.2",
         "path-type": "^3.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-      "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-      "dev": true,
-      "requires": {
-        "find-up": "^3.0.0",
-        "read-pkg": "^3.0.0"
       }
     },
     "readable-stream": {
@@ -4484,26 +4713,26 @@
       "dev": true
     },
     "spawn-wrap": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.3.tgz",
-      "integrity": "sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
       "dev": true,
       "requires": {
-        "foreground-child": "^1.5.6",
-        "mkdirp": "^0.5.0",
-        "os-homedir": "^1.0.1",
-        "rimraf": "^2.6.2",
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
         "signal-exit": "^3.0.2",
-        "which": "^1.3.0"
+        "which": "^2.0.1"
       },
       "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -4599,9 +4828,9 @@
       }
     },
     "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true
     },
     "strip-color": {
@@ -4743,15 +4972,30 @@
       }
     },
     "test-exclude": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
-      "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3",
-        "minimatch": "^3.0.4",
-        "read-pkg-up": "^4.0.0",
-        "require-main-filename": "^2.0.0"
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "through": {
@@ -4980,6 +5224,12 @@
       "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -5009,26 +5259,6 @@
       "requires": {
         "commandpost": "^1.0.0",
         "editorconfig": "^0.15.0"
-      }
-    },
-    "uglify-js": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
-      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true
-        }
       }
     },
     "unique-string": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4315,6 +4315,11 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "qs": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -5038,9 +5043,9 @@
       "dev": true
     },
     "superagent": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.1.3.tgz",
-      "integrity": "sha512-2bno1Nb4uvZPECTJ7NDYlae6Q8LLQoZZZ9Vumd346jU1UGVkNC/lQI42jHwtrqVoepyt0QxNKFty01IRKgD4CA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.2.1.tgz",
+      "integrity": "sha512-46b4Lkwnlz7Ebdv2FBbfuqb3kVkG1jV/SK3EW6NnwL9a3T4h5hHtegNEQfbXvTFbDoUZXId4W3dMgap2f6ic1g==",
       "requires": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.2",
@@ -5055,11 +5060,6 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
-        "qs": {
-          "version": "6.9.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
-        },
         "readable-stream": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1213,18 +1213,18 @@
       "dev": true
     },
     "cspell": {
-      "version": "4.0.43",
-      "resolved": "https://registry.npmjs.org/cspell/-/cspell-4.0.43.tgz",
-      "integrity": "sha512-msnehTsodBA7XX/lnEdQPC2jqhvdsb7Mqd/Ps2OSNmN0nS1fHYAC9wx2hD5E6wRCfsCmxxcaW0s1VXi0v26ujQ==",
+      "version": "4.0.44",
+      "resolved": "https://registry.npmjs.org/cspell/-/cspell-4.0.44.tgz",
+      "integrity": "sha512-xrjsRbAPyx0s4QOdZ7gDiEPlqKQV+ua47FOvFiZqtq16H082P2O/M9vnDdwiEK4j6ypJQT+GkmR5QVdXXp+1qw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "commander": "^2.20.3",
         "comment-json": "^1.1.3",
-        "cspell-glob": "^0.1.13",
-        "cspell-lib": "^4.1.13",
+        "cspell-glob": "^0.1.14",
+        "cspell-lib": "^4.1.14",
         "fs-extra": "^8.1.0",
-        "gensequence": "^3.0.1",
+        "gensequence": "^3.0.3",
         "get-stdin": "^7.0.0",
         "glob": "^7.1.6",
         "minimatch": "^3.0.4"
@@ -1307,18 +1307,18 @@
       }
     },
     "cspell-dict-en-gb": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/cspell-dict-en-gb/-/cspell-dict-en-gb-1.1.14.tgz",
-      "integrity": "sha512-rkZcVjeAYjC7/2x2K+3fWe54N0RFgIxU+3rr/zY/jc7PmSUIjiuN4PcUrgkHzZUkRl54CGnVQnLR4dvuNVds2A==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/cspell-dict-en-gb/-/cspell-dict-en-gb-1.1.16.tgz",
+      "integrity": "sha512-PBzHF40fVj+6Adm3dV3/uhkE2Ptu8W+WJ28socBDDpEfedFMwnC0rpxvAgmKJlLc0OYsn07/yzRnt9srisNrLg==",
       "dev": true,
       "requires": {
         "configstore": "^5.0.0"
       }
     },
     "cspell-dict-en_us": {
-      "version": "1.2.23",
-      "resolved": "https://registry.npmjs.org/cspell-dict-en_us/-/cspell-dict-en_us-1.2.23.tgz",
-      "integrity": "sha512-zgIalOERfENUHGY3SZ80q8RP7ohJTNCv+CMHU/8OlCgi3VEfytwNg0wlJ4fZIt0/kUiorXmjGNpu5GYS6WDlRw==",
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/cspell-dict-en_us/-/cspell-dict-en_us-1.2.24.tgz",
+      "integrity": "sha512-EINpnko8JlKGod64Sx5JYZHmUH1rNYaE90ALgqlnWins/t2MEi3ma5u0I7Ghh+/RiNRlcNErrVJxYb2xpeqiJg==",
       "dev": true,
       "requires": {
         "configstore": "^5.0.0"
@@ -1334,9 +1334,9 @@
       }
     },
     "cspell-dict-fullstack": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/cspell-dict-fullstack/-/cspell-dict-fullstack-1.0.21.tgz",
-      "integrity": "sha512-vA+hqLBOuqlYVPDZb5qFlYgg0oNOWbik/HqsN/ebxr6Nj4mJlgMmvPUMG5xAkX4Z5R4zLT2I5WY0Db80HaRN2g==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/cspell-dict-fullstack/-/cspell-dict-fullstack-1.0.22.tgz",
+      "integrity": "sha512-k8Op1ltkgKnMTTo/kgkywE0htwi+3EtYrPPWk+mD9o3IFgC6yLKA89Tkrd0kEEPR3qJvC4gQJmGJns6Y25v0Zg==",
       "dev": true,
       "requires": {
         "configstore": "^5.0.0"
@@ -1469,18 +1469,18 @@
       }
     },
     "cspell-glob": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-0.1.13.tgz",
-      "integrity": "sha512-0C4Im4cfFz7oKZjECsnWx9pfk1c1/i8BQr4WMjBokEnTBxA6Idg3S8lff3CdXokK4H0HbO+rxLHx7aQvHA27ag==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-0.1.14.tgz",
+      "integrity": "sha512-mbGKM/O95U/1V14aDiHS32T36JC1dk7ndvOdJOc2dv7er+Z2PX0Qg6uoklsESTpWAO8zZjJiLiWDx8fgKz9+KA==",
       "dev": true,
       "requires": {
         "micromatch": "^4.0.2"
       }
     },
     "cspell-io": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-4.0.19.tgz",
-      "integrity": "sha512-ZDIDDNWtvGi0bCNE8v5Q6pD49raCFxGZkfAsWjs8Q+4FT1X1BiyjNlvEO1csPTxhC9o+MlCkhdpxEnv+QZZCBQ==",
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-4.0.20.tgz",
+      "integrity": "sha512-fomz1P308XgyyxaOEKdNbh82Ac4AKaz26p4JszV7YkJrGDsXMoByTQjVqdDloNN8FchogSEpLPeQoIg648exBA==",
       "dev": true,
       "requires": {
         "iconv-lite": "^0.4.24",
@@ -1488,9 +1488,9 @@
       }
     },
     "cspell-lib": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-4.1.13.tgz",
-      "integrity": "sha512-s3gdPOQyqOW//bW9efdXWasqaOGjwj7jVoRLvLocN13Ls8Em2TAr33r6+sKTYkiOXBlTdUZuU5tDNWJjqkdrBw==",
+      "version": "4.1.14",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-4.1.14.tgz",
+      "integrity": "sha512-K2V7V096c19qOJNPrbAJCVcRHZsyQUISA0eLakIg34nXQlPQZaRdfnXTG5FOFNxyWuub8Ekn8MnDwA54D5AIJw==",
       "dev": true,
       "requires": {
         "comment-json": "^1.1.3",
@@ -1519,27 +1519,27 @@
         "cspell-dict-scala": "^1.0.11",
         "cspell-dict-software-terms": "^1.0.5",
         "cspell-dict-typescript": "^1.0.3",
-        "cspell-io": "^4.0.19",
-        "cspell-trie-lib": "^4.1.7",
-        "cspell-util-bundle": "^4.0.8",
+        "cspell-io": "^4.0.20",
+        "cspell-trie-lib": "^4.1.8",
+        "cspell-util-bundle": "^4.0.9",
         "fs-extra": "^8.1.0",
-        "gensequence": "^3.0.1",
+        "gensequence": "^3.0.3",
         "vscode-uri": "^2.1.1"
       }
     },
     "cspell-trie-lib": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-4.1.7.tgz",
-      "integrity": "sha512-iO9ntmF4lR1iSoxuLFnhR59Jvf99B2D6D/zgmxV5JmfPTXA4SrU3VjaIBAHmyafAT+qy3akaYOmGoyj8auIHfg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-4.1.8.tgz",
+      "integrity": "sha512-G0Jpybwxyl7rG3c4tzrROEVmiKAsyIjaDdnGxkzOFkl4tjcZeCh7GIVrqLyyk3VWslrWMVvmQi1/eLDccagepw==",
       "dev": true,
       "requires": {
-        "gensequence": "^3.0.1"
+        "gensequence": "^3.0.3"
       }
     },
     "cspell-util-bundle": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/cspell-util-bundle/-/cspell-util-bundle-4.0.8.tgz",
-      "integrity": "sha512-sybpmdyE5VZ2jH7q7toAIwXE2w3wp5Db09OXIrdav1t9wy7kCwUaEqYQtn4hqTM5+9HehDkSg0+lDvTuKKbhNg==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/cspell-util-bundle/-/cspell-util-bundle-4.0.9.tgz",
+      "integrity": "sha512-+xhIGJAkPxD7aKl97S0E34B5dF+HSTSoEL6M2f6Y46tusFGc9VdhA/iIZQooZZx2RQy4WaHw/ABfsRfxtnFVLw==",
       "dev": true
     },
     "css-selector-tokenizer": {
@@ -2237,9 +2237,9 @@
       }
     },
     "gensequence": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-3.0.1.tgz",
-      "integrity": "sha512-7yfgY5sMmsZP74N6eWjX2MPwecbfpYdJS0MmxZz+7iWPV566XunxPlmcNaSXW8BpVsXk36sYQCcEaJxVmFeLnQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-3.0.3.tgz",
+      "integrity": "sha512-KM4L8AfWAfjIvdnBhl7erj35iBNf75pP0+8Ww3BKssVEBv95Dqu40cG62kAyVXtuLplb96wh/GUr+GhM6YG9gQ==",
       "dev": true
     },
     "get-caller-file": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
-      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg==",
+      "version": "13.1.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.7.tgz",
+      "integrity": "sha512-HU0q9GXazqiKwviVxg9SI/+t/nAsGkvLDkIdxz+ObejG2nX6Si00TeLqHMoS+a/1tjH7a8YpKVQwtgHuMQsldg==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -313,9 +313,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
-      "integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.0.tgz",
+      "integrity": "sha512-zwrxviZS08kRX40nqBrmERElF2vpw4IUTd5khkhBTfFH8AOaeoLVx48EC4+ZzS2/Iga7NevncqnsUSYjM4OWYA==",
       "dev": true
     },
     "@types/resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4429,9 +4429,9 @@
       }
     },
     "rollup": {
-      "version": "1.27.14",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.27.14.tgz",
-      "integrity": "sha512-DuDjEyn8Y79ALYXMt+nH/EI58L5pEw5HU9K38xXdRnxQhvzUTI/nxAawhkAHUQeudANQ//8iyrhVRHJBuR6DSQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.28.0.tgz",
+      "integrity": "sha512-v2J/DmQi9+Nf6frGqzwZRvbiuTTrqH0yzoUF4Eybf8sONT4UpLZzJYnYzW96Zm9X1+4SJmijfnFBWCzHDAXYnQ==",
       "dev": true,
       "requires": {
         "@types/estree": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,14 +254,14 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.0.tgz",
-      "integrity": "sha512-yG7QbUz38ZPIegfuSMEcbOo0kkLGmPa8a0Qlz4dk7+cXYALDScWjIZzAm/u2+Frh+bcdZF6wZJZwwuJjY0WAjA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-4.2.1.tgz",
+      "integrity": "sha512-7+5S4C4wpug5pzHS+z/63+XUwsH7dtyYELDafoT1QnfruFh7eFjlDWwZXltUB0GLk6y5eMeAt34Bjx8wJ4KfSA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
-        "array-from": "^2.1.1",
-        "lodash.get": "^4.4.2"
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
       }
     },
     "@sinonjs/text-encoding": {
@@ -539,12 +539,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-      "dev": true
-    },
-    "array-from": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-map": {
@@ -3416,9 +3410,9 @@
       "dev": true
     },
     "nise": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.0.tgz",
-      "integrity": "sha512-EObFx5tioBMePHpU/gGczaY2YDqL255iwjmZwswu2CiwEW8xIGrr3E2xij+efIppS1nLQo9NyXSIUySGHUOhHQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-3.0.1.tgz",
+      "integrity": "sha512-fYcH9y0drBGSoi88kvhpbZEsenX58Yr+wOJ4/Mi1K4cy+iGP/a73gNoyNhu5E9QxPdgTlVChfIaAlnyOy/gHUA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
@@ -4667,17 +4661,17 @@
       }
     },
     "sinon": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.0.1.tgz",
-      "integrity": "sha512-vbXMHBszVioyPsuRDLEiPEgvkZnbjfdCFvLYV4jONNJqZNLWTwZ/gYSNh3SuiT1w9MRXUz+S7aX0B4Ar2XI8iw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-8.0.2.tgz",
+      "integrity": "sha512-8W1S7BnCyvk7SK+Xi15B1QAVLuS81G/NGmWefPb31+ly6xI3fXaug/g5oUdfc8+7ruC4Ay51AxuLlYm8diq6kA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
         "@sinonjs/formatio": "^4.0.1",
-        "@sinonjs/samsam": "^4.0.1",
+        "@sinonjs/samsam": "^4.2.1",
         "diff": "^4.0.1",
         "lolex": "^5.1.2",
-        "nise": "^3.0.0",
+        "nise": "^3.0.1",
         "supports-color": "^7.1.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "markdown-toc": "^1.2.0",
     "mocha": "^6.2.1",
     "mocha-jsdom": "^2.0.0",
-    "nock": "^10.0.6",
+    "nock": "^11.7.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
     "rimraf": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/chai": "^4.2.3",
     "@types/event-emitter": "^0.3.3",
     "@types/minimatch": "^3.0.3",
-    "@types/mocha": "^5.2.7",
+    "@types/mocha": "^7.0.1",
     "@types/node": "^13.1.0",
     "@types/superagent": "^4.1.4",
     "adf-tslint-rules": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/event-emitter": "^0.3.3",
     "@types/minimatch": "^3.0.3",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.11.1",
+    "@types/node": "^13.1.0",
     "@types/superagent": "^4.1.4",
     "adf-tslint-rules": "0.0.7",
     "bundlesize": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "event-emitter": "^0.3.5",
     "minimatch": "3.0.4",
-    "superagent": "^3.8.2"
+    "superagent": "^5.1.2"
   },
   "devDependencies": {
     "@types/chai": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alfresco/js-api",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "JavaScript client library for the Alfresco REST API",
   "author": "Alfresco Software, Ltd.",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "mocha-jsdom": "^2.0.0",
     "nock": "^11.7.0",
     "npm-run-all": "^4.1.5",
-    "nyc": "^14.1.1",
+    "nyc": "^15.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.25.1",
     "rollup-plugin-alias": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "fs-extra": "8.1.0",
     "klaw-sync": "6.0.0",
     "markdown-toc": "^1.2.0",
-    "mocha": "^6.2.1",
+    "mocha": "^7.0.0",
     "mocha-jsdom": "^2.0.0",
     "nock": "^11.7.0",
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-terser": "^5.1.3",
     "shx": "^0.3.2",
-    "sinon": "^7.5.0",
+    "sinon": "^8.0.1",
     "sinon-chai": "^3.3.0",
     "ts-node": "^8.4.1",
     "tslint": "^5.20.0",

--- a/scripts/git-tag.sh
+++ b/scripts/git-tag.sh
@@ -9,8 +9,8 @@ fi;
 echo $VERSION
 
 echo "git tag -a ${VERSION} -m ${VERSION}"
-git config --local user.name "eromano"
-git config --local user.email "eugenioromano16@gmail.com"
+git config --local user.name "alfresco-build"
+git config --local user.email "build@alfresco.com"
 git tag -a ${VERSION} -m "${VERSION} [ci skip] "
 git remote rm origin
 GITHUB_REPO=https://$GITHUB_TOKEN:x-oauth-basic@github.com/Alfresco/alfresco-js-api.git

--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -537,6 +537,13 @@ export class AlfrescoApi implements EventEmitter.Emitter {
         return this.config.authType === 'OAUTH';
     }
 
+    isPublicUrl(): boolean {
+        if (this.isOauthConfiguration()) {
+            return this.oauth2Auth.isPublicUrl();
+        }
+        return false;
+    }
+
     isEcmBpmConfiguration(): boolean {
         return this.config.provider && this.config.provider.toUpperCase() === 'ALL';
     }

--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -59,7 +59,9 @@ export class AlfrescoApiClient implements ee.Emitter {
     /**
      * The default HTTP headers to be included for all API calls.
      */
-    defaultHeaders = {};
+    defaultHeaders = {
+        'user-agent': 'superagent'
+    };
 
     /**
      * The default HTTP timeout for all API calls.

--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -415,7 +415,9 @@ export class AlfrescoApiClient implements ee.Emitter {
     delete<T = void>(options: RequestOptions): Promise<T> {
         return this.request<T>({
             ...options,
-            httpMethod: 'DELETE'
+            httpMethod: 'DELETE',
+            contentTypes: options.contentTypes || this.contentTypes.JSON,
+            accepts: options.accepts || this.contentTypes.JSON
         });
     }
 

--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -46,6 +46,50 @@ export interface RequestOptions {
     responseType?: string;
 }
 
+/**
+ * Returns a string representation for an actual parameter.
+ * @param param The actual parameter.
+ * @returns The string representation of <code>param</code>.
+ */
+export function paramToString(param: any): string {
+    if (param === undefined || param === null) {
+        return '';
+    }
+    if (param instanceof Date) {
+        return param.toJSON();
+    }
+    return param.toString();
+}
+
+/**
+ * Builds a string representation of an array-type actual parameter, according to the given collection format.
+ * @param {Array} param An array parameter.
+ * @param {module:ApiClient.CollectionFormatEnum} collectionFormat The array element separator strategy.
+ * @returns {String|Array} A string representation of the supplied collection, using the specified delimiter. Returns
+ * <code>param</code> as is if <code>collectionFormat</code> is <code>multi</code>.
+ */
+export function buildCollectionParam(param: string[], collectionFormat: string): string | any[] {
+    if (!param) {
+        return null;
+    }
+
+    switch (collectionFormat) {
+        case 'csv':
+            return param.map(paramToString).join(',');
+        case 'ssv':
+            return param.map(paramToString).join(' ');
+        case 'tsv':
+            return param.map(paramToString).join('\t');
+        case 'pipes':
+            return param.map(paramToString).join('|');
+        case 'multi':
+            // return the array directly as SuperAgent will handle it as expected
+            return param.map(paramToString);
+        default:
+            throw new Error('Unknown collection format: ' + collectionFormat);
+    }
+}
+
 export class AlfrescoApiClient implements ee.Emitter {
 
     on: ee.EmitterMethod;
@@ -93,21 +137,6 @@ export class AlfrescoApiClient implements ee.Emitter {
     }
 
     /**
-     * Returns a string representation for an actual parameter.
-     * @param param The actual parameter.
-     * @returns The string representation of <code>param</code>.
-     */
-    paramToString(param: any): string {
-        if (param === undefined || param === null) {
-            return '';
-        }
-        if (param instanceof Date) {
-            return param.toJSON();
-        }
-        return param.toString();
-    }
-
-    /**
      * Builds full URL by appending the given path to the base URL and replacing path parameter place-holders with parameter values.
      * NOTE: query parameters are not handled here.
      * @param  path The path to append to the base URL.
@@ -119,11 +148,11 @@ export class AlfrescoApiClient implements ee.Emitter {
             path = '/' + path;
         }
         let url = this.basePath + path;
-        const _this = this;
+
         url = url.replace(/\{([\w-]+)\}/g, function (fullMatch, key) {
             let value;
             if (pathParams.hasOwnProperty(key)) {
-                value = _this.paramToString(pathParams[key]);
+                value = paramToString(pathParams[key]);
             } else {
                 value = fullMatch;
             }
@@ -206,41 +235,11 @@ export class AlfrescoApiClient implements ee.Emitter {
                 if (this.isFileParam(value) || Array.isArray(value)) {
                     newParams[key] = value;
                 } else {
-                    newParams[key] = this.paramToString(value);
+                    newParams[key] = paramToString(value);
                 }
             }
         }
         return newParams;
-    }
-
-
-    /**
-     * Builds a string representation of an array-type actual parameter, according to the given collection format.
-     * @param {Array} param An array parameter.
-     * @param {module:ApiClient.CollectionFormatEnum} collectionFormat The array element separator strategy.
-     * @returns {String|Array} A string representation of the supplied collection, using the specified delimiter. Returns
-     * <code>param</code> as is if <code>collectionFormat</code> is <code>multi</code>.
-     */
-    buildCollectionParam(param: string[], collectionFormat: string): string | any[] {
-        if (!param) {
-            return null;
-        }
-
-        switch (collectionFormat) {
-            case 'csv':
-                return param.map(this.paramToString).join(',');
-            case 'ssv':
-                return param.map(this.paramToString).join(' ');
-            case 'tsv':
-                return param.map(this.paramToString).join('\t');
-            case 'pipes':
-                return param.map(this.paramToString).join('|');
-            case 'multi':
-                // return the array directly as SuperAgent will handle it as expected
-                return param.map(this.paramToString);
-            default:
-                throw new Error('Unknown collection format: ' + collectionFormat);
-        }
     }
 
     isWithCredentials(): boolean {
@@ -614,11 +613,11 @@ export class AlfrescoApiClient implements ee.Emitter {
             path = '/' + path;
         }
         let url = basePath + path;
-        const _this = this;
+
         url = url.replace(/\{([\w-]+)\}/g, function (fullMatch, key) {
             let value;
             if (pathParams.hasOwnProperty(key)) {
-                value = _this.paramToString(pathParams[key]);
+                value = paramToString(pathParams[key]);
             } else {
                 value = fullMatch;
             }

--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -60,7 +60,6 @@ export class AlfrescoApiClient implements ee.Emitter {
      * The default HTTP headers to be included for all API calls.
      */
     defaultHeaders = {
-        'user-agent': 'superagent'
     };
 
     /**

--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -444,7 +444,7 @@ export class AlfrescoApiClient implements ee.Emitter {
                 } else {
                     if (this.isBpmRequest()) {
                         if (response.header && response.header.hasOwnProperty('set-cookie')) {
-                            this.authentications.cookie = response.header['set-cookie'];
+                            this.authentications.cookie = response.header['set-cookie'][0];
                         }
                     }
                     let data = {};

--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -31,6 +31,21 @@ const process: any = {};
 declare const Buffer: any;
 declare const Blob: any;
 
+export interface RequestOptions {
+    path: string;
+    httpMethod?: string;
+    pathParams?: any;
+    queryParams?: any;
+    headerParams?: any;
+    formParams?: any;
+    bodyParam?: any;
+    contentTypes?: string[];
+    accepts?: string[];
+    returnType?: any;
+    contextRoot?: string;
+    responseType?: string;
+}
+
 export class AlfrescoApiClient implements ee.Emitter {
 
     on: ee.EmitterMethod;
@@ -66,6 +81,10 @@ export class AlfrescoApiClient implements ee.Emitter {
      * The default HTTP timeout for all API calls.
      */
     timeout: number | { deadline?: number, response?: number } = undefined;
+
+    contentTypes = {
+        JSON: ['application/json']
+    };
 
     constructor(host?: string) {
         this.host = host;
@@ -347,6 +366,57 @@ export class AlfrescoApiClient implements ee.Emitter {
         }
         return this.callHostApi(path, httpMethod, pathParams, queryParams, headerParams, formParams, bodyParam,
             contentTypes, accepts, returnType, contextRoot, responseType, url);
+    }
+
+    request<T = any>(options: RequestOptions): Promise<T> {
+        return this.callApi(
+            options.path,
+            options.httpMethod,
+            options.pathParams,
+            options.queryParams,
+            options.headerParams,
+            options.formParams,
+            options.bodyParam,
+            options.contentTypes,
+            options.accepts,
+            options.returnType,
+            options.contextRoot,
+            options.responseType
+        );
+    }
+
+    post<T = any>(options: RequestOptions): Promise<T> {
+        return this.request<T>({
+            ...options,
+            httpMethod: 'POST',
+            contentTypes: options.contentTypes || this.contentTypes.JSON,
+            accepts: options.accepts || this.contentTypes.JSON
+        });
+    }
+
+    put<T = any>(options: RequestOptions): Promise<T> {
+        return this.request<T>({
+            ...options,
+            httpMethod: 'PUT',
+            contentTypes: options.contentTypes || this.contentTypes.JSON,
+            accepts: options.accepts || this.contentTypes.JSON
+        });
+    }
+
+    get<T = any>(options: RequestOptions): Promise<T> {
+        return this.request<T>({
+            ...options,
+            httpMethod: 'GET',
+            contentTypes: options.contentTypes || this.contentTypes.JSON,
+            accepts: options.accepts || this.contentTypes.JSON
+        });
+    }
+
+    delete<T = void>(options: RequestOptions): Promise<T> {
+        return this.request<T>({
+            ...options,
+            httpMethod: 'DELETE'
+        });
     }
 
     /**

--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -574,7 +574,7 @@ export class AlfrescoApiClient implements ee.Emitter {
         const token = this.createCSRFToken();
         request.set('X-CSRF-TOKEN', token);
 
-        if (this.isNodeEnv()) {
+        if (!this.isBrowser()) {
             request.set('Cookie', 'CSRF-TOKEN=' + token + ';path=/');
         }
 
@@ -587,6 +587,11 @@ export class AlfrescoApiClient implements ee.Emitter {
     isNodeEnv(): boolean {
         return (typeof process !== 'undefined') && (process.release && process.release.name === 'node');
     }
+
+     isBrowser(): boolean {
+         return ( typeof window !== 'undefined' && typeof window.document !== 'undefined');
+     }
+
 
     createCSRFToken(a?: any): string {
         return a ? (a ^ Math.random() * 16 >> a / 4).toString(16) : ([1e16] + (1e16).toString()).replace(/[01]/g, this.createCSRFToken);
@@ -661,7 +666,7 @@ export class AlfrescoApiClient implements ee.Emitter {
         if (this.isBpmRequest()) {
             request.withCredentials();
             if (this.authentications.cookie) {
-                if (this.isNodeEnv()) {
+                if (!this.isBrowser()) {
                     request.set('Cookie', this.authentications.cookie);
                 }
             }

--- a/src/api/activiti-rest-api/api/adminEndpoints.api.ts
+++ b/src/api/activiti-rest-api/api/adminEndpoints.api.ts
@@ -19,6 +19,7 @@ import { CreateEndpointBasicAuthRepresentation } from '../model/createEndpointBa
 import { EndpointBasicAuthRepresentation } from '../model/endpointBasicAuthRepresentation';
 import { EndpointConfigurationRepresentation } from '../model/endpointConfigurationRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Adminendpoints service.
@@ -34,12 +35,8 @@ export class AdminEndpointsApi extends BaseApi {
     * @return Promise<EndpointBasicAuthRepresentation>
     */
     createBasicAuthConfiguration(createRepresentation: CreateEndpointBasicAuthRepresentation): Promise<EndpointBasicAuthRepresentation> {
-
+        throwIfNotDefined(createRepresentation, 'createRepresentation');
         let postBody = createRepresentation;
-
-        if (createRepresentation === undefined || createRepresentation === null) {
-            throw new Error("Required param 'createRepresentation' in createBasicAuthConfiguration");
-        }
 
         let pathParams = {
 
@@ -71,12 +68,8 @@ export class AdminEndpointsApi extends BaseApi {
         * @return Promise<EndpointConfigurationRepresentation>
         */
     createEndpointConfiguration(representation: EndpointConfigurationRepresentation): Promise<EndpointConfigurationRepresentation> {
-
+        throwIfNotDefined(representation, 'representation');
         let postBody = representation;
-
-        if (representation === undefined || representation === null) {
-            throw new Error("Required param 'representation' in createEndpointConfiguration");
-        }
 
         let pathParams = {
 
@@ -109,16 +102,10 @@ export class AdminEndpointsApi extends BaseApi {
         * @return Promise<EndpointBasicAuthRepresentation>
         */
     getBasicAuthConfiguration(basicAuthId: number, tenantId: number): Promise<EndpointBasicAuthRepresentation> {
+        throwIfNotDefined(basicAuthId, 'basicAuthId');
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (basicAuthId === undefined || basicAuthId === null) {
-            throw new Error("Required param 'basicAuthId' in getBasicAuthConfiguration");
-        }
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in getBasicAuthConfiguration");
-        }
 
         let pathParams = {
             'basicAuthId': basicAuthId
@@ -151,12 +138,9 @@ export class AdminEndpointsApi extends BaseApi {
         * @return Promise<EndpointBasicAuthRepresentation>
         */
     getBasicAuthConfigurations(tenantId: number): Promise<EndpointBasicAuthRepresentation> {
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in getBasicAuthConfigurations");
-        }
 
         let pathParams = {
 
@@ -190,16 +174,10 @@ export class AdminEndpointsApi extends BaseApi {
         * @return Promise<EndpointConfigurationRepresentation>
         */
     getEndpointConfiguration(endpointConfigurationId: number, tenantId: number): Promise<EndpointConfigurationRepresentation> {
+        throwIfNotDefined(endpointConfigurationId, 'endpointConfigurationId');
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (endpointConfigurationId === undefined || endpointConfigurationId === null) {
-            throw new Error("Required param 'endpointConfigurationId' in getEndpointConfiguration");
-        }
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in getEndpointConfiguration");
-        }
 
         let pathParams = {
             'endpointConfigurationId': endpointConfigurationId
@@ -232,12 +210,9 @@ export class AdminEndpointsApi extends BaseApi {
         * @return Promise<EndpointConfigurationRepresentation>
         */
     getEndpointConfigurations(tenantId: number): Promise<EndpointConfigurationRepresentation> {
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in getEndpointConfigurations");
-        }
 
         let pathParams = {
 
@@ -271,16 +246,10 @@ export class AdminEndpointsApi extends BaseApi {
         * @return Promise<{}>
         */
     removeBasicAuthConfiguration(basicAuthId: number, tenantId: number): Promise<any> {
+        throwIfNotDefined(basicAuthId, 'basicAuthId');
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (basicAuthId === undefined || basicAuthId === null) {
-            throw new Error("Required param 'basicAuthId' in removeBasicAuthonfiguration");
-        }
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in removeBasicAuthonfiguration");
-        }
 
         let pathParams = {
             'basicAuthId': basicAuthId
@@ -314,16 +283,10 @@ export class AdminEndpointsApi extends BaseApi {
         * @return Promise<{}>
         */
     removeEndpointConfiguration(endpointConfigurationId: number, tenantId: number): Promise<any> {
+        throwIfNotDefined(endpointConfigurationId, 'endpointConfigurationId');
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (endpointConfigurationId === undefined || endpointConfigurationId === null) {
-            throw new Error("Required param 'endpointConfigurationId' in removeEndpointConfiguration");
-        }
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in removeEndpointConfiguration");
-        }
 
         let pathParams = {
             'endpointConfigurationId': endpointConfigurationId
@@ -357,16 +320,10 @@ export class AdminEndpointsApi extends BaseApi {
         * @return Promise<EndpointBasicAuthRepresentation>
         */
     updateBasicAuthConfiguration(basicAuthId: number, createRepresentation: CreateEndpointBasicAuthRepresentation): Promise<EndpointBasicAuthRepresentation> {
+        throwIfNotDefined(basicAuthId, 'basicAuthId');
+        throwIfNotDefined(createRepresentation, 'createRepresentation');
 
         let postBody = createRepresentation;
-
-        if (basicAuthId === undefined || basicAuthId === null) {
-            throw new Error("Required param 'basicAuthId' in updateBasicAuthConfiguration");
-        }
-
-        if (createRepresentation === undefined || createRepresentation === null) {
-            throw new Error("Required param 'createRepresentation' in updateBasicAuthConfiguration");
-        }
 
         let pathParams = {
             'basicAuthId': basicAuthId
@@ -399,16 +356,10 @@ export class AdminEndpointsApi extends BaseApi {
         * @return Promise<EndpointConfigurationRepresentation>
         */
     updateEndpointConfiguration(endpointConfigurationId: number, representation: EndpointConfigurationRepresentation): Promise<EndpointConfigurationRepresentation> {
+        throwIfNotDefined(endpointConfigurationId, 'endpointConfigurationId');
+        throwIfNotDefined(representation, 'representation');
 
         let postBody = representation;
-
-        if (endpointConfigurationId === undefined || endpointConfigurationId === null) {
-            throw new Error("Required param 'endpointConfigurationId' in updateEndpointConfiguration");
-        }
-
-        if (representation === undefined || representation === null) {
-            throw new Error("Required param 'representation' in updateEndpointConfiguration");
-        }
 
         let pathParams = {
             'endpointConfigurationId': endpointConfigurationId

--- a/src/api/activiti-rest-api/api/adminGroups.api.ts
+++ b/src/api/activiti-rest-api/api/adminGroups.api.ts
@@ -21,6 +21,7 @@ import { GroupRepresentation } from '../model/groupRepresentation';
 import { LightGroupRepresentation } from '../model/lightGroupRepresentation';
 import { ResultListDataRepresentationLightUserRepresentation } from '../model/resultListDataRepresentationLightUserRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Admingroups service.
@@ -36,12 +37,9 @@ export class AdminGroupsApi extends BaseApi {
     * @return Promise<{}>
     */
     activate(groupId: number): Promise<any> {
+        throwIfNotDefined(groupId, 'groupId');
 
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in activate");
-        }
 
         let pathParams = {
             'groupId': groupId
@@ -73,12 +71,9 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<{}>
         */
     addAllUsersToGroup(groupId: number): Promise<any> {
+        throwIfNotDefined(groupId, 'groupId');
 
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in addAllUsersToGroup");
-        }
 
         let pathParams = {
             'groupId': groupId
@@ -111,16 +106,10 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<{}>
         */
     addGroupCapabilities(groupId: number, addGroupCapabilitiesRepresentation: AddGroupCapabilitiesRepresentation): Promise<any> {
+        throwIfNotDefined(groupId, 'groupId');
+        throwIfNotDefined(addGroupCapabilitiesRepresentation, 'addGroupCapabilitiesRepresentation');
 
         let postBody = addGroupCapabilitiesRepresentation;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in addGroupCapabilities");
-        }
-
-        if (addGroupCapabilitiesRepresentation === undefined || addGroupCapabilitiesRepresentation === null) {
-            throw new Error("Required param 'addGroupCapabilitiesRepresentation' in addGroupCapabilities");
-        }
 
         let pathParams = {
             'groupId': groupId
@@ -153,16 +142,10 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<{}>
         */
     addGroupMember(groupId: number, userId: number): Promise<any> {
+        throwIfNotDefined(groupId, 'groupId');
+        throwIfNotDefined(userId, 'userId');
 
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in addGroupMember");
-        }
-
-        if (userId === undefined || userId === null) {
-            throw new Error("Required param 'userId' in addGroupMember");
-        }
 
         let pathParams = {
             'groupId': groupId, 'userId': userId
@@ -196,20 +179,11 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<{}>
         */
     addRelatedGroup(groupId: number, relatedGroupId: number, type: string): Promise<any> {
+        throwIfNotDefined(groupId, 'groupId');
+        throwIfNotDefined(relatedGroupId, 'relatedGroupId');
+        throwIfNotDefined(type, 'type');
 
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in addRelatedGroup");
-        }
-
-        if (relatedGroupId === undefined || relatedGroupId === null) {
-            throw new Error("Required param 'relatedGroupId' in addRelatedGroup");
-        }
-
-        if (type === undefined || type === null) {
-            throw new Error("Required param 'type' in addRelatedGroup");
-        }
 
         let pathParams = {
             'groupId': groupId, 'relatedGroupId': relatedGroupId
@@ -242,12 +216,9 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<GroupRepresentation>
         */
     createNewGroup(groupRepresentation: GroupRepresentation): Promise<GroupRepresentation> {
+        throwIfNotDefined(groupRepresentation, 'groupRepresentation');
 
         let postBody = groupRepresentation;
-
-        if (groupRepresentation === undefined || groupRepresentation === null) {
-            throw new Error("Required param 'groupRepresentation' in createNewGroup");
-        }
 
         let pathParams = {
 
@@ -280,16 +251,10 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteGroupCapability(groupId: number, groupCapabilityId: number): Promise<any> {
+        throwIfNotDefined(groupId, 'groupId');
+        throwIfNotDefined(groupCapabilityId, 'groupCapabilityId');
 
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in deleteGroupCapability");
-        }
-
-        if (groupCapabilityId === undefined || groupCapabilityId === null) {
-            throw new Error("Required param 'groupCapabilityId' in deleteGroupCapability");
-        }
 
         let pathParams = {
             'groupId': groupId, 'groupCapabilityId': groupCapabilityId
@@ -322,16 +287,10 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteGroupMember(groupId: number, userId: number): Promise<any> {
+        throwIfNotDefined(groupId, 'groupId');
+        throwIfNotDefined(userId, 'userId');
 
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in deleteGroupMember");
-        }
-
-        if (userId === undefined || userId === null) {
-            throw new Error("Required param 'userId' in deleteGroupMember");
-        }
 
         let pathParams = {
             'groupId': groupId, 'userId': userId
@@ -363,12 +322,9 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteGroup(groupId: number): Promise<any> {
+        throwIfNotDefined(groupId, 'groupId');
 
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in deleteGroup");
-        }
 
         let pathParams = {
             'groupId': groupId
@@ -401,16 +357,10 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteRelatedGroup(groupId: number, relatedGroupId: number): Promise<any> {
+        throwIfNotDefined(groupId, 'groupId');
+        throwIfNotDefined(relatedGroupId, 'relatedGroupId');
 
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in deleteRelatedGroup");
-        }
-
-        if (relatedGroupId === undefined || relatedGroupId === null) {
-            throw new Error("Required param 'relatedGroupId' in deleteRelatedGroup");
-        }
 
         let pathParams = {
             'groupId': groupId, 'relatedGroupId': relatedGroupId
@@ -442,12 +392,9 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<string>
         */
     getCapabilities(groupId: number): Promise<string> {
+        throwIfNotDefined(groupId, 'groupId');
 
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in getCapabilities");
-        }
 
         let pathParams = {
             'groupId': groupId
@@ -483,12 +430,10 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationLightUserRepresentation>
         */
     getGroupUsers(groupId: number, opts?: any): Promise<ResultListDataRepresentationLightUserRepresentation> {
+        throwIfNotDefined(groupId, 'groupId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in getGroupUsers");
-        }
 
         let pathParams = {
             'groupId': groupId
@@ -526,12 +471,10 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<AbstractGroupRepresentation>
         */
     getGroup(groupId: number, opts?: any): Promise<AbstractGroupRepresentation> {
+        throwIfNotDefined(groupId, 'groupId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in getGroup");
-        }
 
         let pathParams = {
             'groupId': groupId
@@ -604,12 +547,9 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<LightGroupRepresentation>
         */
     getRelatedGroups(groupId: number): Promise<LightGroupRepresentation> {
+        throwIfNotDefined(groupId, 'groupId');
 
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in getRelatedGroups");
-        }
 
         let pathParams = {
             'groupId': groupId
@@ -642,16 +582,10 @@ export class AdminGroupsApi extends BaseApi {
         * @return Promise<GroupRepresentation>
         */
     updateGroup(groupId: number, groupRepresentation: GroupRepresentation): Promise<GroupRepresentation> {
+        throwIfNotDefined(groupId, 'groupId');
+        throwIfNotDefined(groupRepresentation, 'groupRepresentation');
 
         let postBody = groupRepresentation;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in updateGroup");
-        }
-
-        if (groupRepresentation === undefined || groupRepresentation === null) {
-            throw new Error("Required param 'groupRepresentation' in updateGroup");
-        }
 
         let pathParams = {
             'groupId': groupId

--- a/src/api/activiti-rest-api/api/adminTenants.api.ts
+++ b/src/api/activiti-rest-api/api/adminTenants.api.ts
@@ -21,6 +21,7 @@ import { LightTenantRepresentation } from '../model/lightTenantRepresentation';
 import { TenantEvent } from '../model/tenantEvent';
 import { TenantRepresentation } from '../model/tenantRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Admintenants service.
@@ -36,12 +37,9 @@ export class AdminTenantsApi extends BaseApi {
     * @return Promise<LightTenantRepresentation>
     */
     createTenant(createTenantRepresentation: CreateTenantRepresentation): Promise<LightTenantRepresentation> {
+        throwIfNotDefined(createTenantRepresentation, 'groupId');
 
         let postBody = createTenantRepresentation;
-
-        if (createTenantRepresentation === undefined || createTenantRepresentation === null) {
-            throw new Error("Required param 'createTenantRepresentation' in createTenant");
-        }
 
         let pathParams = {
 
@@ -73,12 +71,9 @@ export class AdminTenantsApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteTenant(tenantId: number): Promise<any> {
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in deleteTenant");
-        }
 
         let pathParams = {
             'tenantId': tenantId
@@ -110,12 +105,9 @@ export class AdminTenantsApi extends BaseApi {
         * @return Promise<TenantEvent>
         */
     getTenantEvents(tenantId: number): Promise<TenantEvent> {
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in getTenantEvents");
-        }
 
         let pathParams = {
             'tenantId': tenantId
@@ -147,12 +139,9 @@ export class AdminTenantsApi extends BaseApi {
         * @return Promise<{}>
         */
     getTenantLogo(tenantId: number): Promise<any> {
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in getTenantLogo");
-        }
 
         let pathParams = {
             'tenantId': tenantId
@@ -184,12 +173,9 @@ export class AdminTenantsApi extends BaseApi {
         * @return Promise<TenantRepresentation>
         */
     getTenant(tenantId: number): Promise<TenantRepresentation> {
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in getTenant");
-        }
 
         let pathParams = {
             'tenantId': tenantId
@@ -254,16 +240,10 @@ export class AdminTenantsApi extends BaseApi {
         * @return Promise<TenantRepresentation>
         */
     update(tenantId: number, createTenantRepresentation: CreateTenantRepresentation): Promise<TenantRepresentation> {
+        throwIfNotDefined(tenantId, 'tenantId');
+        throwIfNotDefined(createTenantRepresentation, 'createTenantRepresentation');
 
         let postBody = createTenantRepresentation;
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in update");
-        }
-
-        if (createTenantRepresentation === undefined || createTenantRepresentation === null) {
-            throw new Error("Required param 'createTenantRepresentation' in update");
-        }
 
         let pathParams = {
             'tenantId': tenantId
@@ -296,16 +276,10 @@ export class AdminTenantsApi extends BaseApi {
         * @return Promise<ImageUploadRepresentation>
         */
     uploadTenantLogo(tenantId: number, file: any): Promise<ImageUploadRepresentation> {
+        throwIfNotDefined(tenantId, 'tenantId');
+        throwIfNotDefined(file, 'file');
 
         let postBody = null;
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in uploadTenantLogo");
-        }
-
-        if (file === undefined || file === null) {
-            throw new Error("Required param 'file' in uploadTenantLogo");
-        }
 
         let pathParams = {
             'tenantId': tenantId

--- a/src/api/activiti-rest-api/api/adminUsers.api.ts
+++ b/src/api/activiti-rest-api/api/adminUsers.api.ts
@@ -20,6 +20,7 @@ import { BulkUserUpdateRepresentation } from '../model/bulkUserUpdateRepresentat
 import { ResultListDataRepresentationAbstractUserRepresentation } from '../model/resultListDataRepresentationAbstractUserRepresentation';
 import { UserRepresentation } from '../model/userRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Adminusers service.
@@ -35,12 +36,9 @@ export class AdminUsersApi extends BaseApi {
     * @return Promise<{}>
     */
     bulkUpdateUsers(update: BulkUserUpdateRepresentation): Promise<any> {
+        throwIfNotDefined(update, 'update');
 
         let postBody = update;
-
-        if (update === undefined || update === null) {
-            throw new Error("Required param 'update' in bulkUpdateUsers");
-        }
 
         let pathParams = {
 
@@ -72,12 +70,9 @@ export class AdminUsersApi extends BaseApi {
         * @return Promise<UserRepresentation>
         */
     createNewUser(userRepresentation: UserRepresentation): Promise<UserRepresentation> {
+        throwIfNotDefined(userRepresentation, 'userRepresentation');
 
         let postBody = userRepresentation;
-
-        if (userRepresentation === undefined || userRepresentation === null) {
-            throw new Error("Required param 'userRepresentation' in createNewUser");
-        }
 
         let pathParams = {
 
@@ -111,12 +106,10 @@ export class AdminUsersApi extends BaseApi {
         * @return Promise<AbstractUserRepresentation>
         */
     getUser(userId: number, opts?: any): Promise<AbstractUserRepresentation> {
+        throwIfNotDefined(userId, 'userId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (userId === undefined || userId === null) {
-            throw new Error("Required param 'userId' in getUser");
-        }
 
         let pathParams = {
             'userId': userId
@@ -205,16 +198,10 @@ export class AdminUsersApi extends BaseApi {
         * @return Promise<{}>
         */
     updateUserDetails(userId: number, userRepresentation: UserRepresentation): Promise<any> {
+        throwIfNotDefined(userId, 'userId');
+        throwIfNotDefined(userRepresentation, 'userRepresentation');
 
         let postBody = userRepresentation;
-
-        if (userId === undefined || userId === null) {
-            throw new Error("Required param 'userId' in updateUserDetails");
-        }
-
-        if (userRepresentation === undefined || userRepresentation === null) {
-            throw new Error("Required param 'userRepresentation' in updateUserDetails");
-        }
 
         let pathParams = {
             'userId': userId

--- a/src/api/activiti-rest-api/api/appDefinitions.api.ts
+++ b/src/api/activiti-rest-api/api/appDefinitions.api.ts
@@ -20,6 +20,7 @@ import { AppDefinitionRepresentation } from '../model/appDefinitionRepresentatio
 import { AppDefinitionSaveRepresentation } from '../model/appDefinitionSaveRepresentation';
 import { AppDefinitionUpdateResultRepresentation } from '../model/appDefinitionUpdateResultRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
  * Appdefinitions service.
@@ -35,12 +36,9 @@ export class AppDefinitionsApi extends BaseApi {
      * @return Promise<{}>
      */
     deleteAppDefinition(appDefinitionId: number): Promise<any> {
+        throwIfNotDefined(appDefinitionId, 'appDefinitionId');
 
         let postBody = null;
-
-        if (appDefinitionId === undefined || appDefinitionId === null) {
-            throw new Error("Required param 'appDefinitionId' in deleteAppDefinition");
-        }
 
         let pathParams = {
             'appDefinitionId': appDefinitionId
@@ -69,12 +67,9 @@ export class AppDefinitionsApi extends BaseApi {
      * @return Promise<{}>
      */
     exportAppDefinition(modelId: number): Promise<any> {
+        throwIfNotDefined(modelId, 'modelId');
 
         let postBody = null;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in exportAppDefinition");
-        }
 
         let pathParams = {
             'modelId': modelId
@@ -103,12 +98,9 @@ export class AppDefinitionsApi extends BaseApi {
      * @return Promise<AppDefinitionRepresentation>
      */
     getAppDefinition(modelId: number): Promise<AppDefinitionRepresentation> {
+        throwIfNotDefined(modelId, 'modelId');
 
         let postBody = null;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in getAppDefinition");
-        }
 
         let pathParams = {
             'modelId': modelId
@@ -137,17 +129,11 @@ export class AppDefinitionsApi extends BaseApi {
      * @return Promise<AppDefinitionUpdateResultRepresentation>
      */
     importAndPublishApp(file: any): Promise<AppDefinitionUpdateResultRepresentation> {
+        throwIfNotDefined(file, 'file');
 
         let postBody = null;
-
-        if (file === undefined || file === null) {
-            throw new Error("Required param 'file' in importAndPublishApp");
-        }
-
         let pathParams = {};
-
         let queryParams = {};
-
         let headerParams = {};
         let formParams = {
             'file': file
@@ -174,12 +160,10 @@ export class AppDefinitionsApi extends BaseApi {
      * @return Promise<AppDefinitionRepresentation>
      */
     importAppDefinition(file: any, opts?: any): Promise<AppDefinitionRepresentation> {
+        throwIfNotDefined(file, 'file');
+
         opts = opts || {};
         let postBody = null;
-
-        if (file === undefined || file === null) {
-            throw new Error("Required param 'file' in importAppDefinition");
-        }
 
         let pathParams = {};
 
@@ -211,16 +195,10 @@ export class AppDefinitionsApi extends BaseApi {
      * @return Promise<AppDefinitionUpdateResultRepresentation>
      */
     publishAppDefinition(modelId: number, publishModel: AppDefinitionPublishRepresentation): Promise<AppDefinitionUpdateResultRepresentation> {
+        throwIfNotDefined(modelId, 'modelId');
+        throwIfNotDefined(publishModel, 'publishModel');
 
         let postBody = publishModel;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in publishAppDefinition");
-        }
-
-        if (publishModel === undefined || publishModel === null) {
-            throw new Error("Required param 'publishModel' in publishAppDefinition");
-        }
 
         let pathParams = {
             'modelId': modelId
@@ -250,16 +228,10 @@ export class AppDefinitionsApi extends BaseApi {
      * @return Promise<AppDefinitionUpdateResultRepresentation>
      */
     updateAppDefinition(modelId: number, updatedModel: AppDefinitionSaveRepresentation | any): Promise<any> {
+        throwIfNotDefined(modelId, 'modelId');
+        throwIfNotDefined(updatedModel, 'updatedModel');
 
         let postBody = updatedModel;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in updateAppDefinition");
-        }
-
-        if (updatedModel === undefined || updatedModel === null) {
-            throw new Error("Required param 'updatedModel' in updateAppDefinition");
-        }
 
         let pathParams = {
             'modelId': modelId

--- a/src/api/activiti-rest-api/api/checklists.api.ts
+++ b/src/api/activiti-rest-api/api/checklists.api.ts
@@ -19,6 +19,7 @@ import { ChecklistOrderRepresentation } from '../model/checklistOrderRepresentat
 import { ResultListDataRepresentationTaskRepresentation } from '../model/resultListDataRepresentationTaskRepresentation';
 import { TaskRepresentation } from '../model/taskRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Checklists service.
@@ -35,16 +36,10 @@ export class ChecklistsApi extends BaseApi {
     * @return Promise<TaskRepresentation>
     */
     addSubtask(taskId: string, taskRepresentation: TaskRepresentation): Promise<TaskRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(taskRepresentation, 'taskRepresentation');
 
         let postBody = taskRepresentation;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in addSubtask");
-        }
-
-        if (taskRepresentation === undefined || taskRepresentation === null) {
-            throw new Error("Required param 'taskRepresentation' in addSubtask");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -76,12 +71,9 @@ export class ChecklistsApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationTaskRepresentation>
         */
     getChecklist(taskId: string): Promise<ResultListDataRepresentationTaskRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getChecklist");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -114,16 +106,10 @@ export class ChecklistsApi extends BaseApi {
         * @return Promise<{}>
         */
     orderChecklist(taskId: string, orderRepresentation: ChecklistOrderRepresentation): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(orderRepresentation, 'orderRepresentation');
 
         let postBody = orderRepresentation;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in orderChecklist");
-        }
-
-        if (orderRepresentation === undefined || orderRepresentation === null) {
-            throw new Error("Required param 'orderRepresentation' in orderChecklist");
-        }
 
         let pathParams = {
             'taskId': taskId

--- a/src/api/activiti-rest-api/api/comments.api.ts
+++ b/src/api/activiti-rest-api/api/comments.api.ts
@@ -18,6 +18,7 @@
 import { CommentRepresentation } from '../model/commentRepresentation';
 import { ResultListDataRepresentationCommentRepresentation } from '../model/resultListDataRepresentationCommentRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Comments service.
@@ -34,16 +35,10 @@ export class ActivitiCommentsApi extends BaseApi {
     * @return Promise<CommentRepresentation>
     */
     addProcessInstanceComment(commentRequest: CommentRepresentation, processInstanceId: string): Promise<CommentRepresentation> {
+        throwIfNotDefined(commentRequest, 'commentRequest');
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = commentRequest;
-
-        if (commentRequest === undefined || commentRequest === null) {
-            throw new Error("Required param 'commentRequest' in addProcessInstanceComment");
-        }
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in addProcessInstanceComment");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -76,16 +71,10 @@ export class ActivitiCommentsApi extends BaseApi {
         * @return Promise<CommentRepresentation>
         */
     addTaskComment(commentRequest: CommentRepresentation, taskId: string): Promise<CommentRepresentation> {
+        throwIfNotDefined(commentRequest, 'commentRequest');
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = commentRequest;
-
-        if (commentRequest === undefined || commentRequest === null) {
-            throw new Error("Required param 'commentRequest' in addTaskComment");
-        }
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in addTaskComment");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -119,12 +108,10 @@ export class ActivitiCommentsApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationCommentRepresentation>
         */
     getProcessInstanceComments(processInstanceId: string, opts?: any): Promise<ResultListDataRepresentationCommentRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getProcessInstanceComments");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -159,12 +146,10 @@ export class ActivitiCommentsApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationCommentRepresentation>
         */
     getTaskComments(taskId: string, opts?: any): Promise<ResultListDataRepresentationCommentRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getTaskComments");
-        }
 
         let pathParams = {
             'taskId': taskId

--- a/src/api/activiti-rest-api/api/content.api.ts
+++ b/src/api/activiti-rest-api/api/content.api.ts
@@ -18,6 +18,7 @@
 import { RelatedContentRepresentation } from '../model/relatedContentRepresentation';
 import { ResultListDataRepresentationRelatedContentRepresentation } from '../model/resultListDataRepresentationRelatedContentRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
  * Content service.
@@ -36,14 +37,10 @@ export class ContentApi extends BaseApi {
      * @return Promise<RelatedContentRepresentation>
      */
     createRelatedContentOnProcessInstance(processInstanceId: string, relatedContent: RelatedContentRepresentation | any, opts?: any): Promise<RelatedContentRepresentation> {
-        opts = opts || {};
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in createRelatedContentOnProcessInstance");
-        }
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
+        throwIfNotDefined(relatedContent, 'relatedContent');
 
-        if (relatedContent === undefined || relatedContent === null) {
-            throw new Error("Required param 'relatedContent' in createRelatedContentOnProcessInstance");
-        }
+        opts = opts || {};
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -90,14 +87,10 @@ export class ContentApi extends BaseApi {
      * @return Promise<RelatedContentRepresentation>
      */
     createRelatedContentOnTask(taskId: string, relatedContent: RelatedContentRepresentation | any, opts?: any): Promise<RelatedContentRepresentation> {
-        opts = opts || {};
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in createRelatedContentOnTask");
-        }
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(relatedContent, 'relatedContent');
 
-        if (relatedContent === undefined || relatedContent === null) {
-            throw new Error("Required param 'relatedContent' in createRelatedContentOnTask");
-        }
+        opts = opts || {};
 
         let pathParams = {
             'taskId': taskId
@@ -142,12 +135,9 @@ export class ContentApi extends BaseApi {
      * @return Promise<RelatedContentRepresentation>
      */
     createTemporaryRawRelatedContent(file: any): Promise<RelatedContentRepresentation> {
+        throwIfNotDefined(file, 'file');
 
         let postBody = null;
-
-        if (file === undefined || file === null) {
-            throw new Error("Required param 'file' in createTemporaryRawRelatedContent");
-        }
 
         let pathParams = {};
 
@@ -176,12 +166,9 @@ export class ContentApi extends BaseApi {
      * @return Promise<RelatedContentRepresentation>
      */
     createTemporaryRelatedContent(relatedContent: RelatedContentRepresentation): Promise<RelatedContentRepresentation> {
+        throwIfNotDefined(relatedContent, 'relatedContent');
 
         let postBody = relatedContent;
-
-        if (relatedContent === undefined || relatedContent === null) {
-            throw new Error("Required param 'relatedContent' in createTemporaryRelatedContent");
-        }
 
         let pathParams = {};
 
@@ -208,12 +195,9 @@ export class ContentApi extends BaseApi {
      * @return Promise<{}>
      */
     deleteContent(contentId: number): Promise<any> {
+        throwIfNotDefined(contentId, 'contentId');
 
         let postBody = null;
-
-        if (contentId === undefined || contentId === null) {
-            throw new Error("Required param 'contentId' in deleteContent");
-        }
 
         let pathParams = {
             'contentId': contentId
@@ -242,12 +226,9 @@ export class ContentApi extends BaseApi {
      * @return Promise<RelatedContentRepresentation>
      */
     getContent(contentId: number): Promise<RelatedContentRepresentation> {
+        throwIfNotDefined(contentId, 'contentId');
 
         let postBody = null;
-
-        if (contentId === undefined || contentId === null) {
-            throw new Error("Required param 'contentId' in getContent");
-        }
 
         let pathParams = {
             'contentId': contentId
@@ -284,14 +265,10 @@ export class ContentApi extends BaseApi {
      * @param renditionType renditionType
      * @return Promise<{}>
      */
-    getRawContent(contentId: number): Promise<any>;
-    getRawContent(contentId: number, renditionType: string): Promise<any>;
     getRawContent(contentId: number, renditionType?: string): Promise<any> {
-        let postBody = null;
+        throwIfNotDefined(contentId, 'contentId');
 
-        if (contentId === undefined || contentId === null) {
-            throw new Error("Required param 'contentId' in getRawContent");
-        }
+        let postBody = null;
 
         let queryParams = {};
 
@@ -336,12 +313,10 @@ export class ContentApi extends BaseApi {
      * @return Promise<ResultListDataRepresentationRelatedContentRepresentation>
      */
     getRelatedContentForProcessInstance(processInstanceId: string, opts?: any): Promise<ResultListDataRepresentationRelatedContentRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getRelatedContentForProcessInstance");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -374,12 +349,10 @@ export class ContentApi extends BaseApi {
      * @return Promise<ResultListDataRepresentationRelatedContentRepresentation>
      */
     getRelatedContentForTask(taskId: string, opts?: any): Promise<ResultListDataRepresentationRelatedContentRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getRelatedContentForTask");
-        }
 
         let pathParams = {
             'taskId': taskId

--- a/src/api/activiti-rest-api/api/decisionAudits.api.ts
+++ b/src/api/activiti-rest-api/api/decisionAudits.api.ts
@@ -18,6 +18,7 @@
 import { DecisionAuditRepresentation } from '../model/decisionAuditRepresentation';
 import { ResultListDataRepresentationDecisionAuditRepresentation } from '../model/resultListDataRepresentationDecisionAuditRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Decisionaudits service.
@@ -33,12 +34,9 @@ export class DecisionAuditsApi extends BaseApi {
     * @return Promise<DecisionAuditRepresentation>
     */
     getAuditTrail(auditTrailId: number): Promise<DecisionAuditRepresentation> {
+        throwIfNotDefined(auditTrailId, 'taskId');
 
         let postBody = null;
-
-        if (auditTrailId === undefined || auditTrailId === null) {
-            throw new Error("Required param 'auditTrailId' in getAuditTrail");
-        }
 
         let pathParams = {
             'auditTrailId': auditTrailId
@@ -71,16 +69,10 @@ export class DecisionAuditsApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationDecisionAuditRepresentation>
         */
     getAuditTrails(decisionKey: string, dmnDeploymentId: number): Promise<ResultListDataRepresentationDecisionAuditRepresentation> {
+        throwIfNotDefined(decisionKey, 'decisionKey');
+        throwIfNotDefined(dmnDeploymentId, 'dmnDeploymentId');
 
         let postBody = null;
-
-        if (decisionKey === undefined || decisionKey === null) {
-            throw new Error("Required param 'decisionKey' in getAuditTrails");
-        }
-
-        if (dmnDeploymentId === undefined || dmnDeploymentId === null) {
-            throw new Error("Required param 'dmnDeploymentId' in getAuditTrails");
-        }
 
         let pathParams = {
 

--- a/src/api/activiti-rest-api/api/decisionTables.api.ts
+++ b/src/api/activiti-rest-api/api/decisionTables.api.ts
@@ -19,6 +19,7 @@ import { JsonNode } from '../model/jsonNode';
 import { ResultListDataRepresentationRuntimeDecisionTableRepresentation } from '../model/resultListDataRepresentationRuntimeDecisionTableRepresentation';
 import { RuntimeDecisionTableRepresentation } from '../model/runtimeDecisionTableRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Decisiontables service.
@@ -34,12 +35,9 @@ export class DecisionTablesApi extends BaseApi {
     * @return Promise<JsonNode>
     */
     getDecisionTableEditorJson(decisionTableId: number): Promise<JsonNode> {
+        throwIfNotDefined(decisionTableId, 'decisionTableId');
 
         let postBody = null;
-
-        if (decisionTableId === undefined || decisionTableId === null) {
-            throw new Error("Required param 'decisionTableId' in getDecisionTableEditorJson");
-        }
 
         let pathParams = {
             'decisionTableId': decisionTableId
@@ -71,12 +69,9 @@ export class DecisionTablesApi extends BaseApi {
         * @return Promise<RuntimeDecisionTableRepresentation>
         */
     getDecisionTable(decisionTableId: number): Promise<RuntimeDecisionTableRepresentation> {
+        throwIfNotDefined(decisionTableId, 'decisionTableId');
 
         let postBody = null;
-
-        if (decisionTableId === undefined || decisionTableId === null) {
-            throw new Error("Required param 'decisionTableId' in getDecisionTable");
-        }
 
         let pathParams = {
             'decisionTableId': decisionTableId

--- a/src/api/activiti-rest-api/api/endpoints.api.ts
+++ b/src/api/activiti-rest-api/api/endpoints.api.ts
@@ -17,6 +17,7 @@
 
 import { EndpointConfigurationRepresentation } from '../model/endpointConfigurationRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Endpoints service.
@@ -32,12 +33,9 @@ export class EndpointsApi extends BaseApi {
     * @return Promise<EndpointConfigurationRepresentation>
     */
     getEndpointConfiguration(endpointConfigurationId: number): Promise<EndpointConfigurationRepresentation> {
+        throwIfNotDefined(endpointConfigurationId, 'endpointConfigurationId');
 
         let postBody = null;
-
-        if (endpointConfigurationId === undefined || endpointConfigurationId === null) {
-            throw new Error("Required param 'endpointConfigurationId' in getEndpointConfiguration");
-        }
 
         let pathParams = {
             'endpointConfigurationId': endpointConfigurationId

--- a/src/api/activiti-rest-api/api/formModels.api.ts
+++ b/src/api/activiti-rest-api/api/formModels.api.ts
@@ -22,6 +22,8 @@ import { ResultListDataRepresentationFormRepresentation } from '../model/resultL
 import { ResultListDataRepresentationRuntimeFormRepresentation } from '../model/resultListDataRepresentationRuntimeFormRepresentation';
 import { ValidationErrorRepresentation } from '../model/validationErrorRepresentation';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
  * Formmodels service.
@@ -37,12 +39,9 @@ export class FormModelsApi extends BaseApi {
      * @return Promise<FormDefinitionRepresentation>
      */
     getFormEditorJson(formId: number): Promise<FormDefinitionRepresentation> {
+        throwIfNotDefined(formId, 'formId');
 
         let postBody = null;
-
-        if (formId === undefined || formId === null) {
-            throw new Error("Required param 'formId' in getFormEditorJson");
-        }
 
         let pathParams = {
             'formId': formId
@@ -72,16 +71,10 @@ export class FormModelsApi extends BaseApi {
      * @return Promise<FormRepresentation>
      */
     getFormHistory(formId: number, formHistoryId: number): Promise<FormRepresentation> {
+        throwIfNotDefined(formId, 'formId');
+        throwIfNotDefined(formHistoryId, 'formHistoryId');
 
         let postBody = null;
-
-        if (formId === undefined || formId === null) {
-            throw new Error("Required param 'formId' in getFormHistory");
-        }
-
-        if (formHistoryId === undefined || formHistoryId === null) {
-            throw new Error("Required param 'formHistoryId' in getFormHistory");
-        }
 
         let pathParams = {
             'formId': formId, 'formHistoryId': formHistoryId
@@ -110,12 +103,9 @@ export class FormModelsApi extends BaseApi {
      * @return Promise<FormRepresentation>
      */
     getForm(formId: number): Promise<FormRepresentation> {
+        throwIfNotDefined(formId, 'formId');
 
         let postBody = null;
-
-        if (formId === undefined || formId === null) {
-            throw new Error("Required param 'formId' in getForm");
-        }
 
         let pathParams = {
             'formId': formId
@@ -153,7 +143,7 @@ export class FormModelsApi extends BaseApi {
 
         if (typeof input === 'string') {
             let queryParams = {
-                'formId': this.apiClient.buildCollectionParam(input, 'multi')
+                'formId': buildCollectionParam(input, 'multi')
             };
 
             return this.apiClient.callApi(
@@ -196,16 +186,10 @@ export class FormModelsApi extends BaseApi {
      * @return Promise<FormRepresentation>
      */
     saveForm(formId: number, saveRepresentation: FormSaveRepresentation): Promise<FormRepresentation> {
+        throwIfNotDefined(formId, 'formId');
+        throwIfNotDefined(saveRepresentation, 'saveRepresentation');
 
         let postBody = saveRepresentation;
-
-        if (formId === undefined || formId === null) {
-            throw new Error("Required param 'formId' in saveForm");
-        }
-
-        if (saveRepresentation === undefined || saveRepresentation === null) {
-            throw new Error("Required param 'saveRepresentation' in saveForm");
-        }
 
         let pathParams = {
             'formId': formId
@@ -235,16 +219,10 @@ export class FormModelsApi extends BaseApi {
      * @return Promise<ValidationErrorRepresentation>
      */
     validateModel(formId: number, saveRepresentation: FormSaveRepresentation): Promise<ValidationErrorRepresentation> {
+        throwIfNotDefined(formId, 'formId');
+        throwIfNotDefined(saveRepresentation, 'saveRepresentation');
 
         let postBody = saveRepresentation;
-
-        if (formId === undefined || formId === null) {
-            throw new Error("Required param 'formId' in validateModel");
-        }
-
-        if (saveRepresentation === undefined || saveRepresentation === null) {
-            throw new Error("Required param 'saveRepresentation' in validateModel");
-        }
 
         let pathParams = {
             'formId': formId

--- a/src/api/activiti-rest-api/api/groups.api.ts
+++ b/src/api/activiti-rest-api/api/groups.api.ts
@@ -18,6 +18,7 @@
 import { ResultListDataRepresentationLightGroupRepresentation } from '../model/resultListDataRepresentationLightGroupRepresentation';
 import { ResultListDataRepresentationLightUserRepresentation } from '../model/resultListDataRepresentationLightUserRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Groups service.
@@ -76,12 +77,9 @@ export class ActivitiGroupsApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationLightUserRepresentation>
         */
     getUsersForGroup(groupId: number): Promise<ResultListDataRepresentationLightUserRepresentation> {
+        throwIfNotDefined(groupId, 'formId');
 
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in getUsersForGroup");
-        }
 
         let pathParams = {
             'groupId': groupId

--- a/src/api/activiti-rest-api/api/iDMSync.api.ts
+++ b/src/api/activiti-rest-api/api/iDMSync.api.ts
@@ -17,6 +17,7 @@
 
 import { SyncLogEntryRepresentation } from '../model/syncLogEntryRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Idmsync service.
@@ -32,12 +33,9 @@ export class IDMSyncApi extends BaseApi {
     * @return Promise<{}>
     */
     getLogFile(syncLogEntryId: number): Promise<any> {
+        throwIfNotDefined(syncLogEntryId, 'syncLogEntryId');
 
         let postBody = null;
-
-        if (syncLogEntryId === undefined || syncLogEntryId === null) {
-            throw new Error("Required param 'syncLogEntryId' in getLogFile");
-        }
 
         let pathParams = {
             'syncLogEntryId': syncLogEntryId

--- a/src/api/activiti-rest-api/api/integrationAlfrescoCloud.api.ts
+++ b/src/api/activiti-rest-api/api/integrationAlfrescoCloud.api.ts
@@ -19,6 +19,7 @@ import { ResultListDataRepresentationAlfrescoContentRepresentation } from '../mo
 import { ResultListDataRepresentationAlfrescoNetworkRepresenation } from '../model/resultListDataRepresentationAlfrescoNetworkRepresenation';
 import { ResultListDataRepresentationAlfrescoSiteRepresenation } from '../model/resultListDataRepresentationAlfrescoSiteRepresenation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Integrationalfrescocloud service.
@@ -34,12 +35,9 @@ export class IntegrationAlfrescoCloudApi extends BaseApi {
     * @return Promise<{}>
     */
     confirmAuthorisation(code: string): Promise<any> {
+        throwIfNotDefined(code, 'code');
 
         let postBody = null;
-
-        if (code === undefined || code === null) {
-            throw new Error("Required param 'code' in confirmAuthorisation");
-        }
 
         let pathParams = {
 
@@ -104,12 +102,9 @@ export class IntegrationAlfrescoCloudApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationAlfrescoSiteRepresenation>
         */
     getAllSites(networkId: string): Promise<ResultListDataRepresentationAlfrescoSiteRepresenation> {
+        throwIfNotDefined(networkId, 'networkId');
 
         let postBody = null;
-
-        if (networkId === undefined || networkId === null) {
-            throw new Error("Required param 'networkId' in getAllSites");
-        }
 
         let pathParams = {
             'networkId': networkId
@@ -144,12 +139,10 @@ export class IntegrationAlfrescoCloudApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationAlfrescoContentRepresentation>
         */
     getContentInFolderPath(networkId: string, opts?: any): Promise<ResultListDataRepresentationAlfrescoContentRepresentation> {
+        throwIfNotDefined(networkId, 'networkId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (networkId === undefined || networkId === null) {
-            throw new Error("Required param 'networkId' in getContentInFolderPath");
-        }
 
         let pathParams = {
             'networkId': networkId
@@ -184,16 +177,10 @@ export class IntegrationAlfrescoCloudApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationAlfrescoContentRepresentation>
         */
     getContentInFolder(networkId: string, folderId: string): Promise<ResultListDataRepresentationAlfrescoContentRepresentation> {
+        throwIfNotDefined(networkId, 'networkId');
+        throwIfNotDefined(folderId, 'folderId');
 
         let postBody = null;
-
-        if (networkId === undefined || networkId === null) {
-            throw new Error("Required param 'networkId' in getContentInFolder");
-        }
-
-        if (folderId === undefined || folderId === null) {
-            throw new Error("Required param 'folderId' in getContentInFolder");
-        }
 
         let pathParams = {
             'networkId': networkId, 'folderId': folderId
@@ -226,16 +213,10 @@ export class IntegrationAlfrescoCloudApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationAlfrescoContentRepresentation>
         */
     getContentInSite(networkId: string, siteId: string): Promise<ResultListDataRepresentationAlfrescoContentRepresentation> {
+        throwIfNotDefined(networkId, 'networkId');
+        throwIfNotDefined(siteId, 'siteId');
 
         let postBody = null;
-
-        if (networkId === undefined || networkId === null) {
-            throw new Error("Required param 'networkId' in getContentInSite");
-        }
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in getContentInSite");
-        }
 
         let pathParams = {
             'networkId': networkId, 'siteId': siteId

--- a/src/api/activiti-rest-api/api/integrationAlfrescoOnPremise.api.ts
+++ b/src/api/activiti-rest-api/api/integrationAlfrescoOnPremise.api.ts
@@ -19,6 +19,7 @@ import { ResultListDataRepresentationAlfrescoContentRepresentation } from '../mo
 import { ResultListDataRepresentationAlfrescoEndpointRepresentation } from '../model/resultListDataRepresentationAlfrescoEndpointRepresentation';
 import { ResultListDataRepresentationAlfrescoSiteRepresenation } from '../model/resultListDataRepresentationAlfrescoSiteRepresenation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Integrationalfrescoonpremise service.
@@ -34,12 +35,9 @@ export class IntegrationAlfrescoOnPremiseApi extends BaseApi {
     * @return Promise<ResultListDataRepresentationAlfrescoSiteRepresenation>
     */
     getAllSites(repositoryId: string): Promise<ResultListDataRepresentationAlfrescoSiteRepresenation> {
+        throwIfNotDefined(repositoryId, 'networkId');
 
         let postBody = null;
-
-        if (repositoryId === undefined || repositoryId === null) {
-            throw new Error("Required param 'repositoryId' in getAllSites");
-        }
 
         let pathParams = {
             'repositoryId': repositoryId
@@ -73,20 +71,11 @@ export class IntegrationAlfrescoOnPremiseApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationAlfrescoContentRepresentation>
         */
     getContentInFolderPath(repositoryId: string, siteId: string, folderPath: string): Promise<ResultListDataRepresentationAlfrescoContentRepresentation> {
+        throwIfNotDefined(repositoryId, 'networkId');
+        throwIfNotDefined(siteId, 'siteId');
+        throwIfNotDefined(folderPath, 'folderPath');
 
         let postBody = null;
-
-        if (repositoryId === undefined || repositoryId === null) {
-            throw new Error("Required param 'repositoryId' in getContentInFolderPath");
-        }
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in getContentInFolderPath");
-        }
-
-        if (folderPath === undefined || folderPath === null) {
-            throw new Error("Required param 'folderPath' in getContentInFolderPath");
-        }
 
         let pathParams = {
             'repositoryId': repositoryId, 'siteId': siteId, 'folderPath': folderPath
@@ -119,16 +108,10 @@ export class IntegrationAlfrescoOnPremiseApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationAlfrescoContentRepresentation>
         */
     getContentInFolder(repositoryId: string, folderId: string): Promise<ResultListDataRepresentationAlfrescoContentRepresentation> {
+        throwIfNotDefined(repositoryId, 'networkId');
+        throwIfNotDefined(folderId, 'folderId');
 
         let postBody = null;
-
-        if (repositoryId === undefined || repositoryId === null) {
-            throw new Error("Required param 'repositoryId' in getContentInFolder");
-        }
-
-        if (folderId === undefined || folderId === null) {
-            throw new Error("Required param 'folderId' in getContentInFolder");
-        }
 
         let pathParams = {
             'repositoryId': repositoryId, 'folderId': folderId
@@ -161,16 +144,10 @@ export class IntegrationAlfrescoOnPremiseApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationAlfrescoContentRepresentation>
         */
     getContentInSite(repositoryId: string, siteId: string): Promise<ResultListDataRepresentationAlfrescoContentRepresentation> {
+        throwIfNotDefined(repositoryId, 'networkId');
+        throwIfNotDefined(siteId, 'siteId');
 
         let postBody = null;
-
-        if (repositoryId === undefined || repositoryId === null) {
-            throw new Error("Required param 'repositoryId' in getContentInSite");
-        }
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in getContentInSite");
-        }
 
         let pathParams = {
             'repositoryId': repositoryId, 'siteId': siteId

--- a/src/api/activiti-rest-api/api/integrationBox.api.ts
+++ b/src/api/activiti-rest-api/api/integrationBox.api.ts
@@ -18,6 +18,7 @@
 import { ResultListDataRepresentationBoxContent } from '../model/resultListDataRepresentationBoxContent';
 import { UserAccountCredentialsRepresentation } from '../model/userAccountCredentialsRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Integrationbox service.
@@ -66,16 +67,10 @@ export class IntegrationBoxApi extends BaseApi {
         * @return Promise<{}>
         */
     createRepositoryAccount(userId: number, credentials: UserAccountCredentialsRepresentation): Promise<any> {
+        throwIfNotDefined(userId, 'userId');
+        throwIfNotDefined(credentials, 'credentials');
 
         let postBody = credentials;
-
-        if (userId === undefined || userId === null) {
-            throw new Error("Required param 'userId' in createRepositoryAccount");
-        }
-
-        if (credentials === undefined || credentials === null) {
-            throw new Error("Required param 'credentials' in createRepositoryAccount");
-        }
 
         let pathParams = {
             'userId': userId
@@ -107,12 +102,9 @@ export class IntegrationBoxApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteRepositoryAccount(userId: number): Promise<any> {
+        throwIfNotDefined(userId, 'userId');
 
         let postBody = null;
-
-        if (userId === undefined || userId === null) {
-            throw new Error("Required param 'userId' in deleteRepositoryAccount");
-        }
 
         let pathParams = {
             'userId': userId
@@ -213,12 +205,9 @@ export class IntegrationBoxApi extends BaseApi {
         * @return Promise<{}>
         */
     getRepositoryAccount(userId: number): Promise<any> {
+        throwIfNotDefined(userId, 'userId');
 
         let postBody = null;
-
-        if (userId === undefined || userId === null) {
-            throw new Error("Required param 'userId' in getRepositoryAccount");
-        }
 
         let pathParams = {
             'userId': userId
@@ -251,16 +240,10 @@ export class IntegrationBoxApi extends BaseApi {
         * @return Promise<{}>
         */
     updateRepositoryAccount(userId: number, credentials: UserAccountCredentialsRepresentation): Promise<any> {
+        throwIfNotDefined(userId, 'userId');
+        throwIfNotDefined(credentials, 'credentials');
 
         let postBody = credentials;
-
-        if (userId === undefined || userId === null) {
-            throw new Error("Required param 'userId' in updateRepositoryAccount");
-        }
-
-        if (credentials === undefined || credentials === null) {
-            throw new Error("Required param 'credentials' in updateRepositoryAccount");
-        }
 
         let pathParams = {
             'userId': userId

--- a/src/api/activiti-rest-api/api/models.api.ts
+++ b/src/api/activiti-rest-api/api/models.api.ts
@@ -20,6 +20,7 @@ import { ObjectNode } from '../model/objectNode';
 import { ResultListDataRepresentationModelRepresentation } from '../model/resultListDataRepresentationModelRepresentation';
 import { ValidationErrorRepresentation } from '../model/validationErrorRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Models service.
@@ -35,12 +36,9 @@ export class ModelsApi extends BaseApi {
     * @return Promise<ModelRepresentation>
     */
     createModel(modelRepresentation: ModelRepresentation): Promise<ModelRepresentation> {
+        throwIfNotDefined(modelRepresentation, 'modelRepresentation');
 
         let postBody = modelRepresentation;
-
-        if (modelRepresentation === undefined || modelRepresentation === null) {
-            throw new Error("Required param 'modelRepresentation' in createModel");
-        }
 
         let pathParams = {
 
@@ -75,12 +73,10 @@ export class ModelsApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteModel(modelId: number, opts?: any): Promise<any> {
+        throwIfNotDefined(modelId, 'modelId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in deleteModel");
-        }
 
         let pathParams = {
             'modelId': modelId
@@ -115,16 +111,10 @@ export class ModelsApi extends BaseApi {
         * @return Promise<ModelRepresentation>
         */
     duplicateModel(modelId: number, modelRepresentation: ModelRepresentation): Promise<ModelRepresentation> {
+        throwIfNotDefined(modelId, 'modelId');
+        throwIfNotDefined(modelRepresentation, 'modelRepresentation');
 
         let postBody = modelRepresentation;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in duplicateModel");
-        }
-
-        if (modelRepresentation === undefined || modelRepresentation === null) {
-            throw new Error("Required param 'modelRepresentation' in duplicateModel");
-        }
 
         let pathParams = {
             'modelId': modelId
@@ -156,12 +146,8 @@ export class ModelsApi extends BaseApi {
         * @return Promise<ObjectNode>
         */
     getModelJSON(modelId: number): Promise<ObjectNode> {
-
+        throwIfNotDefined(modelId, 'modelId');
         let postBody = null;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in getModelJSON");
-        }
 
         let pathParams = {
             'modelId': modelId
@@ -193,12 +179,8 @@ export class ModelsApi extends BaseApi {
         * @return Promise<string>
         */
     getModelThumbnail(modelId: number): Promise<string> {
-
+        throwIfNotDefined(modelId, 'modelId');
         let postBody = null;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in getModelThumbnail");
-        }
 
         let pathParams = {
             'modelId': modelId
@@ -232,12 +214,9 @@ export class ModelsApi extends BaseApi {
         * @return Promise<ModelRepresentation>
         */
     getModel(modelId: number, opts?: any): Promise<ModelRepresentation> {
+        throwIfNotDefined(modelId, 'modelId');
         opts = opts || {};
         let postBody = null;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in getModel");
-        }
 
         let pathParams = {
             'modelId': modelId
@@ -347,16 +326,10 @@ export class ModelsApi extends BaseApi {
         * @return Promise<ModelRepresentation>
         */
     importNewVersion(modelId: number, file: any): Promise<ModelRepresentation> {
+        throwIfNotDefined(modelId, 'modelId');
+        throwIfNotDefined(file, 'file');
 
         let postBody = null;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in importNewVersion");
-        }
-
-        if (file === undefined || file === null) {
-            throw new Error("Required param 'file' in importNewVersion");
-        }
 
         let pathParams = {
             'modelId': modelId
@@ -389,12 +362,9 @@ export class ModelsApi extends BaseApi {
         * @return Promise<ModelRepresentation>
         */
     importProcessModel(file: any): Promise<ModelRepresentation> {
+        throwIfNotDefined(file, 'file');
 
         let postBody = null;
-
-        if (file === undefined || file === null) {
-            throw new Error("Required param 'file' in importProcessModel");
-        }
 
         let pathParams = {
 
@@ -428,16 +398,10 @@ export class ModelsApi extends BaseApi {
         * @return Promise<ModelRepresentation>
         */
     saveModel(modelId: number, values: any): Promise<ModelRepresentation> {
+        throwIfNotDefined(modelId, 'modelId');
+        throwIfNotDefined(values, 'values');
 
         let postBody = values;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in saveModel");
-        }
-
-        if (values === undefined || values === null) {
-            throw new Error("Required param 'values' in saveModel");
-        }
 
         let pathParams = {
             'modelId': modelId
@@ -470,16 +434,10 @@ export class ModelsApi extends BaseApi {
         * @return Promise<ModelRepresentation>
         */
     updateModel(modelId: number, updatedModel: ModelRepresentation): Promise<ModelRepresentation> {
+        throwIfNotDefined(modelId, 'modelId');
+        throwIfNotDefined(updatedModel, 'updatedModel');
 
         let postBody = updatedModel;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in updateModel");
-        }
-
-        if (updatedModel === undefined || updatedModel === null) {
-            throw new Error("Required param 'updatedModel' in updateModel");
-        }
 
         let pathParams = {
             'modelId': modelId
@@ -513,12 +471,10 @@ export class ModelsApi extends BaseApi {
         * @return Promise<ValidationErrorRepresentation>
         */
     validateModel(modelId: number, opts?: any): Promise<ValidationErrorRepresentation> {
+        throwIfNotDefined(modelId, 'modelId');
+
         opts = opts || {};
         let postBody = opts['values'];
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in validateModel");
-        }
 
         let pathParams = {
             'modelId': modelId

--- a/src/api/activiti-rest-api/api/modelsBpmn.api.ts
+++ b/src/api/activiti-rest-api/api/modelsBpmn.api.ts
@@ -16,6 +16,7 @@
 */
 
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Modelsbpmn service.
@@ -32,16 +33,10 @@ export class ModelsBpmnApi extends BaseApi {
     * @return Promise<{}>
     */
     getHistoricProcessModelBpmn20Xml(processModelId: number, processModelHistoryId: number): Promise<any> {
+        throwIfNotDefined(processModelId, 'processModelId');
+        throwIfNotDefined(processModelHistoryId, 'processModelHistoryId');
 
         let postBody = null;
-
-        if (processModelId === undefined || processModelId === null) {
-            throw new Error("Required param 'processModelId' in getHistoricProcessModelBpmn20Xml");
-        }
-
-        if (processModelHistoryId === undefined || processModelHistoryId === null) {
-            throw new Error("Required param 'processModelHistoryId' in getHistoricProcessModelBpmn20Xml");
-        }
 
         let pathParams = {
             'processModelId': processModelId, 'processModelHistoryId': processModelHistoryId
@@ -73,12 +68,8 @@ export class ModelsBpmnApi extends BaseApi {
         * @return Promise<{}>
         */
     getProcessModelBpmn20Xml(processModelId: number): Promise<any> {
-
+        throwIfNotDefined(processModelId, 'processModelId');
         let postBody = null;
-
-        if (processModelId === undefined || processModelId === null) {
-            throw new Error("Required param 'processModelId' in getProcessModelBpmn20Xml");
-        }
 
         let pathParams = {
             'processModelId': processModelId

--- a/src/api/activiti-rest-api/api/modelsHistory.api.ts
+++ b/src/api/activiti-rest-api/api/modelsHistory.api.ts
@@ -18,6 +18,7 @@
 import { ModelRepresentation } from '../model/modelRepresentation';
 import { ResultListDataRepresentationModelRepresentation } from '../model/resultListDataRepresentationModelRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Modelshistory service.
@@ -35,12 +36,10 @@ export class ModelsHistoryApi extends BaseApi {
     * @return Promise<ResultListDataRepresentationModelRepresentation>
     */
     getModelHistoryCollection(modelId: number, opts?: any): Promise<ResultListDataRepresentationModelRepresentation> {
+        throwIfNotDefined(modelId, 'modelId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in getModelHistoryCollection");
-        }
 
         let pathParams = {
             'modelId': modelId
@@ -74,16 +73,10 @@ export class ModelsHistoryApi extends BaseApi {
         * @return Promise<ModelRepresentation>
         */
     getProcessModelHistory(modelId: number, modelHistoryId: number): Promise<ModelRepresentation> {
+        throwIfNotDefined(modelId, 'modelId');
+        throwIfNotDefined(modelHistoryId, 'modelHistoryId');
 
         let postBody = null;
-
-        if (modelId === undefined || modelId === null) {
-            throw new Error("Required param 'modelId' in getProcessModelHistory");
-        }
-
-        if (modelHistoryId === undefined || modelHistoryId === null) {
-            throw new Error("Required param 'modelHistoryId' in getProcessModelHistory");
-        }
 
         let pathParams = {
             'modelId': modelId, 'modelHistoryId': modelHistoryId

--- a/src/api/activiti-rest-api/api/processDefinitions.api.ts
+++ b/src/api/activiti-rest-api/api/processDefinitions.api.ts
@@ -22,6 +22,7 @@ import { ResultListDataRepresentationProcessDefinitionRepresentation } from '../
 import { ResultListDataRepresentationRuntimeDecisionTableRepresentation } from '../model/resultListDataRepresentationRuntimeDecisionTableRepresentation';
 import { ResultListDataRepresentationRuntimeFormRepresentation } from '../model/resultListDataRepresentationRuntimeFormRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
  * Processdefinitions service.
@@ -38,16 +39,10 @@ export class ProcessDefinitionsApi extends BaseApi {
      * @return Promise<IdentityLinkRepresentation>
      */
     createIdentityLink(processDefinitionId: string, identityLinkRepresentation: IdentityLinkRepresentation): Promise<IdentityLinkRepresentation> {
+        throwIfNotDefined(processDefinitionId, 'processDefinitionId');
+        throwIfNotDefined(identityLinkRepresentation, 'identityLinkRepresentation');
 
         let postBody = identityLinkRepresentation;
-
-        if (processDefinitionId === undefined || processDefinitionId === null) {
-            throw new Error("Required param 'processDefinitionId' in createIdentityLink");
-        }
-
-        if (identityLinkRepresentation === undefined || identityLinkRepresentation === null) {
-            throw new Error("Required param 'identityLinkRepresentation' in createIdentityLink");
-        }
 
         let pathParams = {
             'processDefinitionId': processDefinitionId
@@ -78,20 +73,11 @@ export class ProcessDefinitionsApi extends BaseApi {
      * @return Promise<{}>
      */
     deleteIdentityLink(processDefinitionId: string, family: string, identityId: string): Promise<any> {
+        throwIfNotDefined(processDefinitionId, 'processDefinitionId');
+        throwIfNotDefined(family, 'family');
+        throwIfNotDefined(identityId, 'identityId');
 
         let postBody = null;
-
-        if (processDefinitionId === undefined || processDefinitionId === null) {
-            throw new Error("Required param 'processDefinitionId' in deleteIdentityLink");
-        }
-
-        if (family === undefined || family === null) {
-            throw new Error("Required param 'family' in deleteIdentityLink");
-        }
-
-        if (identityId === undefined || identityId === null) {
-            throw new Error("Required param 'identityId' in deleteIdentityLink");
-        }
 
         let pathParams = {
             'processDefinitionId': processDefinitionId, 'family': family, 'identityId': identityId
@@ -122,20 +108,11 @@ export class ProcessDefinitionsApi extends BaseApi {
      * @return Promise<IdentityLinkRepresentation>
      */
     getIdentityLinkType(processDefinitionId: string, family: string, identityId: string): Promise<IdentityLinkRepresentation> {
+        throwIfNotDefined(processDefinitionId, 'processDefinitionId');
+        throwIfNotDefined(family, 'family');
+        throwIfNotDefined(identityId, 'identityId');
 
         let postBody = null;
-
-        if (processDefinitionId === undefined || processDefinitionId === null) {
-            throw new Error("Required param 'processDefinitionId' in getIdentityLinkType");
-        }
-
-        if (family === undefined || family === null) {
-            throw new Error("Required param 'family' in getIdentityLinkType");
-        }
-
-        if (identityId === undefined || identityId === null) {
-            throw new Error("Required param 'identityId' in getIdentityLinkType");
-        }
 
         let pathParams = {
             'processDefinitionId': processDefinitionId, 'family': family, 'identityId': identityId
@@ -165,16 +142,10 @@ export class ProcessDefinitionsApi extends BaseApi {
      * @return Promise<IdentityLinkRepresentation>
      */
     getIdentityLinksForFamily(processDefinitionId: string, family: string): Promise<IdentityLinkRepresentation> {
+        throwIfNotDefined(processDefinitionId, 'processDefinitionId');
+        throwIfNotDefined(family, 'family');
 
         let postBody = null;
-
-        if (processDefinitionId === undefined || processDefinitionId === null) {
-            throw new Error("Required param 'processDefinitionId' in getIdentityLinksForFamily");
-        }
-
-        if (family === undefined || family === null) {
-            throw new Error("Required param 'family' in getIdentityLinksForFamily");
-        }
 
         let pathParams = {
             'processDefinitionId': processDefinitionId, 'family': family
@@ -203,12 +174,8 @@ export class ProcessDefinitionsApi extends BaseApi {
      * @return Promise<IdentityLinkRepresentation>
      */
     getIdentityLinks(processDefinitionId: string): Promise<IdentityLinkRepresentation> {
-
+        throwIfNotDefined(processDefinitionId, 'processDefinitionId');
         let postBody = null;
-
-        if (processDefinitionId === undefined || processDefinitionId === null) {
-            throw new Error("Required param 'processDefinitionId' in getIdentityLinks");
-        }
 
         let pathParams = {
             'processDefinitionId': processDefinitionId
@@ -237,12 +204,8 @@ export class ProcessDefinitionsApi extends BaseApi {
      * @return Promise<ResultListDataRepresentationRuntimeDecisionTableRepresentation>
      */
     getProcessDefinitionDecisionTables(processDefinitionId: string): Promise<ResultListDataRepresentationRuntimeDecisionTableRepresentation> {
-
+        throwIfNotDefined(processDefinitionId, 'processDefinitionId');
         let postBody = null;
-
-        if (processDefinitionId === undefined || processDefinitionId === null) {
-            throw new Error("Required param 'processDefinitionId' in getProcessDefinitionDecisionTables");
-        }
 
         let pathParams = {
             'processDefinitionId': processDefinitionId
@@ -271,12 +234,8 @@ export class ProcessDefinitionsApi extends BaseApi {
      * @return Promise<ResultListDataRepresentationRuntimeFormRepresentation>
      */
     getProcessDefinitionForms(processDefinitionId: string): Promise<ResultListDataRepresentationRuntimeFormRepresentation> {
-
+        throwIfNotDefined(processDefinitionId, 'processDefinitionId');
         let postBody = null;
-
-        if (processDefinitionId === undefined || processDefinitionId === null) {
-            throw new Error("Required param 'processDefinitionId' in getProcessDefinitionForms");
-        }
 
         let pathParams = {
             'processDefinitionId': processDefinitionId

--- a/src/api/activiti-rest-api/api/processInstanceVariables.api.ts
+++ b/src/api/activiti-rest-api/api/processInstanceVariables.api.ts
@@ -18,6 +18,7 @@
 import { } from '../model/';
 import { RestVariable } from '../model/restVariable';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Processinstancevariables service.
@@ -34,16 +35,10 @@ export class ProcessInstanceVariablesApi extends BaseApi {
     * @return Promise<RestVariable>
     */
     createOrUpdateProcessInstanceVariables(processInstanceId: string, restVariables: RestVariable[]): Promise<RestVariable[]> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
+        throwIfNotDefined(restVariables, 'restVariables');
 
         let postBody = restVariables;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in createOrUpdateProcessInstanceVariables");
-        }
-
-        if (restVariables === undefined || restVariables === null) {
-            throw new Error("Required param 'restVariables' in createOrUpdateProcessInstanceVariables");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -76,16 +71,10 @@ export class ProcessInstanceVariablesApi extends BaseApi {
         * @return Promise<RestVariable>
         */
     createProcessInstanceVariables(processInstanceId: string, restVariables: RestVariable[]): Promise<RestVariable[]> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
+        throwIfNotDefined(restVariables, 'restVariables');
 
         let postBody = restVariables;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in createProcessInstanceVariables");
-        }
-
-        if (restVariables === undefined || restVariables === null) {
-            throw new Error("Required param 'restVariables' in createProcessInstanceVariables");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -118,16 +107,10 @@ export class ProcessInstanceVariablesApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteProcessInstanceVariable(processInstanceId: string, variableName: string): Promise<any> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
+        throwIfNotDefined(variableName, 'variableName');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in deleteProcessInstanceVariable");
-        }
-
-        if (variableName === undefined || variableName === null) {
-            throw new Error("Required param 'variableName' in deleteProcessInstanceVariable");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId, 'variableName': variableName
@@ -160,16 +143,10 @@ export class ProcessInstanceVariablesApi extends BaseApi {
         * @return Promise<RestVariable>
         */
     getProcessInstanceVariable(processInstanceId: string, variableName: string): Promise<RestVariable> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
+        throwIfNotDefined(variableName, 'variableName');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getProcessInstanceVariable");
-        }
-
-        if (variableName === undefined || variableName === null) {
-            throw new Error("Required param 'variableName' in getProcessInstanceVariable");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId, 'variableName': variableName
@@ -201,13 +178,9 @@ export class ProcessInstanceVariablesApi extends BaseApi {
         * @return Promise<RestVariable>
         */
     getProcessInstanceVariables(processInstanceId: string): Promise<RestVariable[]> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getProcessInstanceVariables");
-        }
-
         let pathParams = {
             'processInstanceId': processInstanceId
         };
@@ -240,20 +213,11 @@ export class ProcessInstanceVariablesApi extends BaseApi {
         * @return Promise<RestVariable>
         */
     updateProcessInstanceVariable(processInstanceId: string, variableName: string, restVariable: RestVariable): Promise<RestVariable> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
+        throwIfNotDefined(variableName, 'variableName');
+        throwIfNotDefined(restVariable, 'restVariable');
 
         let postBody = restVariable;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in updateProcessInstanceVariable");
-        }
-
-        if (variableName === undefined || variableName === null) {
-            throw new Error("Required param 'variableName' in updateProcessInstanceVariable");
-        }
-
-        if (restVariable === undefined || restVariable === null) {
-            throw new Error("Required param 'restVariable' in updateProcessInstanceVariable");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId, 'variableName': variableName

--- a/src/api/activiti-rest-api/api/processInstances.api.ts
+++ b/src/api/activiti-rest-api/api/processInstances.api.ts
@@ -27,6 +27,8 @@ import { ProcessInstanceVariableRepresentation } from '../model/processInstanceV
 import { ResultListDataRepresentationProcessContentRepresentation } from '../model/resultListDataRepresentationProcessContentRepresentation';
 import { ResultListDataRepresentationProcessInstanceRepresentation } from '../model/resultListDataRepresentationProcessInstanceRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
+import { ResultListDataRepresentationDecisionTaskRepresentation } from '../model/resultListDataRepresentationDecisionTaskRepresentation';
 
 /**
  * Processinstances service.
@@ -42,12 +44,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<ProcessInstanceRepresentation>
      */
     activateProcessInstance(processInstanceId: string): Promise<ProcessInstanceRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in activateProcessInstance");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -77,16 +76,10 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<IdentityLinkRepresentation>
      */
     createIdentityLink(processInstanceId: string, identityLinkRepresentation: IdentityLinkRepresentation): Promise<IdentityLinkRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
+        throwIfNotDefined(identityLinkRepresentation, 'identityLinkRepresentation');
 
         let postBody = identityLinkRepresentation;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in createIdentityLink");
-        }
-
-        if (identityLinkRepresentation === undefined || identityLinkRepresentation === null) {
-            throw new Error("Required param 'identityLinkRepresentation' in createIdentityLink");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -118,24 +111,12 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<{}>
      */
     deleteIdentityLink(processInstanceId: string, family: string, identityId: string, type: string): Promise<any> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
+        throwIfNotDefined(family, 'family');
+        throwIfNotDefined(identityId, 'identityId');
+        throwIfNotDefined(type, 'type');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in deleteIdentityLink");
-        }
-
-        if (family === undefined || family === null) {
-            throw new Error("Required param 'family' in deleteIdentityLink");
-        }
-
-        if (identityId === undefined || identityId === null) {
-            throw new Error("Required param 'identityId' in deleteIdentityLink");
-        }
-
-        if (type === undefined || type === null) {
-            throw new Error("Required param 'type' in deleteIdentityLink");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId, 'family': family, 'identityId': identityId, 'type': type
@@ -164,12 +145,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<{}>
      */
     deleteProcessInstance(processInstanceId: string): Promise<any> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in deleteProcessInstance");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -198,12 +176,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<ResultListDataRepresentationProcessInstanceRepresentation>
      */
     filterProcessInstances(filterRequest: ProcessInstanceFilterRequestRepresentation): Promise<ResultListDataRepresentationProcessInstanceRepresentation> {
+        throwIfNotDefined(filterRequest, 'filterRequest');
 
         let postBody = filterRequest;
-
-        if (filterRequest === undefined || filterRequest === null) {
-            throw new Error("Required param 'filterRequest' in filterProcessInstances");
-        }
 
         let pathParams = {};
 
@@ -228,13 +203,11 @@ export class ProcessInstancesApi extends BaseApi {
      *
      * @param processInstanceId processInstanceId
      * @return Promise<ResultListDataRepresentationDecisionTaskRepresentation>
-     getHistoricProcessInstanceDecisionTasks(processInstanceId: string): Promise<ResultListDataRepresentationDecisionTaskRepresentation> {
+     */
+    getHistoricProcessInstanceDecisionTasks(processInstanceId: string): Promise<ResultListDataRepresentationDecisionTaskRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getHistoricProcessInstanceDecisionTasks");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -266,12 +239,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<ProcessInstanceVariableRepresentation>
      */
     getHistoricProcessInstanceVariables(processInstanceId: string): Promise<ProcessInstanceVariableRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getHistoricProcessInstanceVariables");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -300,12 +270,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<ResultListDataRepresentationProcessInstanceRepresentation>
      */
     getHistoricProcessInstances(queryRequest: HistoricProcessInstanceQueryRepresentation): Promise<ResultListDataRepresentationProcessInstanceRepresentation> {
+        throwIfNotDefined(queryRequest, 'queryRequest');
 
         let postBody = queryRequest;
-
-        if (queryRequest === undefined || queryRequest === null) {
-            throw new Error("Required param 'queryRequest' in getHistoricProcessInstances");
-        }
 
         let pathParams = {};
 
@@ -335,24 +302,12 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<IdentityLinkRepresentation>
      */
     getIdentityLinkType(processInstanceId: string, family: string, identityId: string, type: string): Promise<IdentityLinkRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
+        throwIfNotDefined(family, 'family');
+        throwIfNotDefined(identityId, 'identityId');
+        throwIfNotDefined(type, 'type');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getIdentityLinkType");
-        }
-
-        if (family === undefined || family === null) {
-            throw new Error("Required param 'family' in getIdentityLinkType");
-        }
-
-        if (identityId === undefined || identityId === null) {
-            throw new Error("Required param 'identityId' in getIdentityLinkType");
-        }
-
-        if (type === undefined || type === null) {
-            throw new Error("Required param 'type' in getIdentityLinkType");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId, 'family': family, 'identityId': identityId, 'type': type
@@ -382,16 +337,10 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<IdentityLinkRepresentation>
      */
     getIdentityLinksForFamily(processInstanceId: string, family: string): Promise<IdentityLinkRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
+        throwIfNotDefined(family, 'family');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getIdentityLinksForFamily");
-        }
-
-        if (family === undefined || family === null) {
-            throw new Error("Required param 'family' in getIdentityLinksForFamily");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId, 'family': family
@@ -420,12 +369,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<IdentityLinkRepresentation>
      */
     getIdentityLinks(processInstanceId: string): Promise<IdentityLinkRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getIdentityLinks");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -454,12 +400,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<ResultListDataRepresentationProcessContentRepresentation>
      */
     getProcessInstanceContent(processInstanceId: string): Promise<ResultListDataRepresentationProcessContentRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getProcessInstanceContent");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -488,12 +431,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<string>
      */
     getProcessInstanceDiagram(processInstanceId: string): Promise<string> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getProcessInstanceDiagram");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -522,12 +462,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<FormDefinitionRepresentation>
      */
     getProcessInstanceStartForm(processInstanceId: string): Promise<FormDefinitionRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getProcessInstanceStartForm");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -556,12 +493,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<ProcessInstanceRepresentation>
      */
     getProcessInstance(processInstanceId: string): Promise<ProcessInstanceRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getProcessInstance");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -590,12 +524,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<ResultListDataRepresentationProcessInstanceRepresentation>
      */
     getProcessInstances(processInstancesQuery: ProcessInstanceQueryRepresentation): Promise<ResultListDataRepresentationProcessInstanceRepresentation> {
+        throwIfNotDefined(processInstancesQuery, 'processInstancesQuery');
 
         let postBody = processInstancesQuery;
-
-        if (processInstancesQuery === undefined || processInstancesQuery === null) {
-            throw new Error("Required param 'processInstancesQuery' in getProcessInstances");
-        }
 
         let pathParams = {};
 
@@ -622,12 +553,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<ProcessInstanceAuditInfoRepresentation>
      */
     getTaskAuditLog(processInstanceId: string): Promise<ProcessInstanceAuditInfoRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in getTaskAuditLog");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId
@@ -689,12 +617,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<ProcessInstanceRepresentation>
      */
     startNewProcessInstance(startRequest: CreateProcessInstanceRepresentation): Promise<ProcessInstanceRepresentation> {
+        throwIfNotDefined(startRequest, 'startRequest');
 
         let postBody = startRequest;
-
-        if (startRequest === undefined || startRequest === null) {
-            throw new Error("Required param 'startRequest' in startNewProcessInstance");
-        }
 
         let pathParams = {};
 
@@ -721,12 +646,9 @@ export class ProcessInstancesApi extends BaseApi {
      * @return Promise<ProcessInstanceRepresentation>
      */
     suspendProcessInstance(processInstanceId: string): Promise<ProcessInstanceRepresentation> {
+        throwIfNotDefined(processInstanceId, 'processInstanceId');
 
         let postBody = null;
-
-        if (processInstanceId === undefined || processInstanceId === null) {
-            throw new Error("Required param 'processInstanceId' in suspendProcessInstance");
-        }
 
         let pathParams = {
             'processInstanceId': processInstanceId

--- a/src/api/activiti-rest-api/api/processScopes.api.ts
+++ b/src/api/activiti-rest-api/api/processScopes.api.ts
@@ -18,6 +18,7 @@
 import { ProcessScopeRepresentation } from '../model/processScopeRepresentation';
 import { ProcessScopesRequestRepresentation } from '../model/processScopesRequestRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Processscopes service.
@@ -33,12 +34,9 @@ export class ProcessScopesApi extends BaseApi {
     * @return Promise<ProcessScopeRepresentation>
     */
     getRuntimeProcessScopes(processScopesRequest: ProcessScopesRequestRepresentation): Promise<ProcessScopeRepresentation> {
+        throwIfNotDefined(processScopesRequest, 'processScopesRequest');
 
         let postBody = processScopesRequest;
-
-        if (processScopesRequest === undefined || processScopesRequest === null) {
-            throw new Error("Required param 'processScopesRequest' in getRuntimeProcessScopes");
-        }
 
         let pathParams = {
 

--- a/src/api/activiti-rest-api/api/runtimeAppDefinitions.api.ts
+++ b/src/api/activiti-rest-api/api/runtimeAppDefinitions.api.ts
@@ -19,6 +19,7 @@ import { AppDefinitionRepresentation } from '../model/appDefinitionRepresentatio
 import { ResultListDataRepresentationAppDefinitionRepresentation } from '../model/resultListDataRepresentationAppDefinitionRepresentation';
 import { RuntimeAppDefinitionSaveRepresentation } from '../model/runtimeAppDefinitionSaveRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Runtimeappdefinitions service.
@@ -34,12 +35,9 @@ export class RuntimeAppDefinitionsApi extends BaseApi {
     * @return Promise<{}>
     */
     deployAppDefinitions(saveObject: RuntimeAppDefinitionSaveRepresentation): Promise<any> {
+        throwIfNotDefined(saveObject, 'saveObject');
 
         let postBody = saveObject;
-
-        if (saveObject === undefined || saveObject === null) {
-            throw new Error("Required param 'saveObject' in deployAppDefinitions");
-        }
 
         let pathParams = {
 
@@ -71,12 +69,9 @@ export class RuntimeAppDefinitionsApi extends BaseApi {
         * @return Promise<AppDefinitionRepresentation>
         */
     getAppDefinition(appDefinitionId: number): Promise<AppDefinitionRepresentation> {
+        throwIfNotDefined(appDefinitionId, 'appDefinitionId');
 
         let postBody = null;
-
-        if (appDefinitionId === undefined || appDefinitionId === null) {
-            throw new Error("Required param 'appDefinitionId' in getAppDefinition");
-        }
 
         let pathParams = {
             'appDefinitionId': appDefinitionId

--- a/src/api/activiti-rest-api/api/runtimeAppDeployments.api.ts
+++ b/src/api/activiti-rest-api/api/runtimeAppDeployments.api.ts
@@ -18,6 +18,7 @@
 import { AppDeploymentRepresentation } from '../model/appDeploymentRepresentation';
 import { ResultListDataRepresentationAppDeploymentRepresentation } from '../model/resultListDataRepresentationAppDeploymentRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Runtimeappdeployments service.
@@ -33,12 +34,9 @@ export class RuntimeAppDeploymentsApi extends BaseApi {
     * @return Promise<{}>
     */
     deleteAppDeployment(appDeploymentId: number): Promise<any> {
+        throwIfNotDefined(appDeploymentId, 'appDeploymentId');
 
         let postBody = null;
-
-        if (appDeploymentId === undefined || appDeploymentId === null) {
-            throw new Error("Required param 'appDeploymentId' in deleteAppDeployment");
-        }
 
         let pathParams = {
             'appDeploymentId': appDeploymentId
@@ -70,12 +68,9 @@ export class RuntimeAppDeploymentsApi extends BaseApi {
         * @return Promise<{}>
         */
     exportAppDefinition(deploymentId: string): Promise<any> {
+        throwIfNotDefined(deploymentId, 'deploymentId');
 
         let postBody = null;
-
-        if (deploymentId === undefined || deploymentId === null) {
-            throw new Error("Required param 'deploymentId' in exportAppDefinition");
-        }
 
         let pathParams = {
             'deploymentId': deploymentId
@@ -154,12 +149,9 @@ export class RuntimeAppDeploymentsApi extends BaseApi {
         * @return Promise<AppDeploymentRepresentation>
         */
     getAppDeployment(appDeploymentId: number): Promise<AppDeploymentRepresentation> {
+        throwIfNotDefined(appDeploymentId, 'appDeploymentId');
 
         let postBody = null;
-
-        if (appDeploymentId === undefined || appDeploymentId === null) {
-            throw new Error("Required param 'appDeploymentId' in getAppDeployment");
-        }
 
         let pathParams = {
             'appDeploymentId': appDeploymentId

--- a/src/api/activiti-rest-api/api/submittedForms.api.ts
+++ b/src/api/activiti-rest-api/api/submittedForms.api.ts
@@ -18,6 +18,7 @@
 import { ResultListDataRepresentationSubmittedFormRepresentation } from '../model/resultListDataRepresentationSubmittedFormRepresentation';
 import { SubmittedFormRepresentation } from '../model/submittedFormRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Submittedforms service.
@@ -37,12 +38,10 @@ export class SubmittedFormsApi extends BaseApi {
     * @return Promise<ResultListDataRepresentationSubmittedFormRepresentation>
     */
     getFormSubmittedForms(formId: number, opts?: any): Promise<ResultListDataRepresentationSubmittedFormRepresentation> {
+        throwIfNotDefined(formId, 'formId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (formId === undefined || formId === null) {
-            throw new Error("Required param 'formId' in getFormSubmittedForms");
-        }
 
         let pathParams = {
             'formId': formId
@@ -77,12 +76,9 @@ export class SubmittedFormsApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationSubmittedFormRepresentation>
         */
     getProcessSubmittedForms(processId: string): Promise<ResultListDataRepresentationSubmittedFormRepresentation> {
+        throwIfNotDefined(processId, 'processId');
 
         let postBody = null;
-
-        if (processId === undefined || processId === null) {
-            throw new Error("Required param 'processId' in getProcessSubmittedForms");
-        }
 
         let pathParams = {
             'processId': processId
@@ -114,12 +110,9 @@ export class SubmittedFormsApi extends BaseApi {
         * @return Promise<SubmittedFormRepresentation>
         */
     getSubmittedFrom(submittedFormId: number): Promise<SubmittedFormRepresentation> {
+        throwIfNotDefined(submittedFormId, 'submittedFormId');
 
         let postBody = null;
-
-        if (submittedFormId === undefined || submittedFormId === null) {
-            throw new Error("Required param 'submittedFormId' in getSubmittedFrom");
-        }
 
         let pathParams = {
             'submittedFormId': submittedFormId
@@ -151,12 +144,9 @@ export class SubmittedFormsApi extends BaseApi {
         * @return Promise<SubmittedFormRepresentation>
         */
     getTaskSubmittedForms(taskId: string): Promise<SubmittedFormRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getTaskSubmittedForms");
-        }
 
         let pathParams = {
             'taskId': taskId

--- a/src/api/activiti-rest-api/api/systemProperties.api.ts
+++ b/src/api/activiti-rest-api/api/systemProperties.api.ts
@@ -19,6 +19,7 @@ import { GlobalDateFormatRepresentation } from '../model/globalDateFormatReprese
 import { PasswordValidationConstraints } from '../model/passwordValidationConstraints';
 import { SystemPropertiesRepresentation } from '../model/systemPropertiesRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Systemproperties service.
@@ -34,12 +35,9 @@ export class SystemPropertiesApi extends BaseApi {
     * @return Promise<GlobalDateFormatRepresentation>
     */
     getGlobalDateFormat(tenantId: number): Promise<GlobalDateFormatRepresentation> {
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in getGlobalDateFormat");
-        }
 
         let pathParams = {
             'tenantId': tenantId
@@ -71,12 +69,9 @@ export class SystemPropertiesApi extends BaseApi {
         * @return Promise<PasswordValidationConstraints>
         */
     getPasswordValidationConstraints(tenantId: number): Promise<PasswordValidationConstraints> {
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in getPasswordValidationConstraints");
-        }
 
         let pathParams = {
             'tenantId': tenantId
@@ -140,12 +135,9 @@ export class SystemPropertiesApi extends BaseApi {
         * @return Promise<boolean>
         */
     involvedUsersCanEditForms(tenantId: number): Promise<boolean> {
+        throwIfNotDefined(tenantId, 'tenantId');
 
         let postBody = null;
-
-        if (tenantId === undefined || tenantId === null) {
-            throw new Error("Required param 'tenantId' in involvedUsersCanEditForms");
-        }
 
         let pathParams = {
             'tenantId': tenantId

--- a/src/api/activiti-rest-api/api/taskActions.api.ts
+++ b/src/api/activiti-rest-api/api/taskActions.api.ts
@@ -20,6 +20,7 @@ import { FormIdentifierRepresentation } from '../model/formIdentifierRepresentat
 import { TaskRepresentation } from '../model/taskRepresentation';
 import { UserIdentifierRepresentation } from '../model/userIdentifierRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
  * Taskactions service.
@@ -36,16 +37,10 @@ export class TaskActionsApi extends BaseApi {
      * @return Promise<TaskRepresentation>
      */
     assignTask(taskId: string, userIdentifier: AssigneeIdentifierRepresentation): Promise<TaskRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(userIdentifier, 'userIdentifier');
 
         let postBody = userIdentifier;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in assignTask");
-        }
-
-        if (userIdentifier === undefined || userIdentifier === null) {
-            throw new Error("Required param 'userIdentifier' in assignTask");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -75,16 +70,10 @@ export class TaskActionsApi extends BaseApi {
      * @return Promise<{}>
      */
     attachForm(taskId: string, formIdentifier: FormIdentifierRepresentation): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(formIdentifier, 'formIdentifier');
 
         let postBody = formIdentifier;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in attachForm");
-        }
-
-        if (formIdentifier === undefined || formIdentifier === null) {
-            throw new Error("Required param 'formIdentifier' in attachForm");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -113,12 +102,9 @@ export class TaskActionsApi extends BaseApi {
      * @return Promise<{}>
      */
     claimTask(taskId: string): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in claimTask");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -147,12 +133,9 @@ export class TaskActionsApi extends BaseApi {
      * @return Promise<{}>
      */
     completeTask(taskId: string): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in completeTask");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -182,16 +165,10 @@ export class TaskActionsApi extends BaseApi {
      * @return Promise<{}>
      */
     delegateTask(taskId: string, userIdentifier: UserIdentifierRepresentation): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(userIdentifier, 'userIdentifier');
 
         let postBody = userIdentifier;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in delegateTask");
-        }
-
-        if (userIdentifier === undefined || userIdentifier === null) {
-            throw new Error("Required param 'userIdentifier' in delegateTask");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -221,16 +198,10 @@ export class TaskActionsApi extends BaseApi {
      * @return Promise<{}>
      */
     involveGroup(taskId: string, groupId: string): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(groupId, 'groupId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in involveGroup");
-        }
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in involveGroup");
-        }
 
         let pathParams = {
             'taskId': taskId, 'groupId': groupId
@@ -260,16 +231,10 @@ export class TaskActionsApi extends BaseApi {
      * @return Promise<{}>
      */
     involveUser(taskId: string, userIdentifier: UserIdentifierRepresentation): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(userIdentifier, 'userIdentifier');
 
         let postBody = userIdentifier;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in involveUser");
-        }
-
-        if (userIdentifier === undefined || userIdentifier === null) {
-            throw new Error("Required param 'userIdentifier' in involveUser");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -298,12 +263,9 @@ export class TaskActionsApi extends BaseApi {
      * @return Promise<{}>
      */
     removeForm(taskId: string): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in removeForm");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -333,13 +295,8 @@ export class TaskActionsApi extends BaseApi {
      * @return Promise<{}>
      */
     removeInvolvedUser(taskId: string, identifier: string | UserIdentifierRepresentation): Promise<any> {
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in removeInvolvedUser");
-        }
-
-        if (identifier === undefined || identifier === null) {
-            throw new Error("Required param 'groupId' in identifier");
-        }
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(identifier, 'identifier');
 
         let pathParams = {
             'taskId': taskId, 'groupId': identifier
@@ -380,12 +337,9 @@ export class TaskActionsApi extends BaseApi {
      * @return Promise<{}>
      */
     resolveTask(taskId: string): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in resolveTask");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -414,12 +368,9 @@ export class TaskActionsApi extends BaseApi {
      * @return Promise<{}>
      */
     unclaimTask(taskId: string): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in unclaimTask");
-        }
 
         let pathParams = {
             'taskId': taskId

--- a/src/api/activiti-rest-api/api/taskForms.api.ts
+++ b/src/api/activiti-rest-api/api/taskForms.api.ts
@@ -21,6 +21,7 @@ import { FormValueRepresentation } from '../model/formValueRepresentation';
 import { ProcessInstanceVariableRepresentation } from '../model/processInstanceVariableRepresentation';
 import { SaveFormRepresentation } from '../model/saveFormRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Taskforms service.
@@ -37,16 +38,10 @@ export class TaskFormsApi extends BaseApi {
     * @return Promise<{}>
     */
     completeTaskForm(taskId: string, completeTaskFormRepresentation: CompleteFormRepresentation): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(completeTaskFormRepresentation, 'completeTaskFormRepresentation');
 
         let postBody = completeTaskFormRepresentation;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in completeTaskForm");
-        }
-
-        if (completeTaskFormRepresentation === undefined || completeTaskFormRepresentation === null) {
-            throw new Error("Required param 'completeTaskFormRepresentation' in completeTaskForm");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -78,12 +73,9 @@ export class TaskFormsApi extends BaseApi {
         * @return Promise<ProcessInstanceVariableRepresentation>
         */
     getProcessInstanceVariables(taskId: string): Promise<ProcessInstanceVariableRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getProcessInstanceVariables");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -164,16 +156,10 @@ export class TaskFormsApi extends BaseApi {
         * @return Promise<FormValueRepresentation []>
         */
     getRestFieldValues(taskId: string, field: string): Promise<FormValueRepresentation []> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(field, 'field');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getRestFieldValues");
-        }
-
-        if (field === undefined || field === null) {
-            throw new Error("Required param 'field' in getRestFieldValues");
-        }
 
         let pathParams = {
             'taskId': taskId, 'field': field
@@ -205,12 +191,9 @@ export class TaskFormsApi extends BaseApi {
         * @return Promise<FormDefinitionRepresentation>
         */
     getTaskForm(taskId: string): Promise<FormDefinitionRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getTaskForm");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -243,16 +226,10 @@ export class TaskFormsApi extends BaseApi {
         * @return Promise<{}>
         */
     saveTaskForm(taskId: string, saveTaskFormRepresentation: SaveFormRepresentation): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(saveTaskFormRepresentation, 'saveTaskFormRepresentation');
 
         let postBody = saveTaskFormRepresentation;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in saveTaskForm");
-        }
-
-        if (saveTaskFormRepresentation === undefined || saveTaskFormRepresentation === null) {
-            throw new Error("Required param 'saveTaskFormRepresentation' in saveTaskForm");
-        }
 
         let pathParams = {
             'taskId': taskId

--- a/src/api/activiti-rest-api/api/taskVariables.api.ts
+++ b/src/api/activiti-rest-api/api/taskVariables.api.ts
@@ -18,6 +18,7 @@
 import { } from '../model/';
 import { RestVariable } from '../model/restVariable';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Taskvariables service.
@@ -34,16 +35,10 @@ export class TaskVariablesApi extends BaseApi {
     * @return Promise<RestVariable>
     */
     createTaskVariable(taskId: string, restVariables: RestVariable): Promise<RestVariable> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(restVariables, 'restVariables');
 
         let postBody = restVariables;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in createTaskVariable");
-        }
-
-        if (restVariables === undefined || restVariables === null) {
-            throw new Error("Required param 'restVariables' in createTaskVariable");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -75,12 +70,9 @@ export class TaskVariablesApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteAllLocalTaskVariables(taskId: string): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in deleteAllLocalTaskVariables");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -115,16 +107,11 @@ export class TaskVariablesApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteVariable(taskId: string, variableName: string, opts?: any): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(variableName, 'variableName');
+
         opts = opts || {};
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in deleteVariable");
-        }
-
-        if (variableName === undefined || variableName === null) {
-            throw new Error("Required param 'variableName' in deleteVariable");
-        }
 
         let pathParams = {
             'taskId': taskId, 'variableName': variableName
@@ -160,16 +147,11 @@ export class TaskVariablesApi extends BaseApi {
         * @return Promise<RestVariable>
         */
     getVariable(taskId: string, variableName: string, opts?: any): Promise<RestVariable> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(variableName, 'variableName');
+
         opts = opts || {};
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getVariable");
-        }
-
-        if (variableName === undefined || variableName === null) {
-            throw new Error("Required param 'variableName' in getVariable");
-        }
 
         let pathParams = {
             'taskId': taskId, 'variableName': variableName
@@ -204,12 +186,10 @@ export class TaskVariablesApi extends BaseApi {
         * @return Promise<RestVariable>
         */
     getVariables(taskId: string, opts?: any): Promise<RestVariable> {
+        throwIfNotDefined(taskId, 'taskId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getVariables");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -244,20 +224,11 @@ export class TaskVariablesApi extends BaseApi {
         * @return Promise<RestVariable>
         */
     updateVariable(taskId: string, variableName: string, restVariable: RestVariable): Promise<RestVariable> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(variableName, 'variableName');
+        throwIfNotDefined(restVariable, 'restVariable');
 
         let postBody = restVariable;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in updateVariable");
-        }
-
-        if (variableName === undefined || variableName === null) {
-            throw new Error("Required param 'variableName' in updateVariable");
-        }
-
-        if (restVariable === undefined || restVariable === null) {
-            throw new Error("Required param 'restVariable' in updateVariable");
-        }
 
         let pathParams = {
             'taskId': taskId, 'variableName': variableName

--- a/src/api/activiti-rest-api/api/tasks.api.ts
+++ b/src/api/activiti-rest-api/api/tasks.api.ts
@@ -24,6 +24,7 @@ import { TaskQueryRepresentation } from '../model/taskQueryRepresentation';
 import { TaskRepresentation } from '../model/taskRepresentation';
 import { TaskUpdateRepresentation } from '../model/taskUpdateRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Tasks service.
@@ -40,16 +41,10 @@ export class TasksApi extends BaseApi {
     * @return Promise<IdentityLinkRepresentation>
     */
     createIdentityLink(taskId: string, identityLinkRepresentation: IdentityLinkRepresentation): Promise<IdentityLinkRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(identityLinkRepresentation, 'identityLinkRepresentation');
 
         let postBody = identityLinkRepresentation;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in createIdentityLink");
-        }
-
-        if (identityLinkRepresentation === undefined || identityLinkRepresentation === null) {
-            throw new Error("Required param 'identityLinkRepresentation' in createIdentityLink");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -81,12 +76,9 @@ export class TasksApi extends BaseApi {
         * @return Promise<TaskRepresentation>
         */
     createNewTask(taskRepresentation: TaskRepresentation): Promise<TaskRepresentation> {
+        throwIfNotDefined(taskRepresentation, 'taskRepresentation');
 
         let postBody = taskRepresentation;
-
-        if (taskRepresentation === undefined || taskRepresentation === null) {
-            throw new Error("Required param 'taskRepresentation' in createNewTask");
-        }
 
         let pathParams = {
 
@@ -121,24 +113,12 @@ export class TasksApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteIdentityLink(taskId: string, family: string, identityId: string, type: string): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(family, 'family');
+        throwIfNotDefined(identityId, 'identityId');
+        throwIfNotDefined(type, 'type');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in deleteIdentityLink");
-        }
-
-        if (family === undefined || family === null) {
-            throw new Error("Required param 'family' in deleteIdentityLink");
-        }
-
-        if (identityId === undefined || identityId === null) {
-            throw new Error("Required param 'identityId' in deleteIdentityLink");
-        }
-
-        if (type === undefined || type === null) {
-            throw new Error("Required param 'type' in deleteIdentityLink");
-        }
 
         let pathParams = {
             'taskId': taskId, 'family': family, 'identityId': identityId, 'type': type
@@ -170,12 +150,9 @@ export class TasksApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteTask(taskId: string): Promise<any> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in deleteTask");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -207,12 +184,9 @@ export class TasksApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationTaskRepresentation>
         */
     filterTasks(tasksFilter: TaskFilterRequestRepresentation): Promise<ResultListDataRepresentationTaskRepresentation> {
+        throwIfNotDefined(tasksFilter, 'tasksFilter');
 
         let postBody = tasksFilter;
-
-        if (tasksFilter === undefined || tasksFilter === null) {
-            throw new Error("Required param 'tasksFilter' in filterTasks");
-        }
 
         let pathParams = {
 
@@ -247,24 +221,12 @@ export class TasksApi extends BaseApi {
         * @return Promise<IdentityLinkRepresentation>
         */
     getIdentityLinkType(taskId: string, family: string, identityId: string, type: string): Promise<IdentityLinkRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(family, 'family');
+        throwIfNotDefined(identityId, 'identityId');
+        throwIfNotDefined(type, 'type');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getIdentityLinkType");
-        }
-
-        if (family === undefined || family === null) {
-            throw new Error("Required param 'family' in getIdentityLinkType");
-        }
-
-        if (identityId === undefined || identityId === null) {
-            throw new Error("Required param 'identityId' in getIdentityLinkType");
-        }
-
-        if (type === undefined || type === null) {
-            throw new Error("Required param 'type' in getIdentityLinkType");
-        }
 
         let pathParams = {
             'taskId': taskId, 'family': family, 'identityId': identityId, 'type': type
@@ -297,16 +259,10 @@ export class TasksApi extends BaseApi {
         * @return Promise<IdentityLinkRepresentation>
         */
     getIdentityLinksForFamily(taskId: string, family: string): Promise<IdentityLinkRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(family, 'family');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getIdentityLinksForFamily");
-        }
-
-        if (family === undefined || family === null) {
-            throw new Error("Required param 'family' in getIdentityLinksForFamily");
-        }
 
         let pathParams = {
             'taskId': taskId, 'family': family
@@ -338,12 +294,9 @@ export class TasksApi extends BaseApi {
         * @return Promise<IdentityLinkRepresentation>
         */
     getIdentityLinks(taskId: string): Promise<IdentityLinkRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getIdentityLinks");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -375,12 +328,9 @@ export class TasksApi extends BaseApi {
         * @return Promise<TaskAuditInfoRepresentation>
         */
     getTaskAuditLog(taskId: string): Promise<TaskAuditInfoRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getTaskAuditLog");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -412,12 +362,9 @@ export class TasksApi extends BaseApi {
         * @return Promise<TaskRepresentation>
         */
     getTask(taskId: string): Promise<TaskRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
 
         let postBody = null;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in getTask");
-        }
 
         let pathParams = {
             'taskId': taskId
@@ -449,12 +396,9 @@ export class TasksApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationTaskRepresentation>
         */
     listHistoricTasks(queryRequest: HistoricTaskInstanceQueryRepresentation): Promise<ResultListDataRepresentationTaskRepresentation> {
+        throwIfNotDefined(queryRequest, 'queryRequest');
 
         let postBody = queryRequest;
-
-        if (queryRequest === undefined || queryRequest === null) {
-            throw new Error("Required param 'queryRequest' in listHistoricTasks");
-        }
 
         let pathParams = {
 
@@ -486,12 +430,9 @@ export class TasksApi extends BaseApi {
         * @return Promise<ResultListDataRepresentationTaskRepresentation>
         */
     listTasks(tasksQuery: TaskQueryRepresentation): Promise<ResultListDataRepresentationTaskRepresentation> {
+        throwIfNotDefined(tasksQuery, 'tasksQuery');
 
         let postBody = tasksQuery;
-
-        if (tasksQuery === undefined || tasksQuery === null) {
-            throw new Error("Required param 'tasksQuery' in listTasks");
-        }
 
         let pathParams = {
 
@@ -524,16 +465,10 @@ export class TasksApi extends BaseApi {
         * @return Promise<TaskRepresentation>
         */
     updateTask(taskId: string, updated: TaskUpdateRepresentation): Promise<TaskRepresentation> {
+        throwIfNotDefined(taskId, 'taskId');
+        throwIfNotDefined(updated, 'updated');
 
         let postBody = updated;
-
-        if (taskId === undefined || taskId === null) {
-            throw new Error("Required param 'taskId' in updateTask");
-        }
-
-        if (updated === undefined || updated === null) {
-            throw new Error("Required param 'updated' in updateTask");
-        }
 
         let pathParams = {
             'taskId': taskId

--- a/src/api/activiti-rest-api/api/userFilters.api.ts
+++ b/src/api/activiti-rest-api/api/userFilters.api.ts
@@ -21,6 +21,7 @@ import { UserFilterOrderRepresentation } from '../model/userFilterOrderRepresent
 import { UserProcessInstanceFilterRepresentation } from '../model/userProcessInstanceFilterRepresentation';
 import { UserTaskFilterRepresentation } from '../model/userTaskFilterRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Userfilters service.
@@ -36,12 +37,9 @@ export class UserFiltersApi extends BaseApi {
     * @return Promise<UserProcessInstanceFilterRepresentation>
     */
     createUserProcessInstanceFilter(userProcessInstanceFilterRepresentation: UserProcessInstanceFilterRepresentation): Promise<UserProcessInstanceFilterRepresentation> {
+        throwIfNotDefined(userProcessInstanceFilterRepresentation, 'userProcessInstanceFilterRepresentation');
 
         let postBody = userProcessInstanceFilterRepresentation;
-
-        if (userProcessInstanceFilterRepresentation === undefined || userProcessInstanceFilterRepresentation === null) {
-            throw new Error("Required param 'userProcessInstanceFilterRepresentation' in createUserProcessInstanceFilter");
-        }
 
         let pathParams = {
 
@@ -73,12 +71,9 @@ export class UserFiltersApi extends BaseApi {
         * @return Promise<UserTaskFilterRepresentation>
         */
     createUserTaskFilter(userTaskFilterRepresentation: UserTaskFilterRepresentation): Promise<UserTaskFilterRepresentation> {
+        throwIfNotDefined(userTaskFilterRepresentation, 'userTaskFilterRepresentation');
 
         let postBody = userTaskFilterRepresentation;
-
-        if (userTaskFilterRepresentation === undefined || userTaskFilterRepresentation === null) {
-            throw new Error("Required param 'userTaskFilterRepresentation' in createUserTaskFilter");
-        }
 
         let pathParams = {
 
@@ -110,12 +105,9 @@ export class UserFiltersApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteUserProcessInstanceFilter(userFilterId: number): Promise<any> {
+        throwIfNotDefined(userFilterId, 'userFilterId');
 
         let postBody = null;
-
-        if (userFilterId === undefined || userFilterId === null) {
-            throw new Error("Required param 'userFilterId' in deleteUserProcessInstanceFilter");
-        }
 
         let pathParams = {
             'userFilterId': userFilterId
@@ -147,12 +139,9 @@ export class UserFiltersApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteUserTaskFilter(userFilterId: number): Promise<any> {
+        throwIfNotDefined(userFilterId, 'userFilterId');
 
         let postBody = null;
-
-        if (userFilterId === undefined || userFilterId === null) {
-            throw new Error("Required param 'userFilterId' in deleteUserTaskFilter");
-        }
 
         let pathParams = {
             'userFilterId': userFilterId
@@ -184,12 +173,9 @@ export class UserFiltersApi extends BaseApi {
         * @return Promise<UserProcessInstanceFilterRepresentation>
         */
     getUserProcessInstanceFilter(userFilterId: number): Promise<UserProcessInstanceFilterRepresentation> {
+        throwIfNotDefined(userFilterId, 'userFilterId');
 
         let postBody = null;
-
-        if (userFilterId === undefined || userFilterId === null) {
-            throw new Error("Required param 'userFilterId' in getUserProcessInstanceFilter");
-        }
 
         let pathParams = {
             'userFilterId': userFilterId
@@ -256,12 +242,9 @@ export class UserFiltersApi extends BaseApi {
         * @return Promise<UserTaskFilterRepresentation>
         */
     getUserTaskFilter(userFilterId: number): Promise<UserTaskFilterRepresentation> {
+        throwIfNotDefined(userFilterId, 'userFilterId');
 
         let postBody = null;
-
-        if (userFilterId === undefined || userFilterId === null) {
-            throw new Error("Required param 'userFilterId' in getUserTaskFilter");
-        }
 
         let pathParams = {
             'userFilterId': userFilterId
@@ -328,12 +311,9 @@ export class UserFiltersApi extends BaseApi {
         * @return Promise<{}>
         */
     orderUserProcessInstanceFilters(filterOrderRepresentation: UserFilterOrderRepresentation): Promise<any> {
+        throwIfNotDefined(filterOrderRepresentation, 'filterOrderRepresentation');
 
         let postBody = filterOrderRepresentation;
-
-        if (filterOrderRepresentation === undefined || filterOrderRepresentation === null) {
-            throw new Error("Required param 'filterOrderRepresentation' in orderUserProcessInstanceFilters");
-        }
 
         let pathParams = {
 
@@ -365,12 +345,9 @@ export class UserFiltersApi extends BaseApi {
         * @return Promise<{}>
         */
     orderUserTaskFilters(filterOrderRepresentation: UserFilterOrderRepresentation): Promise<any> {
+        throwIfNotDefined(filterOrderRepresentation, 'filterOrderRepresentation');
 
         let postBody = filterOrderRepresentation;
-
-        if (filterOrderRepresentation === undefined || filterOrderRepresentation === null) {
-            throw new Error("Required param 'filterOrderRepresentation' in orderUserTaskFilters");
-        }
 
         let pathParams = {
 
@@ -403,16 +380,10 @@ export class UserFiltersApi extends BaseApi {
         * @return Promise<UserProcessInstanceFilterRepresentation>
         */
     updateUserProcessInstanceFilter(userFilterId: number, userProcessInstanceFilterRepresentation: UserProcessInstanceFilterRepresentation): Promise<UserProcessInstanceFilterRepresentation> {
+        throwIfNotDefined(userFilterId, 'userFilterId');
+        throwIfNotDefined(userProcessInstanceFilterRepresentation, 'userProcessInstanceFilterRepresentation');
 
         let postBody = userProcessInstanceFilterRepresentation;
-
-        if (userFilterId === undefined || userFilterId === null) {
-            throw new Error("Required param 'userFilterId' in updateUserProcessInstanceFilter");
-        }
-
-        if (userProcessInstanceFilterRepresentation === undefined || userProcessInstanceFilterRepresentation === null) {
-            throw new Error("Required param 'userProcessInstanceFilterRepresentation' in updateUserProcessInstanceFilter");
-        }
 
         let pathParams = {
             'userFilterId': userFilterId
@@ -445,16 +416,10 @@ export class UserFiltersApi extends BaseApi {
         * @return Promise<UserTaskFilterRepresentation>
         */
     updateUserTaskFilter(userFilterId: number, userTaskFilterRepresentation: UserTaskFilterRepresentation): Promise<UserTaskFilterRepresentation> {
+        throwIfNotDefined(userFilterId, 'userFilterId');
+        throwIfNotDefined(userTaskFilterRepresentation, 'userTaskFilterRepresentation');
 
         let postBody = userTaskFilterRepresentation;
-
-        if (userFilterId === undefined || userFilterId === null) {
-            throw new Error("Required param 'userFilterId' in updateUserTaskFilter");
-        }
-
-        if (userTaskFilterRepresentation === undefined || userTaskFilterRepresentation === null) {
-            throw new Error("Required param 'userTaskFilterRepresentation' in updateUserTaskFilter");
-        }
 
         let pathParams = {
             'userFilterId': userFilterId

--- a/src/api/activiti-rest-api/api/userProfile.api.ts
+++ b/src/api/activiti-rest-api/api/userProfile.api.ts
@@ -19,6 +19,7 @@ import { ChangePasswordRepresentation } from '../model/changePasswordRepresentat
 import { ImageUploadRepresentation } from '../model/imageUploadRepresentation';
 import { UserRepresentation } from '../model/userRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Userprofile service.
@@ -34,12 +35,9 @@ export class UserProfileApi extends BaseApi {
     * @return Promise<{}>
     */
     changePassword(changePasswordRepresentation: ChangePasswordRepresentation): Promise<any> {
+        throwIfNotDefined(changePasswordRepresentation, 'changePasswordRepresentation');
 
         let postBody = changePasswordRepresentation;
-
-        if (changePasswordRepresentation === undefined || changePasswordRepresentation === null) {
-            throw new Error("Required param 'changePasswordRepresentation' in changePassword");
-        }
 
         let pathParams = {
 
@@ -144,12 +142,9 @@ export class UserProfileApi extends BaseApi {
         * @return Promise<UserRepresentation>
         */
     updateProfile(userRepresentation: UserRepresentation): Promise<UserRepresentation> {
+        throwIfNotDefined(userRepresentation, 'userRepresentation');
 
         let postBody = userRepresentation;
-
-        if (userRepresentation === undefined || userRepresentation === null) {
-            throw new Error("Required param 'userRepresentation' in updateProfile");
-        }
 
         let pathParams = {
 
@@ -181,12 +176,9 @@ export class UserProfileApi extends BaseApi {
         * @return Promise<ImageUploadRepresentation>
         */
     uploadProfilePicture(file: any): Promise<ImageUploadRepresentation> {
+        throwIfNotDefined(file, 'file');
 
         let postBody = null;
-
-        if (file === undefined || file === null) {
-            throw new Error("Required param 'file' in uploadProfilePicture");
-        }
 
         let pathParams = {
 

--- a/src/api/activiti-rest-api/api/users.api.ts
+++ b/src/api/activiti-rest-api/api/users.api.ts
@@ -20,6 +20,7 @@ import { ResultListDataRepresentationLightUserRepresentation } from '../model/re
 import { UserActionRepresentation } from '../model/userActionRepresentation';
 import { UserRepresentation } from '../model/userRepresentation';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Users service.
@@ -36,16 +37,10 @@ export class UsersApi extends BaseApi {
     * @return Promise<{}>
     */
     executeAction(userId: number, actionRequest: UserActionRepresentation): Promise<any> {
+        throwIfNotDefined(userId, 'userId');
+        throwIfNotDefined(actionRequest, 'actionRequest');
 
         let postBody = actionRequest;
-
-        if (userId === undefined || userId === null) {
-            throw new Error("Required param 'userId' in executeAction");
-        }
-
-        if (actionRequest === undefined || actionRequest === null) {
-            throw new Error("Required param 'actionRequest' in executeAction");
-        }
 
         let pathParams = {
             'userId': userId
@@ -89,12 +84,9 @@ export class UsersApi extends BaseApi {
         * @return Promise<UserRepresentation>
         */
     getUser(userId: number): Promise<UserRepresentation> {
+        throwIfNotDefined(userId, 'userId');
 
         let postBody = null;
-
-        if (userId === undefined || userId === null) {
-            throw new Error("Required param 'userId' in getUser");
-        }
 
         let pathParams = {
             'userId': userId
@@ -175,12 +167,9 @@ export class UsersApi extends BaseApi {
         * @return Promise<{}>
         */
     requestPasswordReset(resetPassword: ResetPasswordRepresentation): Promise<any> {
+        throwIfNotDefined(resetPassword, 'resetPassword');
 
         let postBody = resetPassword;
-
-        if (resetPassword === undefined || resetPassword === null) {
-            throw new Error("Required param 'resetPassword' in requestPasswordReset");
-        }
 
         let pathParams = {
 
@@ -213,16 +202,10 @@ export class UsersApi extends BaseApi {
         * @return Promise<UserRepresentation>
         */
     updateUser(userId: number, userRequest: UserRepresentation): Promise<UserRepresentation> {
+        throwIfNotDefined(userId, 'userId');
+        throwIfNotDefined(userRequest, 'userRequest');
 
         let postBody = userRequest;
-
-        if (userId === undefined || userId === null) {
-            throw new Error("Required param 'userId' in updateUser");
-        }
-
-        if (userRequest === undefined || userRequest === null) {
-            throw new Error("Required param 'userRequest' in updateUser");
-        }
 
         let pathParams = {
             'userId': userId

--- a/src/api/auth-rest-api/api/authentication.api.ts
+++ b/src/api/auth-rest-api/api/authentication.api.ts
@@ -19,6 +19,7 @@ import { TicketBody } from '../model/ticketBody';
 import { TicketEntry } from '../model/ticketEntry';
 import { ValidTicketEntry } from '../model/validTicketEntry';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Authentication service.
@@ -50,12 +51,9 @@ For example using Javascript:
     * @return Promise<TicketEntry>
     */
     createTicket(ticketBodyCreate: TicketBody): Promise<TicketEntry> {
+        throwIfNotDefined(ticketBodyCreate, 'ticketBodyCreate');
 
         let postBody = ticketBodyCreate;
-
-        if (ticketBodyCreate === undefined || ticketBodyCreate === null) {
-            throw new Error("Required param 'ticketBodyCreate' in createTicket");
-        }
 
         let pathParams = {
 

--- a/src/api/auth-rest-api/api/base.api.ts
+++ b/src/api/auth-rest-api/api/base.api.ts
@@ -16,7 +16,7 @@
 */
 
 import { AlfrescoApi } from '../../../alfrescoApi';
-import { AlfrescoApiClient } from '../../../alfrescoApiClient';
+import { AlfrescoApiClient, RequestOptions } from '../../../alfrescoApiClient';
 
 export class BaseApi {
 
@@ -26,6 +26,22 @@ export class BaseApi {
         if (alfrescoApi) {
             this.apiClient = alfrescoApi.authClient;
         }
+    }
+
+    post<T = any>(options: RequestOptions): Promise<T> {
+        return this.apiClient.post<T>(options);
+    }
+
+    put<T = any>(options: RequestOptions): Promise<T> {
+        return this.apiClient.put<T>(options);
+    }
+
+    get<T = any>(options: RequestOptions): Promise<T> {
+        return this.apiClient.get<T>(options);
+    }
+
+    delete<T = void>(options: RequestOptions): Promise<T> {
+        return this.apiClient.delete(options);
     }
 
     errorMessage(param: string, methodName: string) {

--- a/src/api/content-rest-api/api/actions.api.ts
+++ b/src/api/content-rest-api/api/actions.api.ts
@@ -20,6 +20,8 @@ import { ActionDefinitionEntry } from '../model/actionDefinitionEntry';
 import { ActionDefinitionList } from '../model/actionDefinitionList';
 import { ActionExecResultEntry } from '../model/actionExecResultEntry';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Actions service.
@@ -38,12 +40,9 @@ Retrieve the details of the action denoted by **actionDefinitionId**.
     * @return Promise<ActionDefinitionEntry>
     */
     actionDetails(actionDefinitionId: string): Promise<ActionDefinitionEntry> {
+        throwIfNotDefined(actionDefinitionId, 'actionDefinitionId');
 
         let postBody = null;
-
-        if (actionDefinitionId === undefined || actionDefinitionId === null) {
-            throw new Error("Required param 'actionDefinitionId' in actionDetails");
-        }
 
         let pathParams = {
             'actionDefinitionId': actionDefinitionId
@@ -123,12 +122,9 @@ Retrieve the details of the action denoted by **actionDefinitionId**.
         * @return Promise<ActionExecResultEntry>
         */
     actionExec(actionBodyExec: ActionBodyExec): Promise<ActionExecResultEntry> {
+        throwIfNotDefined(actionBodyExec, 'actionBodyExec');
 
         let postBody = actionBodyExec;
-
-        if (actionBodyExec === undefined || actionBodyExec === null) {
-            throw new Error("Required param 'actionBodyExec' in actionExec");
-        }
 
         let pathParams = {
 
@@ -206,8 +202,8 @@ Retrieve the details of the action denoted by **actionDefinitionId**.
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -270,12 +266,10 @@ Retrieve the details of the action denoted by **actionDefinitionId**.
         * @return Promise<ActionDefinitionList>
         */
     nodeActions(nodeId: string, opts?: any): Promise<ActionDefinitionList> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in nodeActions");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -284,8 +278,8 @@ Retrieve the details of the action denoted by **actionDefinitionId**.
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/activities.api.ts
+++ b/src/api/content-rest-api/api/activities.api.ts
@@ -17,6 +17,8 @@
 
 import { ActivityPaging } from '../model/activityPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Activities service.
@@ -57,12 +59,10 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<ActivityPaging>
     */
     listActivitiesForPerson(personId: string, opts?: any): Promise<ActivityPaging> {
+        throwIfNotDefined(personId, 'personId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in listActivitiesForPerson");
-        }
 
         let pathParams = {
             'personId': personId
@@ -73,7 +73,7 @@ parameter are returned in addition to those specified in the **fields** paramete
             'maxItems': opts['maxItems'],
             'who': opts['who'],
             'siteId': opts['siteId'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/audit.api.ts
+++ b/src/api/content-rest-api/api/audit.api.ts
@@ -21,6 +21,8 @@ import { AuditBodyUpdate } from '../model/auditBodyUpdate';
 import { AuditEntryEntry } from '../model/auditEntryEntry';
 import { AuditEntryPaging } from '../model/auditEntryPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Audit service.
@@ -54,16 +56,10 @@ You must have admin rights to delete audit information.
     * @return Promise<{}>
     */
     deleteAuditEntriesForAuditApp(auditApplicationId: string, where: string): Promise<any> {
+        throwIfNotDefined(auditApplicationId, 'auditApplicationId');
+        throwIfNotDefined(where, 'where');
 
         let postBody = null;
-
-        if (auditApplicationId === undefined || auditApplicationId === null) {
-            throw new Error("Required param 'auditApplicationId' in deleteAuditEntriesForAuditApp");
-        }
-
-        if (where === undefined || where === null) {
-            throw new Error("Required param 'where' in deleteAuditEntriesForAuditApp");
-        }
 
         let pathParams = {
             'auditApplicationId': auditApplicationId
@@ -102,16 +98,10 @@ You must have admin rights to delete audit information.
         * @return Promise<{}>
         */
     deleteAuditEntry(auditApplicationId: string, auditEntryId: string): Promise<any> {
+        throwIfNotDefined(auditApplicationId, 'auditApplicationId');
+        throwIfNotDefined(auditEntryId, 'auditEntryId');
 
         let postBody = null;
-
-        if (auditApplicationId === undefined || auditApplicationId === null) {
-            throw new Error("Required param 'auditApplicationId' in deleteAuditEntry");
-        }
-
-        if (auditEntryId === undefined || auditEntryId === null) {
-            throw new Error("Required param 'auditEntryId' in deleteAuditEntry");
-        }
 
         let pathParams = {
             'auditApplicationId': auditApplicationId, 'auditEntryId': auditEntryId
@@ -161,19 +151,17 @@ You must have admin rights to delete audit information.
         * @return Promise<AuditApp>
         */
     getAuditApp(auditApplicationId: string, opts?: any): Promise<AuditApp> {
+        throwIfNotDefined(auditApplicationId, 'auditApplicationId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (auditApplicationId === undefined || auditApplicationId === null) {
-            throw new Error("Required param 'auditApplicationId' in getAuditApp");
-        }
 
         let pathParams = {
             'auditApplicationId': auditApplicationId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -218,23 +206,18 @@ You must have admin rights to delete audit information.
         * @return Promise<AuditEntryEntry>
         */
     getAuditEntry(auditApplicationId: string, auditEntryId: string, opts?: any): Promise<AuditEntryEntry> {
+        throwIfNotDefined(auditApplicationId, 'auditApplicationId');
+        throwIfNotDefined(auditEntryId, 'auditEntryId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (auditApplicationId === undefined || auditApplicationId === null) {
-            throw new Error("Required param 'auditApplicationId' in getAuditEntry");
-        }
-
-        if (auditEntryId === undefined || auditEntryId === null) {
-            throw new Error("Required param 'auditEntryId' in getAuditEntry");
-        }
 
         let pathParams = {
             'auditApplicationId': auditApplicationId, 'auditEntryId': auditEntryId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -300,7 +283,7 @@ You must have admin rights to delete audit information.
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -389,12 +372,10 @@ You must have admin rights to delete audit information.
         * @return Promise<AuditEntryPaging>
         */
     listAuditEntriesForAuditApp(auditApplicationId: string, opts?: any): Promise<AuditEntryPaging> {
+        throwIfNotDefined(auditApplicationId, 'auditApplicationId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (auditApplicationId === undefined || auditApplicationId === null) {
-            throw new Error("Required param 'auditApplicationId' in listAuditEntriesForAuditApp");
-        }
 
         let pathParams = {
             'auditApplicationId': auditApplicationId
@@ -402,11 +383,11 @@ You must have admin rights to delete audit information.
 
         let queryParams = {
             'skipCount': opts['skipCount'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
             'maxItems': opts['maxItems'],
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -482,12 +463,10 @@ You must have admin rights to delete audit information.
         * @return Promise<AuditEntryPaging>
         */
     listAuditEntriesForNode(nodeId: string, opts?: any): Promise<AuditEntryPaging> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in listAuditEntriesForNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -495,11 +474,11 @@ You must have admin rights to delete audit information.
 
         let queryParams = {
             'skipCount': opts['skipCount'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
             'maxItems': opts['maxItems'],
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -550,23 +529,18 @@ You must have admin rights to delete audit information.
         * @return Promise<AuditApp>
         */
     updateAuditApp(auditApplicationId: string, auditAppBodyUpdate: AuditBodyUpdate, opts?: any): Promise<AuditApp> {
+        throwIfNotDefined(auditApplicationId, 'auditApplicationId');
+        throwIfNotDefined(auditAppBodyUpdate, 'auditAppBodyUpdate');
+
         opts = opts || {};
         let postBody = auditAppBodyUpdate;
-
-        if (auditApplicationId === undefined || auditApplicationId === null) {
-            throw new Error("Required param 'auditApplicationId' in updateAuditApp");
-        }
-
-        if (auditAppBodyUpdate === undefined || auditAppBodyUpdate === null) {
-            throw new Error("Required param 'auditAppBodyUpdate' in updateAuditApp");
-        }
 
         let pathParams = {
             'auditApplicationId': auditApplicationId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/base.api.ts
+++ b/src/api/content-rest-api/api/base.api.ts
@@ -16,7 +16,7 @@
 */
 
 import { AlfrescoApi } from '../../../alfrescoApi';
-import { AlfrescoApiClient } from '../../../alfrescoApiClient';
+import { AlfrescoApiClient, RequestOptions } from '../../../alfrescoApiClient';
 
 export class BaseApi {
 
@@ -26,6 +26,22 @@ export class BaseApi {
         if (alfrescoApi) {
             this.apiClient = alfrescoApi.contentClient;
         }
+    }
+
+    post<T = any>(options: RequestOptions): Promise<T> {
+        return this.apiClient.post<T>(options);
+    }
+
+    put<T = any>(options: RequestOptions): Promise<T> {
+        return this.apiClient.put<T>(options);
+    }
+
+    get<T = any>(options: RequestOptions): Promise<T> {
+        return this.apiClient.get<T>(options);
+    }
+
+    delete<T = void>(options: RequestOptions): Promise<T> {
+        return this.apiClient.delete(options);
     }
 
     errorMessage(param: string, methodName: string) {

--- a/src/api/content-rest-api/api/classes.api.ts
+++ b/src/api/content-rest-api/api/classes.api.ts
@@ -80,7 +80,7 @@ export class ClassesApi extends BaseApi {
         );
     }
 
-    getSubclasses(className: string, opts?: any): Promise<ClassDescription> {
+    getSubclasses(className: string, opts?: any): Promise<ClassDescription[]> {
         opts = opts || {};
 
         // verify the required parameter 'className' is set

--- a/src/api/content-rest-api/api/comments.api.ts
+++ b/src/api/content-rest-api/api/comments.api.ts
@@ -19,6 +19,8 @@ import { CommentBody } from '../model/commentBody';
 import { CommentEntry } from '../model/commentEntry';
 import { CommentPaging } from '../model/commentPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Comments service.
@@ -94,23 +96,18 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<CommentEntry>
     */
     createComment(nodeId: string, commentBodyCreate: CommentBody, opts?: any): Promise<CommentEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(commentBodyCreate, 'commentBodyCreate');
+
         opts = opts || {};
         let postBody = commentBodyCreate;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in createComment");
-        }
-
-        if (commentBodyCreate === undefined || commentBodyCreate === null) {
-            throw new Error("Required param 'commentBodyCreate' in createComment");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -137,16 +134,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteComment(nodeId: string, commentId: string): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(commentId, 'commentId');
 
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in deleteComment");
-        }
-
-        if (commentId === undefined || commentId === null) {
-            throw new Error("Required param 'commentId' in deleteComment");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'commentId': commentId
@@ -197,12 +188,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<CommentPaging>
         */
     listComments(nodeId: string, opts?: any): Promise<CommentPaging> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in listComments");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -211,7 +200,7 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -252,27 +241,19 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<CommentEntry>
         */
     updateComment(nodeId: string, commentId: string, commentBodyUpdate: CommentBody, opts?: any): Promise<CommentEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(commentId, 'commentId');
+        throwIfNotDefined(commentBodyUpdate, 'commentBodyUpdate');
+
         opts = opts || {};
         let postBody = commentBodyUpdate;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in updateComment");
-        }
-
-        if (commentId === undefined || commentId === null) {
-            throw new Error("Required param 'commentId' in updateComment");
-        }
-
-        if (commentBodyUpdate === undefined || commentBodyUpdate === null) {
-            throw new Error("Required param 'commentBodyUpdate' in updateComment");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'commentId': commentId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/customModel.api.ts
+++ b/src/api/content-rest-api/api/customModel.api.ts
@@ -16,7 +16,56 @@
 */
 
 import { AlfrescoApi } from '../../../alfrescoApi';
-import { AlfrescoApiClient } from '../../../alfrescoApiClient';
+import { PaginatedList, PaginatedEntries } from '../model/pagination';
+import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
+
+export interface CustomModel {
+    name: string;
+    namespacePrefix: string;
+    description: string;
+    author: string;
+    namespaceUri: string;
+    status: 'ACTIVE' | 'DRAFT';
+}
+
+export interface CustomType {
+    name?: string;
+    parentName?: string;
+    prefixedName?: string;
+    properties?: CustomModelProperty[];
+    title?: string;
+}
+
+export interface CustomAspect {
+    description?: string;
+    name?: string;
+    parentName?: string;
+    prefixedName?: string;
+    properties?: CustomModelProperty[];
+    title?: string;
+}
+
+export interface CustomModelProperty {
+    name?: string;
+    prefixedName?: string;
+    title?: string;
+    dataType?: string;
+    facetable?: 'FALSE' | 'TRUE';
+    indexTokenisationMode?: 'FALSE' | 'TRUE';
+    constraints?: CustomModelPropertyConstraint[];
+    multiValued?: boolean;
+    mandatoryEnforced?: boolean;
+    mandatory?: boolean;
+    indexed?: boolean;
+}
+
+export interface CustomModelPropertyConstraint {
+    name: string;
+    prefixedName: string;
+    type: string;
+    parameters: any[];
+}
 
 /**
  * Comments service.
@@ -31,13 +80,12 @@ import { AlfrescoApiClient } from '../../../alfrescoApiClient';
  * @param {module:ApiClient} apiClient Optional API client implementation to use, default to {@link module:ApiClient#instance}
  * if unspecified.
  */
-export class CustomModelApi {
-
-    private: boolean = true;
-
-    apiClient: AlfrescoApiClient;
+export class CustomModelApi extends BaseApi {
+    private = true;
 
     constructor(alfrescoApi?: AlfrescoApi) {
+        super(alfrescoApi);
+
         if (alfrescoApi) {
             this.apiClient = alfrescoApi.contentPrivateClient;
         }
@@ -46,17 +94,11 @@ export class CustomModelApi {
     /**
      * create Custom Model
      */
-    createCustomModel(status: string, description: string, name: string, namespaceUri: string, namespacePrefix: string, author?: string): Promise<any> {
+    createCustomModel(status: string, description: string, name: string, namespaceUri: string, namespacePrefix: string, author?: string): Promise<{ entry: CustomModel }> {
+        throwIfNotDefined(namespaceUri, 'namespaceUri');
+        throwIfNotDefined(namespacePrefix, 'namespacePrefix');
 
-        if (namespaceUri === undefined || namespaceUri === null) {
-            throw "Missing param 'namespaceUri' in createCustomModel";
-        }
-
-        if (namespacePrefix === undefined || namespacePrefix === null) {
-            throw "Missing param 'namespacePrefix' in createCustomModel";
-        }
-
-        let postBody = {
+        const bodyParam = {
             status,
             description,
             name,
@@ -65,735 +107,489 @@ export class CustomModelApi {
             author
         };
 
-        let pathParams = {};
-        let queryParams = {};
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-        return this.apiClient.callApi(
-            'cmm', 'POST',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
+        return this.post({
+            path: 'cmm',
+            bodyParam
+        });
     }
 
     /**
      * Create a custom type
      */
-    createCustomType(modelName: string, name: string, parentName?: string, title?: string, description?: string): Promise<any> {
+    createCustomType(modelName: string, name: string, parentName?: string, title?: string, description?: string): Promise<{ entry: CustomType }> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(name, 'name');
 
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in createCustomType";
-        }
-
-        if (name === undefined || name === null) {
-            throw "Missing param 'name' in createCustomType";
-        }
-
-        let postBody = {
-            'name': name,
-            'parentName': parentName,
-            'title': title,
-            'description': description
+        const bodyParam = {
+            name,
+            parentName,
+            title,
+            description
         };
 
-        let pathParams = {
-            'modelName': modelName
+        const pathParams = {
+            modelName
         };
-        let queryParams = {};
-        let headerParams = {};
-        let formParams = {};
 
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/types', 'POST',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
+        return this.post({
+            path: 'cmm/{modelName}/types',
+            bodyParam,
+            pathParams
+        });
     }
 
     /**
      * Create a custom aspect
      */
     createCustomAspect(modelName: string, name: string, parentName?: string, title?: string, description?: string): Promise<any> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(name, 'name');
 
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in createCustomAspect";
-        }
-
-        if (name === undefined || name === null) {
-            throw "Missing param 'name' in createCustomAspect";
-        }
-
-        let postBody = {
-            'name': name,
-            'parentName': parentName,
-            'title': title,
-            'description': description
+        const bodyParam = {
+            name,
+            parentName,
+            title,
+            description
         };
 
-        let pathParams = {
-            'modelName': modelName
+        const pathParams = {
+            modelName
         };
-        let queryParams = {};
-        let headerParams = {};
-        let formParams = {};
 
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/aspects', 'POST',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
+        return this.post({
+            path: 'cmm/{modelName}/aspects',
+            bodyParam,
+            pathParams
+        });
     }
 
     /**
      * Create a custom constraint
      */
     createCustomConstraint(modelName: string, name: string, type: string, parameters?: any): Promise<any> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(type, 'type');
+        throwIfNotDefined(name, 'name');
 
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in createCustomConstraint";
-        }
-        if (type === undefined || type === null) {
-            throw "Missing param 'type' in createCustomConstraint";
-        }
-        if (name === undefined || name === null) {
-            throw "Missing param 'name' in createCustomConstraint";
-        }
-
-        let postBody = {
-            'name': name,
-            'type': type,
-            'parameters': parameters
+        const bodyParam = {
+            name,
+            type,
+            parameters
         };
 
-        let pathParams = {
-            'modelName': modelName
+        const pathParams = {
+            modelName
         };
-        let queryParams = {};
-        let headerParams = {};
-        let formParams = {};
 
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/constraints', 'POST',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
+        return this.post({
+            path: 'cmm/{modelName}/constraints',
+            bodyParam,
+            pathParams
+        });
     }
 
     /**
      * Activate the custom model
      */
-    activateCustomModel(modelName: string): Promise<any> {
+    activateCustomModel(modelName: string): Promise<{ entry: CustomModel }> {
+        throwIfNotDefined(modelName, 'modelName');
 
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in activateCustomModel";
-        }
-
-        let postBody = {
+        const bodyParam = {
             'status': 'ACTIVE'
         };
 
-        let pathParams = {
-            'modelName': modelName
+        const pathParams = {
+            modelName
         };
-        let queryParams = {};
-        let headerParams = {};
-        let formParams = {};
 
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}?select=status', 'PUT',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
+        return this.put({
+            path: 'cmm/{modelName}?select=status',
+            bodyParam,
+            pathParams
+        });
     }
 
     /**
      * Deactivate the custom model
      */
-    deactivateCustomModel(modelName: string): Promise<any> {
+    deactivateCustomModel(modelName: string): Promise<{ entry: CustomModel }> {
+        throwIfNotDefined(modelName, 'modelName');
 
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in deactivateCustomModel";
-        }
-
-        let postBody = {
+        const bodyParam = {
             'status': 'DRAFT'
         };
 
-        let pathParams = {
-            'modelName': modelName
+        const pathParams = {
+            modelName
         };
-        let queryParams = {};
-        let headerParams = {};
-        let formParams = {};
 
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}?select=status', 'PUT',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
+        return this.put({
+            path: 'cmm/{modelName}?select=status',
+            bodyParam,
+            pathParams
+        });
     }
 
     /**
      * Add property into an existing aspect
      */
-    addPropertyToAspect(modelName: string, aspectName: string, properties?: any[]): Promise<any> {
+    addPropertyToAspect(modelName: string, aspectName: string, properties?: CustomModelProperty[]): Promise<CustomAspect> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(aspectName, 'aspectName');
 
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in addPropertyToAspect";
-        }
-
-        if (aspectName === undefined || aspectName === null) {
-            throw "Missing param 'aspectName' in addPropertyToAspect";
-        }
-
-        let postBody = {
+        const bodyParam = {
             'name': aspectName,
-            'properties': properties
+            properties
         };
-
-        let pathParams = {
-            'modelName': modelName,
-            'aspectName': aspectName
-        };
-        let queryParams = {};
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/aspects/{aspectName}?select=props', 'PUT',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Add Property into an existing type
-     */
-    addPropertyToType(modelName: string, typeName: string, properties?: any[]): Promise<any> {
-
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in addPropertyToType";
-        }
-
-        if (typeName === undefined || typeName === null) {
-            throw "Missing param 'typeName' in addPropertyToType";
-        }
-
-        const postBody = {
-            'name': typeName,
-            'properties': properties
-        };
-
-        const pathParams = {
-            'modelName': modelName,
-            'typeName': typeName
-        };
-        const queryParams = {};
-        const headerParams = {};
-        const formParams = {};
-
-        const contentTypes = ['application/json'];
-        const accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/types/{typeName}?select=props', 'PUT',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Edit an existing custom model
-     */
-    updateCustomModel(modelName: string, description?: string, namespaceUri?: string, namespacePrefix?: string): Promise<any> {
-
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in updateCustomModel";
-        }
-
-        let postBody = {
-            'name': modelName,
-            'description': description,
-            'namespaceUri': namespaceUri,
-            'namespacePrefix': namespacePrefix
-        };
-
-        let pathParams = {
-            'modelName': modelName
-        };
-        let queryParams = {};
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}', 'PUT',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Edit an existing custom model type
-     */
-    updateCustomType(modelName: string, typeName: string, description?: string, parentName?: string, title?: string): Promise<any> {
-
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in UpdateCustomType";
-        }
-
-        if (typeName === undefined || typeName === null) {
-            throw "Missing param 'typeName' in UpdateCustomType";
-        }
-
-        let postBody = {
-            'name': modelName,
-            'parentName': parentName,
-            'title': title,
-            'description': description
-        };
-
-        let pathParams = {
-            'modelName': modelName,
-            'typeName': typeName
-        };
-        let queryParams = {};
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/types/{typeName}', 'PUT',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Edit an existing custom model aspect
-     */
-    updateCustomAspect(modelName: string, aspectName: string, description?: string, parentName?: string, title?: string): Promise<any> {
-
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in updateCustomAspect";
-        }
-
-        if (aspectName === undefined || aspectName === null) {
-            throw "Missing param 'aspectName' in updateCustomAspect";
-        }
-
-        let postBody = {
-            'name': modelName,
-            'parentName': parentName,
-            'title': title,
-            'description': description
-        };
-
-        let pathParams = {
-            'modelName': modelName,
-            'aspectName': aspectName
-        };
-        let queryParams = {};
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/aspects/{aspectName}', 'PUT',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Get all custom models
-     */
-    getAllCustomModel(): Promise<any> {
-
-        let postBody = {};
-
-        let pathParams = {};
-        let queryParams = {};
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm', 'GET',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Get custom model
-     */
-    getCustomModel(modelName: string, queryParamsInput?: any): Promise<any> {
-
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in getCustomModel";
-        }
-
-        let postBody = {};
-
-        let pathParams = {
-            'modelName': modelName
-        };
-
-        let queryParams = queryParamsInput || {};
-
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}', 'GET',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Get all custom model types
-     */
-    getAllCustomType(modelName: string): Promise<any> {
-
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in getAllCustomType";
-        }
-
-        let postBody = {};
-
-        let pathParams = {
-            'modelName': modelName
-        };
-
-        let queryParams = {};
-
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/types', 'GET',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Get custom model type
-     */
-    getCustomType(modelName: string, typeName?: string, queryParamsInput?: any): Promise<any> {
-
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in getCustomType";
-        }
-
-        if (typeName === undefined || typeName === null) {
-            throw "Missing param 'typeName' in getCustomType";
-        }
-
-        let postBody = {};
-
-        let pathParams = {
-            'modelName': modelName,
-            'typeName': typeName
-        };
-
-        let queryParams = queryParamsInput || {};
-
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/types/{typeName}', 'GET',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Get all custom model aspect
-     */
-    getAllCustomAspect(modelName: string, queryParamsInput?: any): Promise<any> {
-
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in getAllCustomAspect";
-        }
-
-        let postBody = {};
-
-        let pathParams = {
-            'modelName': modelName
-        };
-
-        let queryParams = queryParamsInput || {};
-
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/aspects', 'GET',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Get custom model aspect
-     */
-    getCustomAspect(modelName: string, aspectName: string, queryParamsInput?: any): Promise<any> {
-
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in getCustomAspect";
-        }
-
-        if (aspectName === undefined || aspectName === null) {
-            throw "Missing param 'aspectName' in getCustomAspect";
-        }
-
-        let postBody = {};
-
-        let pathParams = {
-            'modelName': modelName,
-            'aspectName': aspectName
-        };
-
-        let queryParams = queryParamsInput || {};
-
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/aspects/{aspectName}', 'GET',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Get all custom model defined constraints
-     */
-    getAllCustomConstraints(modelName: string, queryParamsInput?: any): Promise<any> {
-
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in getAllCustomConstraints";
-        }
-
-        let postBody = {};
-
-        let pathParams = {
-            'modelName': modelName
-        };
-
-        let queryParams = queryParamsInput || {};
-
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/constraints', 'GET',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Get custom model defined constraints
-     */
-    getCustomConstraints(modelName: string, constraintName: string, queryParamsInput?: any): Promise<any> {
-
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in getCustomConstraints";
-        }
-
-        if (constraintName === undefined || constraintName === null) {
-            throw "Missing param 'constraintName' in getCustomConstraints";
-        }
-
-        let postBody = {};
-
-        let pathParams = {
-            'modelName': modelName,
-            'constraintName': constraintName
-        };
-
-        let queryParams = queryParamsInput || {};
-
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/constraints{constraintName}', 'GET',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Delete the given custom model
-     */
-    deleteCustomModel(modelName: string): Promise<any> {
-
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in deleteCustomModel";
-        }
-
-        let postBody = {};
-
-        let pathParams = {
-            'modelName': modelName
-        };
-
-        let queryParams = {};
-
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}', 'DELETE',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    /**
-     * Delete the given custom type
-     */
-    deleteCustomType(modelName: string, typeName: string): Promise<any> {
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in deleteCustomType";
-        }
-
-        if (typeName === undefined || typeName === null) {
-            throw "Missing param 'modelName' in deleteCustomType";
-        }
-
-        let postBody = {};
-
-        let pathParams = {
-            'modelName': modelName,
-            'typeName': typeName
-        };
-
-        let queryParams = {};
-
-        let headerParams = {};
-        let formParams = {};
-
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
-
-
-        return this.apiClient.callApi(
-            'cmm/{modelName}/types/{typeName}', 'DELETE',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
-    }
-
-    deleteCustomAspect(modelName: string, aspectName: string): Promise<any> {
-        if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in deleteAspect";
-        }
-
-        if (aspectName === undefined || aspectName === null) {
-            throw "Missing param 'aspectName' in deleteAspect";
-        }
-
-        const postBody = {};
 
         const pathParams = {
             modelName,
             aspectName
         };
 
-        const queryParams = {};
+        return this.put({
+            path: 'cmm/{modelName}/aspects/{aspectName}?select=props',
+            bodyParam,
+            pathParams
+        });
+    }
 
-        const headerParams = {};
-        const formParams = {};
+    /**
+     * Add Property into an existing type
+     */
+    addPropertyToType(modelName: string, typeName: string, properties?: CustomModelProperty[]): Promise<CustomType> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(typeName, 'typeName');
 
-        const contentTypes = ['application/json'];
-        const accepts = ['application/json'];
+        const bodyParam = {
+            'name': typeName,
+            properties
+        };
 
+        const pathParams = {
+            modelName,
+            typeName
+        };
 
-        return this.apiClient.callApi(
-            'cmm/{modelName}/aspects/{aspectName}', 'DELETE',
-            pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts
-        );
+        return this.put({
+            path: 'cmm/{modelName}/types/{typeName}?select=props',
+            bodyParam,
+            pathParams
+        });
+    }
+
+    /**
+     * Edit an existing custom model
+     */
+    updateCustomModel(modelName: string, description?: string, namespaceUri?: string, namespacePrefix?: string): Promise<any> {
+        throwIfNotDefined(modelName, 'modelName');
+
+        const bodyParam = {
+            'name': modelName,
+            description,
+            namespaceUri,
+            namespacePrefix
+        };
+
+        const pathParams = {
+            modelName
+        };
+
+        return this.put({
+            path: 'cmm/{modelName}',
+            bodyParam,
+            pathParams
+        });
+    }
+
+    /**
+     * Edit an existing custom model type
+     */
+    updateCustomType(modelName: string, typeName: string, description?: string, parentName?: string, title?: string): Promise<any> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(typeName, 'typeName');
+
+        const bodyParam = {
+            'name': modelName,
+            parentName,
+            title,
+            description
+        };
+
+        const pathParams = {
+            modelName,
+            typeName
+        };
+
+        return this.put({
+            path: 'cmm/{modelName}/types/{typeName}',
+            bodyParam,
+            pathParams
+        });
+    }
+
+    /**
+     * Edit an existing custom model aspect
+     */
+    updateCustomAspect(modelName: string, aspectName: string, description?: string, parentName?: string, title?: string): Promise<any> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(aspectName, 'aspectName');
+
+        const bodyParam = {
+            'name': modelName,
+            parentName,
+            title,
+            description
+        };
+
+        const pathParams = {
+            modelName,
+            aspectName
+        };
+
+        return this.put({
+            path: 'cmm/{modelName}/aspects/{aspectName}',
+            bodyParam,
+            pathParams
+        });
+    }
+
+    /**
+     * Get all custom models
+     */
+    getAllCustomModel(): Promise<PaginatedEntries<CustomModel>> {
+        return this.get({
+            path: 'cmm'
+        });
+    }
+
+    /**
+     * Get custom model
+     */
+    getCustomModel(modelName: string, queryParams?: any): Promise<{ entry: CustomModel }> {
+        throwIfNotDefined(modelName, 'modelName');
+
+        const pathParams = {
+            modelName
+        };
+
+        return this.get({
+            path: 'cmm/{modelName}',
+            pathParams,
+            queryParams
+        });
+    }
+
+    /**
+     * Get all custom model types
+     */
+    getAllCustomType(modelName: string): Promise<PaginatedList<CustomType>> {
+        throwIfNotDefined(modelName, 'modelName');
+
+        const pathParams = {
+            modelName
+        };
+
+        return this.get({
+            path: 'cmm/{modelName}/types',
+            pathParams
+        });
+    }
+
+    /**
+     * Get custom model type
+     */
+    getCustomType(modelName: string, typeName?: string, queryParams?: any): Promise<any> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(typeName, 'typeName');
+
+        const pathParams = {
+            modelName,
+            typeName
+        };
+
+        return this.get({
+            path: 'cmm/{modelName}/types/{typeName}',
+            pathParams,
+            queryParams
+        });
+    }
+
+    /**
+     * Get all custom model aspect
+     */
+    getAllCustomAspect(modelName: string, queryParams?: any): Promise<PaginatedList<CustomAspect>> {
+        throwIfNotDefined(modelName, 'modelName');
+
+        const pathParams = {
+            modelName
+        };
+
+        return this.get({
+            path: 'cmm/{modelName}/aspects',
+            pathParams,
+            queryParams
+        });
+    }
+
+    /**
+     * Get custom model aspect
+     */
+    getCustomAspect(modelName: string, aspectName: string, queryParams?: any): Promise<any> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(aspectName, 'aspectName');
+
+        const pathParams = {
+            modelName,
+            aspectName
+        };
+
+        return this.get({
+            path: 'cmm/{modelName}/aspects/{aspectName}',
+            pathParams,
+            queryParams
+        });
+    }
+
+    /**
+     * Get all custom model defined constraints
+     */
+    getAllCustomConstraints(modelName: string, queryParams?: any): Promise<any> {
+        throwIfNotDefined(modelName, 'modelName');
+
+        const pathParams = {
+            modelName
+        };
+
+        return this.get({
+            path: 'cmm/{modelName}/constraints',
+            pathParams,
+            queryParams
+        });
+    }
+
+    /**
+     * Get custom model defined constraints
+     */
+    getCustomConstraints(modelName: string, constraintName: string, queryParams?: any): Promise<any> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(constraintName, 'constraintName');
+
+        const pathParams = {
+            modelName,
+            constraintName
+        };
+
+        return this.get({
+            path: 'cmm/{modelName}/constraints{constraintName}',
+            pathParams,
+            queryParams
+        });
+    }
+
+    /**
+     * Delete the given custom model
+     */
+    deleteCustomModel(modelName: string): Promise<any> {
+        throwIfNotDefined(modelName, 'modelName');
+
+        const pathParams = {
+            modelName
+        };
+
+        return this.delete({
+            path: 'cmm/{modelName}',
+            pathParams
+        });
+    }
+
+    /**
+     * Delete the given custom type
+     */
+    deleteCustomType(modelName: string, typeName: string): Promise<any> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(typeName, 'typeName');
+
+        const pathParams = {
+            modelName,
+            typeName
+        };
+
+        return this.delete({
+            path: 'cmm/{modelName}/types/{typeName}',
+            pathParams
+        });
+    }
+
+    deleteCustomAspect(modelName: string, aspectName: string): Promise<any> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(aspectName, 'aspectName');
+
+        const pathParams = {
+            modelName,
+            aspectName
+        };
+
+        return this.delete({
+            path: 'cmm/{modelName}/aspects/{aspectName}',
+            pathParams
+        });
+    }
+
+    deleteCustomAspectProperty(modelName: string, aspectName: string, propertyName: string): Promise<{ entry: CustomAspect }> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(aspectName, 'aspectName');
+        throwIfNotDefined(propertyName, 'propertyName');
+
+        const bodyParam = {
+            'name': aspectName
+        };
+
+        const pathParams = {
+            modelName,
+            aspectName
+        };
+
+        const queryParams = {
+            select: 'props',
+            delete: propertyName,
+            update: true
+        };
+
+        return this.put({
+            path: 'cmm/{modelName}/aspects/{aspectName}',
+            bodyParam,
+            pathParams,
+            queryParams
+        });
+    }
+
+    deleteCustomTypeProperty(modelName: string, typeName: string, propertyName: string): Promise<{ entry: CustomType }> {
+        throwIfNotDefined(modelName, 'modelName');
+        throwIfNotDefined(typeName, 'typeName');
+        throwIfNotDefined(propertyName, 'propertyName');
+
+        const bodyParam = {
+            'name': typeName
+        };
+
+        const pathParams = {
+            modelName,
+            typeName
+        };
+
+        const queryParams = {
+            select: 'props',
+            delete: propertyName,
+            update: true
+        };
+
+        return this.put({
+            path: 'cmm/{modelName}/types/{typeName}',
+            bodyParam,
+            pathParams,
+            queryParams
+        });
     }
 
 }

--- a/src/api/content-rest-api/api/customModel.api.ts
+++ b/src/api/content-rest-api/api/customModel.api.ts
@@ -33,6 +33,7 @@ export interface CustomType {
     name?: string;
     parentName?: string;
     prefixedName?: string;
+    description?: string;
     properties?: CustomModelProperty[];
     title?: string;
 }
@@ -310,7 +311,7 @@ export class CustomModelApi extends BaseApi {
         throwIfNotDefined(typeName, 'typeName');
 
         const bodyParam = {
-            'name': modelName,
+            'name': typeName,
             parentName,
             title,
             description
@@ -336,7 +337,7 @@ export class CustomModelApi extends BaseApi {
         throwIfNotDefined(aspectName, 'aspectName');
 
         const bodyParam = {
-            'name': modelName,
+            'name': aspectName,
             parentName,
             title,
             description
@@ -399,7 +400,7 @@ export class CustomModelApi extends BaseApi {
     /**
      * Get custom model type
      */
-    getCustomType(modelName: string, typeName?: string, queryParams?: any): Promise<any> {
+    getCustomType(modelName: string, typeName?: string, queryParams?: any): Promise<{ entry: CustomType }> {
         throwIfNotDefined(modelName, 'modelName');
         throwIfNotDefined(typeName, 'typeName');
 
@@ -435,7 +436,7 @@ export class CustomModelApi extends BaseApi {
     /**
      * Get custom model aspect
      */
-    getCustomAspect(modelName: string, aspectName: string, queryParams?: any): Promise<any> {
+    getCustomAspect(modelName: string, aspectName: string, queryParams?: any): Promise<{ entry: CustomAspect }> {
         throwIfNotDefined(modelName, 'modelName');
         throwIfNotDefined(aspectName, 'aspectName');
 

--- a/src/api/content-rest-api/api/customModel.api.ts
+++ b/src/api/content-rest-api/api/customModel.api.ts
@@ -733,9 +733,8 @@ export class CustomModelApi {
      * Delete the given custom type
      */
     deleteCustomType(modelName: string, typeName: string): Promise<any> {
-
         if (modelName === undefined || modelName === null) {
-            throw "Missing param 'modelName' in getCustomConstraints";
+            throw "Missing param 'modelName' in deleteCustomType";
         }
 
         if (typeName === undefined || typeName === null) {
@@ -760,6 +759,38 @@ export class CustomModelApi {
 
         return this.apiClient.callApi(
             'cmm/{modelName}/types/{typeName}', 'DELETE',
+            pathParams, queryParams, headerParams, formParams, postBody,
+            contentTypes, accepts
+        );
+    }
+
+    deleteCustomAspect(modelName: string, aspectName: string): Promise<any> {
+        if (modelName === undefined || modelName === null) {
+            throw "Missing param 'modelName' in deleteAspect";
+        }
+
+        if (aspectName === undefined || aspectName === null) {
+            throw "Missing param 'aspectName' in deleteAspect";
+        }
+
+        const postBody = {};
+
+        const pathParams = {
+            modelName,
+            aspectName
+        };
+
+        const queryParams = {};
+
+        const headerParams = {};
+        const formParams = {};
+
+        const contentTypes = ['application/json'];
+        const accepts = ['application/json'];
+
+
+        return this.apiClient.callApi(
+            'cmm/{modelName}/aspects/{aspectName}', 'DELETE',
             pathParams, queryParams, headerParams, formParams, postBody,
             contentTypes, accepts
         );

--- a/src/api/content-rest-api/api/customModel.api.ts
+++ b/src/api/content-rest-api/api/customModel.api.ts
@@ -282,14 +282,15 @@ export class CustomModelApi extends BaseApi {
     /**
      * Edit an existing custom model
      */
-    updateCustomModel(modelName: string, description?: string, namespaceUri?: string, namespacePrefix?: string): Promise<any> {
+    updateCustomModel(modelName: string, description?: string, namespaceUri?: string, namespacePrefix?: string, author?: string): Promise<any> {
         throwIfNotDefined(modelName, 'modelName');
 
         const bodyParam = {
             'name': modelName,
             description,
             namespaceUri,
-            namespacePrefix
+            namespacePrefix,
+            author
         };
 
         const pathParams = {

--- a/src/api/content-rest-api/api/customModel.api.ts
+++ b/src/api/content-rest-api/api/customModel.api.ts
@@ -297,7 +297,7 @@ export class CustomModelApi {
     /**
      * Add Property into an existing type
      */
-    addPropertyToType(modelName: string, typeName: string, properties?: any[], aspectName?: string): Promise<any> {
+    addPropertyToType(modelName: string, typeName: string, properties?: any[]): Promise<any> {
 
         if (modelName === undefined || modelName === null) {
             throw "Missing param 'modelName' in addPropertyToType";
@@ -307,21 +307,21 @@ export class CustomModelApi {
             throw "Missing param 'typeName' in addPropertyToType";
         }
 
-        let postBody = {
-            'name': aspectName,
+        const postBody = {
+            'name': typeName,
             'properties': properties
         };
 
-        let pathParams = {
+        const pathParams = {
             'modelName': modelName,
             'typeName': typeName
         };
-        let queryParams = {};
-        let headerParams = {};
-        let formParams = {};
+        const queryParams = {};
+        const headerParams = {};
+        const formParams = {};
 
-        let contentTypes = ['application/json'];
-        let accepts = ['application/json'];
+        const contentTypes = ['application/json'];
+        const accepts = ['application/json'];
 
 
         return this.apiClient.callApi(

--- a/src/api/content-rest-api/api/downloads.api.ts
+++ b/src/api/content-rest-api/api/downloads.api.ts
@@ -18,6 +18,8 @@
 import { DownloadBodyCreate } from '../model/downloadBodyCreate';
 import { DownloadEntry } from '../model/downloadEntry';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Downloads service.
@@ -44,12 +46,9 @@ The cancel operation is done asynchronously.
     * @return Promise<{}>
     */
     cancelDownload(downloadId: string): Promise<any> {
+        throwIfNotDefined(downloadId, 'downloadId');
 
         let postBody = null;
-
-        if (downloadId === undefined || downloadId === null) {
-            throw new Error("Required param 'downloadId' in cancelDownload");
-        }
 
         let pathParams = {
             'downloadId': downloadId
@@ -109,19 +108,17 @@ The cancel operation is done asynchronously.
         * @return Promise<DownloadEntry>
         */
     createDownload(downloadBodyCreate: DownloadBodyCreate, opts?: any): Promise<DownloadEntry> {
+        throwIfNotDefined(downloadBodyCreate, 'downloadBodyCreate');
+
         opts = opts || {};
         let postBody = downloadBodyCreate;
-
-        if (downloadBodyCreate === undefined || downloadBodyCreate === null) {
-            throw new Error("Required param 'downloadBodyCreate' in createDownload");
-        }
 
         let pathParams = {
 
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -163,19 +160,17 @@ The cancel operation is done asynchronously.
         * @return Promise<DownloadEntry>
         */
     getDownload(downloadId: string, opts?: any): Promise<DownloadEntry> {
+        throwIfNotDefined(downloadId, 'downloadId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (downloadId === undefined || downloadId === null) {
-            throw new Error("Required param 'downloadId' in getDownload");
-        }
 
         let pathParams = {
             'downloadId': downloadId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/favorites.api.ts
+++ b/src/api/content-rest-api/api/favorites.api.ts
@@ -23,6 +23,8 @@ import { FavoriteSiteEntry } from '../model/favoriteSiteEntry';
 import { SiteEntry } from '../model/siteEntry';
 import { SitePaging } from '../model/sitePaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Favorites service.
@@ -121,24 +123,19 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<FavoriteEntry>
     */
     createFavorite(personId: string, favoriteBodyCreate: FavoriteBodyCreate, opts?: any): Promise<FavoriteEntry> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(favoriteBodyCreate, 'favoriteBodyCreate');
+
         opts = opts || {};
         let postBody = favoriteBodyCreate;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in createFavorite");
-        }
-
-        if (favoriteBodyCreate === undefined || favoriteBodyCreate === null) {
-            throw new Error("Required param 'favoriteBodyCreate' in createFavorite");
-        }
 
         let pathParams = {
             'personId': personId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -225,23 +222,18 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<FavoriteSiteEntry>
         */
     createSiteFavorite(personId: string, favoriteSiteBodyCreate: FavoriteSiteBodyCreate, opts?: any): Promise<FavoriteSiteEntry> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(favoriteSiteBodyCreate, 'favoriteSiteBodyCreate');
+
         opts = opts || {};
         let postBody = favoriteSiteBodyCreate;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in createSiteFavorite");
-        }
-
-        if (favoriteSiteBodyCreate === undefined || favoriteSiteBodyCreate === null) {
-            throw new Error("Required param 'favoriteSiteBodyCreate' in createSiteFavorite");
-        }
 
         let pathParams = {
             'personId': personId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -271,16 +263,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteFavorite(personId: string, favoriteId: string): Promise<any> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(favoriteId, 'favoriteId');
 
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in deleteFavorite");
-        }
-
-        if (favoriteId === undefined || favoriteId === null) {
-            throw new Error("Required param 'favoriteId' in deleteFavorite");
-        }
 
         let pathParams = {
             'personId': personId, 'favoriteId': favoriteId
@@ -319,16 +305,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteSiteFavorite(personId: string, siteId: string): Promise<any> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(siteId, 'siteId');
 
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in deleteSiteFavorite");
-        }
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in deleteSiteFavorite");
-        }
 
         let pathParams = {
             'personId': personId, 'siteId': siteId
@@ -380,24 +360,19 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<FavoriteEntry>
         */
     getFavorite(personId: string, favoriteId: string, opts?: any): Promise<FavoriteEntry> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(favoriteId, 'favoriteId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in getFavorite");
-        }
-
-        if (favoriteId === undefined || favoriteId === null) {
-            throw new Error("Required param 'favoriteId' in getFavorite");
-        }
 
         let pathParams = {
             'personId': personId, 'favoriteId': favoriteId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -443,23 +418,18 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<SiteEntry>
         */
     getFavoriteSite(personId: string, siteId: string, opts?: any): Promise<SiteEntry> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(siteId, 'siteId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in getFavoriteSite");
-        }
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in getFavoriteSite");
-        }
 
         let pathParams = {
             'personId': personId, 'siteId': siteId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -510,12 +480,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<SitePaging>
         */
     listFavoriteSitesForPerson(personId: string, opts?: any): Promise<SitePaging> {
+        throwIfNotDefined(personId, 'personId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in listFavoriteSitesForPerson");
-        }
 
         let pathParams = {
             'personId': personId
@@ -524,7 +492,7 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -600,12 +568,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<FavoritePaging>
         */
     listFavorites(personId: string, opts?: any): Promise<FavoritePaging> {
+        throwIfNotDefined(personId, 'personId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in listFavorites");
-        }
 
         let pathParams = {
             'personId': personId
@@ -615,8 +581,8 @@ parameter are returned in addition to those specified in the **fields** paramete
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/groups.api.ts
+++ b/src/api/content-rest-api/api/groups.api.ts
@@ -23,6 +23,8 @@ import { GroupMemberPaging } from '../model/groupMemberPaging';
 import { GroupMembershipBodyCreate } from '../model/groupMembershipBodyCreate';
 import { GroupPaging } from '../model/groupPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Groups service.
@@ -71,20 +73,18 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<GroupEntry>
     */
     createGroup(groupBodyCreate: GroupBodyCreate, opts?: any): Promise<GroupEntry> {
+        throwIfNotDefined(groupBodyCreate, 'groupBodyCreate');
+
         opts = opts || {};
         let postBody = groupBodyCreate;
-
-        if (groupBodyCreate === undefined || groupBodyCreate === null) {
-            throw new Error("Required param 'groupBodyCreate' in createGroup");
-        }
 
         let pathParams = {
 
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -133,23 +133,18 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<GroupMemberEntry>
         */
     createGroupMembership(groupId: string, groupMembershipBodyCreate: GroupMembershipBodyCreate, opts?: any): Promise<GroupMemberEntry> {
+        throwIfNotDefined(groupId, 'groupId');
+        throwIfNotDefined(groupMembershipBodyCreate, 'groupMembershipBodyCreate');
+
         opts = opts || {};
         let postBody = groupMembershipBodyCreate;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in createGroupMembership");
-        }
-
-        if (groupMembershipBodyCreate === undefined || groupMembershipBodyCreate === null) {
-            throw new Error("Required param 'groupMembershipBodyCreate' in createGroupMembership");
-        }
 
         let pathParams = {
             'groupId': groupId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -187,12 +182,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteGroup(groupId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(groupId, 'groupId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in deleteGroup");
-        }
 
         let cascadeDelete = opts['cascade'] ? opts['cascade'] : false;
 
@@ -237,16 +230,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteGroupMembership(groupId: string, groupMemberId: string): Promise<any> {
+        throwIfNotDefined(groupId, 'groupId');
+        throwIfNotDefined(groupMemberId, 'groupMemberId');
 
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in deleteGroupMembership");
-        }
-
-        if (groupMemberId === undefined || groupMemberId === null) {
-            throw new Error("Required param 'groupMemberId' in deleteGroupMembership");
-        }
 
         let pathParams = {
             'groupId': groupId, 'groupMemberId': groupMemberId
@@ -300,20 +287,18 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<GroupEntry>
         */
     getGroup(groupId: string, opts?: any): Promise<GroupEntry> {
+        throwIfNotDefined(groupId, 'groupId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in getGroup");
-        }
 
         let pathParams = {
             'groupId': groupId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -384,12 +369,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<GroupMemberPaging>
         */
     listGroupMemberships(groupId: string, opts?: any): Promise<GroupMemberPaging> {
+        throwIfNotDefined(groupId, 'groupId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in listGroupMemberships");
-        }
 
         let pathParams = {
             'groupId': groupId
@@ -398,9 +381,9 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
             'where': opts['where'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -497,12 +480,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<GroupPaging>
         */
     listGroupMembershipsForPerson(personId: string, opts?: any): Promise<GroupPaging> {
+        throwIfNotDefined(personId, 'personId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in listGroupMembershipsForPerson");
-        }
 
         let pathParams = {
             'personId': personId
@@ -511,10 +492,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'where': opts['where'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -617,10 +598,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'where': opts['where'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -669,24 +650,19 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<GroupEntry>
         */
     updateGroup(groupId: string, groupBodyUpdate: GroupBodyUpdate, opts?: any): Promise<GroupEntry> {
+        throwIfNotDefined(groupId, 'groupId');
+        throwIfNotDefined(groupBodyUpdate, 'groupBodyUpdate');
+
         opts = opts || {};
         let postBody = groupBodyUpdate;
-
-        if (groupId === undefined || groupId === null) {
-            throw new Error("Required param 'groupId' in updateGroup");
-        }
-
-        if (groupBodyUpdate === undefined || groupBodyUpdate === null) {
-            throw new Error("Required param 'groupBodyUpdate' in updateGroup");
-        }
 
         let pathParams = {
             'groupId': groupId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/networks.api.ts
+++ b/src/api/content-rest-api/api/networks.api.ts
@@ -18,6 +18,8 @@
 import { PersonNetworkEntry } from '../model/personNetworkEntry';
 import { PersonNetworkPaging } from '../model/personNetworkPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Networks service.
@@ -46,19 +48,17 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<PersonNetworkEntry>
     */
     getNetwork(networkId: string, opts?: any): Promise<PersonNetworkEntry> {
+        throwIfNotDefined(networkId, 'networkId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (networkId === undefined || networkId === null) {
-            throw new Error("Required param 'networkId' in getNetwork");
-        }
 
         let pathParams = {
             'networkId': networkId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -101,23 +101,18 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<PersonNetworkEntry>
         */
     getNetworkForPerson(personId: string, networkId: string, opts?: any): Promise<PersonNetworkEntry> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(networkId, 'networkId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in getNetworkForPerson");
-        }
-
-        if (networkId === undefined || networkId === null) {
-            throw new Error("Required param 'networkId' in getNetworkForPerson");
-        }
 
         let pathParams = {
             'personId': personId, 'networkId': networkId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -165,12 +160,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<PersonNetworkPaging>
         */
     listNetworksForPerson(personId: string, opts?: any): Promise<PersonNetworkPaging> {
+        throwIfNotDefined(personId, 'personId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in listNetworksForPerson");
-        }
 
         let pathParams = {
             'personId': personId
@@ -179,7 +172,7 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/nodes.api.ts
+++ b/src/api/content-rest-api/api/nodes.api.ts
@@ -28,6 +28,8 @@ import { NodeBodyUpdate } from '../model/nodeBodyUpdate';
 import { NodeChildAssociationPaging } from '../model/nodeChildAssociationPaging';
 import { NodeEntry } from '../model/nodeEntry';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
  * Nodes service.
@@ -75,24 +77,19 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeEntry>
      */
     copyNode(nodeId: string, nodeBodyCopy: NodeBodyCopy, opts?: any): Promise<NodeEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(nodeBodyCopy, 'nodeBodyCopy');
+
         opts = opts || {};
         let postBody = nodeBodyCopy;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in copyNode");
-        }
-
-        if (nodeBodyCopy === undefined || nodeBodyCopy === null) {
-            throw new Error("Required param 'nodeBodyCopy' in copyNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -176,23 +173,18 @@ export class NodesApi extends BaseApi {
      * @return Promise<AssociationEntry>
      */
     createAssociation(nodeId: string, associationBodyCreate: AssociationBody, opts?: any): Promise<AssociationEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(associationBodyCreate, 'associationBodyCreate');
+
         opts = opts || {};
         let postBody = associationBodyCreate;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in createAssociation");
-        }
-
-        if (associationBodyCreate === undefined || associationBodyCreate === null) {
-            throw new Error("Required param 'associationBodyCreate' in createAssociation");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -412,16 +404,11 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeEntry>
      */
     createNode(nodeId: string, nodeBodyCreate: NodeBodyCreate, opts?: any, formParams?: any): Promise<NodeEntry| any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(nodeBodyCreate, 'nodeBodyCreate');
+
         opts = opts || {};
         let postBody = nodeBodyCreate;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in createNode");
-        }
-
-        if (nodeBodyCreate === undefined || nodeBodyCreate === null) {
-            throw new Error("Required param 'nodeBodyCreate' in createNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -429,8 +416,8 @@ export class NodesApi extends BaseApi {
 
         let queryParams = {
             'autoRename': opts['autoRename'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -522,23 +509,18 @@ export class NodesApi extends BaseApi {
      * @return Promise<ChildAssociationEntry>
      */
     createSecondaryChildAssociation(nodeId: string, secondaryChildAssociationBodyCreate: ChildAssociationBody, opts?: any): Promise<ChildAssociationEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(secondaryChildAssociationBodyCreate, 'secondaryChildAssociationBodyCreate');
+
         opts = opts || {};
         let postBody = secondaryChildAssociationBodyCreate;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in createSecondaryChildAssociation");
-        }
-
-        if (secondaryChildAssociationBodyCreate === undefined || secondaryChildAssociationBodyCreate === null) {
-            throw new Error("Required param 'secondaryChildAssociationBodyCreate' in createSecondaryChildAssociation");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -574,16 +556,11 @@ export class NodesApi extends BaseApi {
      * @return Promise<{}>
      */
     deleteAssociation(nodeId: string, targetId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(targetId, 'targetId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in deleteAssociation");
-        }
-
-        if (targetId === undefined || targetId === null) {
-            throw new Error("Required param 'targetId' in deleteAssociation");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'targetId': targetId
@@ -633,12 +610,10 @@ export class NodesApi extends BaseApi {
      * @return Promise<{}>
      */
     deleteNode(nodeId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in deleteNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -679,16 +654,11 @@ export class NodesApi extends BaseApi {
      * @return Promise<{}>
      */
     deleteSecondaryChildAssociation(nodeId: string, childId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(childId, 'childId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in deleteSecondaryChildAssociation");
-        }
-
-        if (childId === undefined || childId === null) {
-            throw new Error("Required param 'childId' in deleteSecondaryChildAssociation");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'childId': childId
@@ -753,21 +723,19 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeEntry>
      */
     getNode(nodeId: string, opts?: any): Promise<NodeEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in getNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'relativePath': opts['relativePath'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -811,12 +779,10 @@ export class NodesApi extends BaseApi {
      * @return Promise<{}>
      */
     getNodeContent(nodeId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in getNodeContent");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -939,12 +905,10 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeChildAssociationPaging>
      */
     listNodeChildren(nodeId: string, opts?: any): Promise<NodeChildAssociationPaging> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in listNodeChildren");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -953,12 +917,12 @@ export class NodesApi extends BaseApi {
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'relativePath': opts['relativePath'],
             'includeSource': opts['includeSource'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -1028,12 +992,10 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeAssociationPaging>
      */
     listParents(nodeId: string, opts?: any): Promise<NodeAssociationPaging> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in listParents");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -1041,11 +1003,11 @@ export class NodesApi extends BaseApi {
 
         let queryParams = {
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
             'includeSource': opts['includeSource'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -1109,12 +1071,10 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeChildAssociationPaging>
      */
     listSecondaryChildren(nodeId: string, opts?: any): Promise<NodeChildAssociationPaging> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in listSecondaryChildren");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -1122,11 +1082,11 @@ export class NodesApi extends BaseApi {
 
         let queryParams = {
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
             'includeSource': opts['includeSource'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -1179,12 +1139,10 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeAssociationPaging>
      */
     listSourceAssociations(nodeId: string, opts?: any): Promise<NodeAssociationPaging> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in listSourceAssociations");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -1192,8 +1150,8 @@ export class NodesApi extends BaseApi {
 
         let queryParams = {
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -1246,12 +1204,10 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeAssociationPaging>
      */
     listTargetAssociations(nodeId: string, opts?: any): Promise<NodeAssociationPaging> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in listTargetAssociations");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -1259,8 +1215,8 @@ export class NodesApi extends BaseApi {
 
         let queryParams = {
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -1333,24 +1289,19 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeEntry>
      */
     lockNode(nodeId: string, nodeBodyLock: NodeBodyLock, opts?: any): Promise<NodeEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(nodeBodyLock, 'nodeBodyLock');
+
         opts = opts || {};
         let postBody = nodeBodyLock;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in lockNode");
-        }
-
-        if (nodeBodyLock === undefined || nodeBodyLock === null) {
-            throw new Error("Required param 'nodeBodyLock' in lockNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -1408,24 +1359,19 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeEntry>
      */
     moveNode(nodeId: string, nodeBodyMove: NodeBodyMove, opts?: any): Promise<NodeEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(nodeBodyMove, 'nodeBodyMove');
+
         opts = opts || {};
         let postBody = nodeBodyMove;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in moveNode");
-        }
-
-        if (nodeBodyMove === undefined || nodeBodyMove === null) {
-            throw new Error("Required param 'nodeBodyMove' in moveNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -1478,20 +1424,18 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeEntry>
      */
     unlockNode(nodeId: string, opts?: any): Promise<NodeEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in unlockNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -1577,24 +1521,19 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeEntry>
      */
     updateNode(nodeId: string, nodeBodyUpdate: NodeBodyUpdate, opts?: any): Promise<NodeEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(nodeBodyUpdate, 'nodeBodyUpdate');
+
         opts = opts || {};
         let postBody = nodeBodyUpdate;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in updateNode");
-        }
-
-        if (nodeBodyUpdate === undefined || nodeBodyUpdate === null) {
-            throw new Error("Required param 'nodeBodyUpdate' in updateNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};
@@ -1666,16 +1605,11 @@ export class NodesApi extends BaseApi {
      * @return Promise<NodeEntry>
      */
     updateNodeContent(nodeId: string, contentBodyUpdate: any, opts?: any): Promise<NodeEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(contentBodyUpdate, 'contentBodyUpdate');
+
         opts = opts || {};
         let postBody = contentBodyUpdate;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in updateNodeContent");
-        }
-
-        if (contentBodyUpdate === undefined || contentBodyUpdate === null) {
-            throw new Error("Required param 'contentBodyUpdate' in updateNodeContent");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -1685,8 +1619,8 @@ export class NodesApi extends BaseApi {
             'majorVersion': opts['majorVersion'],
             'comment': opts['comment'],
             'name': opts['name'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {};

--- a/src/api/content-rest-api/api/people.api.ts
+++ b/src/api/content-rest-api/api/people.api.ts
@@ -22,6 +22,8 @@ import { PersonBodyUpdate } from '../model/personBodyUpdate';
 import { PersonEntry } from '../model/personEntry';
 import { PersonPaging } from '../model/personPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * People service.
@@ -73,19 +75,17 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<PersonEntry>
     */
     createPerson(personBodyCreate: PersonBodyCreate, opts?: any): Promise<PersonEntry> {
+        throwIfNotDefined(personBodyCreate, 'personBodyCreate');
+
         opts = opts || {};
         let postBody = personBodyCreate;
-
-        if (personBodyCreate === undefined || personBodyCreate === null) {
-            throw new Error("Required param 'personBodyCreate' in createPerson");
-        }
 
         let pathParams = {
 
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -118,12 +118,9 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteAvatarImage(personId: string): Promise<any> {
+        throwIfNotDefined(personId, 'personId');
 
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in deleteAvatarImage");
-        }
 
         let pathParams = {
             'personId': personId
@@ -178,12 +175,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     getAvatarImage(personId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(personId, 'personId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in getAvatarImage");
-        }
 
         let pathParams = {
             'personId': personId
@@ -233,19 +228,17 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<PersonEntry>
         */
     getPerson(personId: string, opts?: any): Promise<PersonEntry> {
+        throwIfNotDefined(personId, 'personId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in getPerson");
-        }
 
         let pathParams = {
             'personId': personId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -325,9 +318,9 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -372,16 +365,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     requestPasswordReset(personId: string, clientBody: ClientBody): Promise<any> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(clientBody, 'clientBody');
 
         let postBody = clientBody;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in requestPasswordReset");
-        }
-
-        if (clientBody === undefined || clientBody === null) {
-            throw new Error("Required param 'clientBody' in requestPasswordReset");
-        }
 
         let pathParams = {
             'personId': personId
@@ -427,16 +414,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     resetPassword(personId: string, passwordResetBody: PasswordResetBody): Promise<any> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(passwordResetBody, 'passwordResetBody');
 
         let postBody = passwordResetBody;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in resetPassword");
-        }
-
-        if (passwordResetBody === undefined || passwordResetBody === null) {
-            throw new Error("Required param 'passwordResetBody' in resetPassword");
-        }
 
         let pathParams = {
             'personId': personId
@@ -479,16 +460,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     updateAvatarImage(personId: string, contentBodyUpdate: string): Promise<any> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(contentBodyUpdate, 'contentBodyUpdate');
 
         let postBody = contentBodyUpdate;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in updateAvatarImage");
-        }
-
-        if (contentBodyUpdate === undefined || contentBodyUpdate === null) {
-            throw new Error("Required param 'contentBodyUpdate' in updateAvatarImage");
-        }
 
         let pathParams = {
             'personId': personId
@@ -562,23 +537,18 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<PersonEntry>
         */
     updatePerson(personId: string, personBodyUpdate: PersonBodyUpdate, opts?: any): Promise<PersonEntry> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(personBodyUpdate, 'personBodyUpdate');
+
         opts = opts || {};
         let postBody = personBodyUpdate;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in updatePerson");
-        }
-
-        if (personBodyUpdate === undefined || personBodyUpdate === null) {
-            throw new Error("Required param 'personBodyUpdate' in updatePerson");
-        }
 
         let pathParams = {
             'personId': personId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/preferences.api.ts
+++ b/src/api/content-rest-api/api/preferences.api.ts
@@ -18,6 +18,8 @@
 import { PreferenceEntry } from '../model/preferenceEntry';
 import { PreferencePaging } from '../model/preferencePaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Preferences service.
@@ -50,23 +52,18 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<PreferenceEntry>
     */
     getPreference(personId: string, preferenceName: string, opts?: any): Promise<PreferenceEntry> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(preferenceName, 'preferenceName');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in getPreference");
-        }
-
-        if (preferenceName === undefined || preferenceName === null) {
-            throw new Error("Required param 'preferenceName' in getPreference");
-        }
 
         let pathParams = {
             'personId': personId, 'preferenceName': preferenceName
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -117,12 +114,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<PreferencePaging>
         */
     listPreferences(personId: string, opts?: any): Promise<PreferencePaging> {
+        throwIfNotDefined(personId, 'personId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in listPreferences");
-        }
 
         let pathParams = {
             'personId': personId
@@ -131,7 +126,7 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/probes.api.ts
+++ b/src/api/content-rest-api/api/probes.api.ts
@@ -17,6 +17,7 @@
 
 import { ProbeEntry } from '../model/probeEntry';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Probes service.
@@ -44,12 +45,9 @@ The liveness probe should then be used to check the repository is still respondi
     * @return Promise<ProbeEntry>
     */
     getProbe(probeId: string): Promise<ProbeEntry> {
+        throwIfNotDefined(probeId, 'probeId');
 
         let postBody = null;
-
-        if (probeId === undefined || probeId === null) {
-            throw new Error("Required param 'probeId' in getProbe");
-        }
 
         let pathParams = {
             'probeId': probeId

--- a/src/api/content-rest-api/api/queries.api.ts
+++ b/src/api/content-rest-api/api/queries.api.ts
@@ -19,6 +19,8 @@ import { NodePaging } from '../model/nodePaging';
 import { PersonPaging } from '../model/personPaging';
 import { SitePaging } from '../model/sitePaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Queries service.
@@ -95,12 +97,10 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<NodePaging>
     */
     findNodes(term: string, opts?: any): Promise<NodePaging> {
+        throwIfNotDefined(term, 'term');
+
         opts = opts || {};
         let postBody = null;
-
-        if (term === undefined || term === null) {
-            throw new Error("Required param 'term' in findNodes");
-        }
 
         let pathParams = {
 
@@ -112,9 +112,9 @@ parameter are returned in addition to those specified in the **fields** paramete
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
             'nodeType': opts['nodeType'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -182,12 +182,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<PersonPaging>
         */
     findPeople(term: string, opts?: any): Promise<PersonPaging> {
+        throwIfNotDefined(term, 'term');
+
         opts = opts || {};
         let postBody = null;
-
-        if (term === undefined || term === null) {
-            throw new Error("Required param 'term' in findPeople");
-        }
 
         let pathParams = {
 
@@ -197,8 +195,8 @@ parameter are returned in addition to those specified in the **fields** paramete
             'term': term,
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv'),
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv')
         };
 
         let headerParams = {
@@ -266,12 +264,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<SitePaging>
         */
     findSites(term: string, opts?: any): Promise<SitePaging> {
+        throwIfNotDefined(term, 'term');
+
         opts = opts || {};
         let postBody = null;
-
-        if (term === undefined || term === null) {
-            throw new Error("Required param 'term' in findSites");
-        }
 
         let pathParams = {
 
@@ -281,8 +277,8 @@ parameter are returned in addition to those specified in the **fields** paramete
             'term': term,
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/ratings.api.ts
+++ b/src/api/content-rest-api/api/ratings.api.ts
@@ -19,6 +19,8 @@ import { RatingBody } from '../model/ratingBody';
 import { RatingEntry } from '../model/ratingEntry';
 import { RatingPaging } from '../model/ratingPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Ratings service.
@@ -57,23 +59,18 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<RatingEntry>
     */
     createRating(nodeId: string, ratingBodyCreate: RatingBody, opts?: any): Promise<RatingEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(ratingBodyCreate, 'ratingBodyCreate');
+
         opts = opts || {};
         let postBody = ratingBodyCreate;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in createRating");
-        }
-
-        if (ratingBodyCreate === undefined || ratingBodyCreate === null) {
-            throw new Error("Required param 'ratingBodyCreate' in createRating");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -100,16 +97,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteRating(nodeId: string, ratingId: string): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(ratingId, 'ratingId');
 
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in deleteRating");
-        }
-
-        if (ratingId === undefined || ratingId === null) {
-            throw new Error("Required param 'ratingId' in deleteRating");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'ratingId': ratingId
@@ -155,23 +146,18 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RatingEntry>
         */
     getRating(nodeId: string, ratingId: string, opts?: any): Promise<RatingEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(ratingId, 'ratingId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in getRating");
-        }
-
-        if (ratingId === undefined || ratingId === null) {
-            throw new Error("Required param 'ratingId' in getRating");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'ratingId': ratingId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -216,12 +202,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RatingPaging>
         */
     listRatings(nodeId: string, opts?: any): Promise<RatingPaging> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in listRatings");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -230,7 +214,7 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/renditions.api.ts
+++ b/src/api/content-rest-api/api/renditions.api.ts
@@ -19,6 +19,7 @@ import { RenditionBodyCreate } from '../model/renditionBodyCreate';
 import { RenditionEntry } from '../model/renditionEntry';
 import { RenditionPaging } from '../model/renditionPaging';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Renditions service.
@@ -44,16 +45,10 @@ JSON
     * @return Promise<{}>
     */
     createRendition(nodeId: string, renditionBodyCreate: RenditionBodyCreate): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(renditionBodyCreate, 'renditionBodyCreate');
 
         let postBody = renditionBodyCreate;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in createRendition");
-        }
-
-        if (renditionBodyCreate === undefined || renditionBodyCreate === null) {
-            throw new Error("Required param 'renditionBodyCreate' in createRendition");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -89,16 +84,10 @@ JSON
         * @return Promise<RenditionEntry>
         */
     getRendition(nodeId: string, renditionId: string): Promise<RenditionEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(renditionId, 'renditionId');
 
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in getRendition");
-        }
-
-        if (renditionId === undefined || renditionId === null) {
-            throw new Error("Required param 'renditionId' in getRendition");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'renditionId': renditionId
@@ -155,16 +144,11 @@ JSON
         * @return Promise<{}>
         */
     getRenditionContent(nodeId: string, renditionId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(renditionId, 'renditionId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in getRenditionContent");
-        }
-
-        if (renditionId === undefined || renditionId === null) {
-            throw new Error("Required param 'renditionId' in getRenditionContent");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'renditionId': renditionId
@@ -212,12 +196,10 @@ JSON
         * @return Promise<RenditionPaging>
         */
     listRenditions(nodeId: string, opts?: any): Promise<RenditionPaging> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in listRenditions");
-        }
 
         let pathParams = {
             'nodeId': nodeId

--- a/src/api/content-rest-api/api/sharedlinks.api.ts
+++ b/src/api/content-rest-api/api/sharedlinks.api.ts
@@ -22,6 +22,8 @@ import { SharedLinkBodyEmail } from '../model/sharedLinkBodyEmail';
 import { SharedLinkEntry } from '../model/sharedLinkEntry';
 import { SharedLinkPaging } from '../model/sharedLinkPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Sharedlinks service.
@@ -104,20 +106,18 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<SharedLinkEntry>
     */
     createSharedLink(sharedLinkBodyCreate: SharedLinkBodyCreate, opts?: any): Promise<SharedLinkEntry> {
+        throwIfNotDefined(sharedLinkBodyCreate, 'sharedLinkBodyCreate');
+
         opts = opts || {};
         let postBody = sharedLinkBodyCreate;
-
-        if (sharedLinkBodyCreate === undefined || sharedLinkBodyCreate === null) {
-            throw new Error("Required param 'sharedLinkBodyCreate' in createSharedLink");
-        }
 
         let pathParams = {
 
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -146,12 +146,9 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteSharedLink(sharedId: string): Promise<any> {
+        throwIfNotDefined(sharedId, 'sharedId');
 
         let postBody = null;
-
-        if (sharedId === undefined || sharedId === null) {
-            throw new Error("Required param 'sharedId' in deleteSharedLink");
-        }
 
         let pathParams = {
             'sharedId': sharedId
@@ -214,16 +211,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     emailSharedLink(sharedId: string, sharedLinkBodyEmail: SharedLinkBodyEmail): Promise<any> {
+        throwIfNotDefined(sharedId, 'sharedId');
+        throwIfNotDefined(sharedLinkBodyEmail, 'sharedLinkBodyEmail');
 
         let postBody = sharedLinkBodyEmail;
-
-        if (sharedId === undefined || sharedId === null) {
-            throw new Error("Required param 'sharedId' in emailSharedLink");
-        }
-
-        if (sharedLinkBodyEmail === undefined || sharedLinkBodyEmail === null) {
-            throw new Error("Required param 'sharedLinkBodyEmail' in emailSharedLink");
-        }
 
         let pathParams = {
             'sharedId': sharedId
@@ -273,19 +264,17 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<SharedLinkEntry>
         */
     getSharedLink(sharedId: string, opts?: any): Promise<SharedLinkEntry> {
+        throwIfNotDefined(sharedId, 'sharedId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (sharedId === undefined || sharedId === null) {
-            throw new Error("Required param 'sharedId' in getSharedLink");
-        }
 
         let pathParams = {
             'sharedId': sharedId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -333,12 +322,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     getSharedLinkContent(sharedId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(sharedId, 'sharedId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (sharedId === undefined || sharedId === null) {
-            throw new Error("Required param 'sharedId' in getSharedLinkContent");
-        }
 
         let pathParams = {
             'sharedId': sharedId
@@ -380,16 +367,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RenditionEntry>
         */
     getSharedLinkRendition(sharedId: string, renditionId: string): Promise<RenditionEntry> {
+        throwIfNotDefined(sharedId, 'sharedId');
+        throwIfNotDefined(renditionId, 'renditionId');
 
         let postBody = null;
-
-        if (sharedId === undefined || sharedId === null) {
-            throw new Error("Required param 'sharedId' in getSharedLinkRendition");
-        }
-
-        if (renditionId === undefined || renditionId === null) {
-            throw new Error("Required param 'renditionId' in getSharedLinkRendition");
-        }
 
         let pathParams = {
             'sharedId': sharedId, 'renditionId': renditionId
@@ -444,16 +425,11 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     getSharedLinkRenditionContent(sharedId: string, renditionId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(sharedId, 'sharedId');
+        throwIfNotDefined(renditionId, 'renditionId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (sharedId === undefined || sharedId === null) {
-            throw new Error("Required param 'sharedId' in getSharedLinkRenditionContent");
-        }
-
-        if (renditionId === undefined || renditionId === null) {
-            throw new Error("Required param 'renditionId' in getSharedLinkRenditionContent");
-        }
 
         let pathParams = {
             'sharedId': sharedId, 'renditionId': renditionId
@@ -494,12 +470,9 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RenditionPaging>
         */
     listSharedLinkRenditions(sharedId: string): Promise<RenditionPaging> {
+        throwIfNotDefined(sharedId, 'sharedId');
 
         let postBody = null;
-
-        if (sharedId === undefined || sharedId === null) {
-            throw new Error("Required param 'sharedId' in listSharedLinkRenditions");
-        }
 
         let pathParams = {
             'sharedId': sharedId
@@ -577,8 +550,8 @@ parameter are returned in addition to those specified in the **fields** paramete
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/sites.api.ts
+++ b/src/api/content-rest-api/api/sites.api.ts
@@ -33,6 +33,8 @@ import { SitePaging } from '../model/sitePaging';
 import { SiteRoleEntry } from '../model/siteRoleEntry';
 import { SiteRolePaging } from '../model/siteRolePaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Sites service.
@@ -53,16 +55,11 @@ export class SitesApi extends BaseApi {
     * @return Promise<{}>
     */
     approveSiteMembershipRequest(siteId: string, inviteeId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(siteId, 'siteId');
+        throwIfNotDefined(inviteeId, 'inviteeId');
+
         opts = opts || {};
         let postBody = opts['siteMembershipApprovalBody'];
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in approveSiteMembershipRequest");
-        }
-
-        if (inviteeId === undefined || inviteeId === null) {
-            throw new Error("Required param 'inviteeId' in approveSiteMembershipRequest");
-        }
 
         let pathParams = {
             'siteId': siteId, 'inviteeId': inviteeId
@@ -134,12 +131,10 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteEntry>
         */
     createSite(siteBodyCreate: SiteBodyCreate, opts?: any): Promise<SiteEntry> {
+        throwIfNotDefined(siteBodyCreate, 'siteBodyCreate');
+
         opts = opts || {};
         let postBody = siteBodyCreate;
-
-        if (siteBodyCreate === undefined || siteBodyCreate === null) {
-            throw new Error("Required param 'siteBodyCreate' in createSite");
-        }
 
         let pathParams = {
 
@@ -148,7 +143,7 @@ export class SitesApi extends BaseApi {
         let queryParams = {
             'skipConfiguration': opts['skipConfiguration'],
             'skipAddToFavorites': opts['skipAddToFavorites'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -239,23 +234,18 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteMemberEntry>
         */
     createSiteMembership(siteId: string, siteMembershipBodyCreate: SiteMembershipBodyCreate, opts?: any): Promise<SiteMemberEntry> {
+        throwIfNotDefined(siteId, 'siteId');
+        throwIfNotDefined(siteMembershipBodyCreate, 'siteMembershipBodyCreate');
+
         opts = opts || {};
         let postBody = siteMembershipBodyCreate;
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in createSiteMembership");
-        }
-
-        if (siteMembershipBodyCreate === undefined || siteMembershipBodyCreate === null) {
-            throw new Error("Required param 'siteMembershipBodyCreate' in createSiteMembership");
-        }
 
         let pathParams = {
             'siteId': siteId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -348,23 +338,18 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteMembershipRequestEntry>
         */
     createSiteMembershipRequestForPerson(personId: string, siteMembershipRequestBodyCreate: SiteMembershipRequestBodyCreate, opts?: any): Promise<SiteMembershipRequestEntry> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(siteMembershipRequestBodyCreate, 'siteMembershipRequestBodyCreate');
+
         opts = opts || {};
         let postBody = siteMembershipRequestBodyCreate;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in createSiteMembershipRequestForPerson");
-        }
-
-        if (siteMembershipRequestBodyCreate === undefined || siteMembershipRequestBodyCreate === null) {
-            throw new Error("Required param 'siteMembershipRequestBodyCreate' in createSiteMembershipRequestForPerson");
-        }
 
         let pathParams = {
             'personId': personId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -395,12 +380,10 @@ export class SitesApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteSite(siteId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(siteId, 'siteId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in deleteSite");
-        }
 
         let pathParams = {
             'siteId': siteId
@@ -437,16 +420,10 @@ export class SitesApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteSiteMembership(siteId: string, personId: string): Promise<any> {
+        throwIfNotDefined(siteId, 'siteId');
+        throwIfNotDefined(personId, 'personId');
 
         let postBody = null;
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in deleteSiteMembership");
-        }
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in deleteSiteMembership");
-        }
 
         let pathParams = {
             'siteId': siteId, 'personId': personId
@@ -482,16 +459,10 @@ export class SitesApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteSiteMembershipForPerson(personId: string, siteId: string): Promise<any> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(siteId, 'siteId');
 
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in deleteSiteMembershipForPerson");
-        }
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in deleteSiteMembershipForPerson");
-        }
 
         let pathParams = {
             'personId': personId, 'siteId': siteId
@@ -527,16 +498,10 @@ export class SitesApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteSiteMembershipRequestForPerson(personId: string, siteId: string): Promise<any> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(siteId, 'siteId');
 
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in deleteSiteMembershipRequestForPerson");
-        }
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in deleteSiteMembershipRequestForPerson");
-        }
 
         let pathParams = {
             'personId': personId, 'siteId': siteId
@@ -595,20 +560,18 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteEntry>
         */
     getSite(siteId: string, opts?: any): Promise<SiteEntry> {
+        throwIfNotDefined(siteId, 'siteId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in getSite");
-        }
 
         let pathParams = {
             'siteId': siteId
         };
 
         let queryParams = {
-            'relations': this.apiClient.buildCollectionParam(opts['relations'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'relations': buildCollectionParam(opts['relations'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -648,23 +611,18 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteContainerEntry>
         */
     getSiteContainer(siteId: string, containerId: string, opts?: any): Promise<SiteContainerEntry> {
+        throwIfNotDefined(siteId, 'siteId');
+        throwIfNotDefined(containerId, 'containerId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in getSiteContainer");
-        }
-
-        if (containerId === undefined || containerId === null) {
-            throw new Error("Required param 'containerId' in getSiteContainer");
-        }
 
         let pathParams = {
             'siteId': siteId, 'containerId': containerId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -707,23 +665,18 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteMemberEntry>
         */
     getSiteMembership(siteId: string, personId: string, opts?: any): Promise<SiteMemberEntry> {
+        throwIfNotDefined(siteId, 'siteId');
+        throwIfNotDefined(personId, 'personId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in getSiteMembership");
-        }
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in getSiteMembership");
-        }
 
         let pathParams = {
             'siteId': siteId, 'personId': personId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -753,16 +706,10 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteRoleEntry>
         */
     getSiteMembershipForPerson(personId: string, siteId: string): Promise<SiteRoleEntry> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(siteId, 'siteId');
 
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in getSiteMembershipForPerson");
-        }
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in getSiteMembershipForPerson");
-        }
 
         let pathParams = {
             'personId': personId, 'siteId': siteId
@@ -811,23 +758,18 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteMembershipRequestEntry>
         */
     getSiteMembershipRequestForPerson(personId: string, siteId: string, opts?: any): Promise<SiteMembershipRequestEntry> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(siteId, 'siteId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in getSiteMembershipRequestForPerson");
-        }
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in getSiteMembershipRequestForPerson");
-        }
 
         let pathParams = {
             'personId': personId, 'siteId': siteId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -902,7 +844,7 @@ export class SitesApi extends BaseApi {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
             'where': opts['where'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -947,12 +889,10 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteContainerPaging>
         */
     listSiteContainers(siteId: string, opts?: any): Promise<SiteContainerPaging> {
+        throwIfNotDefined(siteId, 'siteId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in listSiteContainers");
-        }
 
         let pathParams = {
             'siteId': siteId
@@ -961,7 +901,7 @@ export class SitesApi extends BaseApi {
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -1009,12 +949,10 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteMembershipRequestPaging>
         */
     listSiteMembershipRequestsForPerson(personId: string, opts?: any): Promise<SiteMembershipRequestPaging> {
+        throwIfNotDefined(personId, 'personId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in listSiteMembershipRequestsForPerson");
-        }
 
         let pathParams = {
             'personId': personId
@@ -1023,7 +961,7 @@ export class SitesApi extends BaseApi {
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -1068,12 +1006,10 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteMemberPaging>
         */
     listSiteMemberships(siteId: string, opts?: any): Promise<SiteMemberPaging> {
+        throwIfNotDefined(siteId, 'siteId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in listSiteMemberships");
-        }
 
         let pathParams = {
             'siteId': siteId
@@ -1082,7 +1018,7 @@ export class SitesApi extends BaseApi {
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -1162,12 +1098,10 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteRolePaging>
         */
     listSiteMembershipsForPerson(personId: string, opts?: any): Promise<SiteRolePaging> {
+        throwIfNotDefined(personId, 'personId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in listSiteMembershipsForPerson");
-        }
 
         let pathParams = {
             'personId': personId
@@ -1176,9 +1110,9 @@ export class SitesApi extends BaseApi {
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
-            'relations': this.apiClient.buildCollectionParam(opts['relations'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
+            'relations': buildCollectionParam(opts['relations'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv'),
             'where': opts['where']
         };
 
@@ -1278,9 +1212,9 @@ export class SitesApi extends BaseApi {
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
-            'relations': this.apiClient.buildCollectionParam(opts['relations'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
+            'relations': buildCollectionParam(opts['relations'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv'),
             'where': opts['where']
         };
 
@@ -1312,16 +1246,11 @@ export class SitesApi extends BaseApi {
         * @return Promise<{}>
         */
     rejectSiteMembershipRequest(siteId: string, inviteeId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(siteId, 'siteId');
+        throwIfNotDefined(inviteeId, 'inviteeId');
+
         opts = opts || {};
         let postBody = opts['siteMembershipRejectionBody'];
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in rejectSiteMembershipRequest");
-        }
-
-        if (inviteeId === undefined || inviteeId === null) {
-            throw new Error("Required param 'inviteeId' in rejectSiteMembershipRequest");
-        }
 
         let pathParams = {
             'siteId': siteId, 'inviteeId': inviteeId
@@ -1373,23 +1302,18 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteEntry>
         */
     updateSite(siteId: string, siteBodyUpdate: SiteBodyUpdate, opts?: any): Promise<SiteEntry> {
+        throwIfNotDefined(siteId, 'siteId');
+        throwIfNotDefined(siteBodyUpdate, 'siteBodyUpdate');
+
         opts = opts || {};
         let postBody = siteBodyUpdate;
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in updateSite");
-        }
-
-        if (siteBodyUpdate === undefined || siteBodyUpdate === null) {
-            throw new Error("Required param 'siteBodyUpdate' in updateSite");
-        }
 
         let pathParams = {
             'siteId': siteId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -1440,27 +1364,19 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteMemberEntry>
         */
     updateSiteMembership(siteId: string, personId: string, siteMembershipBodyUpdate: SiteMembershipBodyUpdate, opts?: any): Promise<SiteMemberEntry> {
+        throwIfNotDefined(siteId, 'siteId');
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(siteMembershipBodyUpdate, 'siteMembershipBodyUpdate');
+
         opts = opts || {};
         let postBody = siteMembershipBodyUpdate;
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in updateSiteMembership");
-        }
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in updateSiteMembership");
-        }
-
-        if (siteMembershipBodyUpdate === undefined || siteMembershipBodyUpdate === null) {
-            throw new Error("Required param 'siteMembershipBodyUpdate' in updateSiteMembership");
-        }
 
         let pathParams = {
             'siteId': siteId, 'personId': personId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -1504,27 +1420,19 @@ export class SitesApi extends BaseApi {
         * @return Promise<SiteMembershipRequestEntry>
         */
     updateSiteMembershipRequestForPerson(personId: string, siteId: string, siteMembershipRequestBodyUpdate: SiteMembershipRequestBodyUpdate, opts?: any): Promise<SiteMembershipRequestEntry> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(siteId, 'siteId');
+        throwIfNotDefined(siteMembershipRequestBodyUpdate, 'siteMembershipRequestBodyUpdate');
+
         opts = opts || {};
         let postBody = siteMembershipRequestBodyUpdate;
-
-        if (personId === undefined || personId === null) {
-            throw new Error("Required param 'personId' in updateSiteMembershipRequestForPerson");
-        }
-
-        if (siteId === undefined || siteId === null) {
-            throw new Error("Required param 'siteId' in updateSiteMembershipRequestForPerson");
-        }
-
-        if (siteMembershipRequestBodyUpdate === undefined || siteMembershipRequestBodyUpdate === null) {
-            throw new Error("Required param 'siteMembershipRequestBodyUpdate' in updateSiteMembershipRequestForPerson");
-        }
 
         let pathParams = {
             'personId': personId, 'siteId': siteId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/tags.api.ts
+++ b/src/api/content-rest-api/api/tags.api.ts
@@ -19,6 +19,8 @@ import { TagBody } from '../model/tagBody';
 import { TagEntry } from '../model/tagEntry';
 import { TagPaging } from '../model/tagPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Tags service.
@@ -94,23 +96,18 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<TagEntry>
     */
     createTagForNode(nodeId: string, tagBodyCreate: TagBody, opts?: any): Promise<TagEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(tagBodyCreate, 'tagBodyCreate');
+
         opts = opts || {};
         let postBody = tagBodyCreate;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in createTagForNode");
-        }
-
-        if (tagBodyCreate === undefined || tagBodyCreate === null) {
-            throw new Error("Required param 'tagBodyCreate' in createTagForNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -137,16 +134,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteTagFromNode(nodeId: string, tagId: string): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(tagId, 'tagId');
 
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in deleteTagFromNode");
-        }
-
-        if (tagId === undefined || tagId === null) {
-            throw new Error("Required param 'tagId' in deleteTagFromNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'tagId': tagId
@@ -191,19 +182,17 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<TagEntry>
         */
     getTag(tagId: string, opts?: any): Promise<TagEntry> {
+        throwIfNotDefined(tagId, 'tagId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (tagId === undefined || tagId === null) {
-            throw new Error("Required param 'tagId' in getTag");
-        }
 
         let pathParams = {
             'tagId': tagId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -263,8 +252,8 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv'),
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv')
         };
 
         let headerParams = {
@@ -309,12 +298,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<TagPaging>
         */
     listTagsForNode(nodeId: string, opts?: any): Promise<TagPaging> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in listTagsForNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -323,7 +310,7 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -363,23 +350,18 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<TagEntry>
         */
     updateTag(tagId: string, tagBodyUpdate: TagBody, opts?: any): Promise<TagEntry> {
+        throwIfNotDefined(tagId, 'tagId');
+        throwIfNotDefined(tagBodyUpdate, 'tagBodyUpdate');
+
         opts = opts || {};
         let postBody = tagBodyUpdate;
-
-        if (tagId === undefined || tagId === null) {
-            throw new Error("Required param 'tagId' in updateTag");
-        }
-
-        if (tagBodyUpdate === undefined || tagBodyUpdate === null) {
-            throw new Error("Required param 'tagBodyUpdate' in updateTag");
-        }
 
         let pathParams = {
             'tagId': tagId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/trashcan.api.ts
+++ b/src/api/content-rest-api/api/trashcan.api.ts
@@ -21,6 +21,8 @@ import { NodeEntry } from '../model/nodeEntry';
 import { RenditionEntry } from '../model/renditionEntry';
 import { RenditionPaging } from '../model/renditionPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Trashcan service.
@@ -39,12 +41,9 @@ Permanently deletes the deleted node **nodeId**.
     * @return Promise<{}>
     */
     deleteDeletedNode(nodeId: string): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
 
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in deleteDeletedNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -80,16 +79,10 @@ Permanently deletes the deleted node **nodeId**.
         * @return Promise<RenditionEntry>
         */
     getArchivedNodeRendition(nodeId: string, renditionId: string): Promise<RenditionEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(renditionId, 'renditionId');
 
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in getArchivedNodeRendition");
-        }
-
-        if (renditionId === undefined || renditionId === null) {
-            throw new Error("Required param 'renditionId' in getArchivedNodeRendition");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'renditionId': renditionId
@@ -146,16 +139,11 @@ Permanently deletes the deleted node **nodeId**.
         * @return Promise<{}>
         */
     getArchivedNodeRenditionContent(nodeId: string, renditionId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(renditionId, 'renditionId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in getArchivedNodeRenditionContent");
-        }
-
-        if (renditionId === undefined || renditionId === null) {
-            throw new Error("Required param 'renditionId' in getArchivedNodeRenditionContent");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'renditionId': renditionId
@@ -202,19 +190,17 @@ Permanently deletes the deleted node **nodeId**.
         * @return Promise<DeletedNodeEntry>
         */
     getDeletedNode(nodeId: string, opts?: any): Promise<DeletedNodeEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in getDeletedNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv')
         };
 
         let headerParams = {
@@ -260,12 +246,10 @@ Permanently deletes the deleted node **nodeId**.
         * @return Promise<{}>
         */
     getDeletedNodeContent(nodeId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in getDeletedNodeContent");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -312,12 +296,10 @@ Permanently deletes the deleted node **nodeId**.
         * @return Promise<RenditionPaging>
         */
     listDeletedNodeRenditions(nodeId: string, opts?: any): Promise<RenditionPaging> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in listDeletedNodeRenditions");
-        }
 
         let pathParams = {
             'nodeId': nodeId
@@ -384,7 +366,7 @@ Permanently deletes the deleted node **nodeId**.
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv')
         };
 
         let headerParams = {
@@ -437,19 +419,17 @@ Permanently deletes the deleted node **nodeId**.
         * @return Promise<NodeEntry>
         */
     restoreDeletedNode(nodeId: string, opts?: any): Promise<NodeEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = opts['deletedNodeBodyRestore'];
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in restoreDeletedNode");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/api/versions.api.ts
+++ b/src/api/content-rest-api/api/versions.api.ts
@@ -19,6 +19,8 @@ import { RevertBody } from '../model/revertBody';
 import { VersionEntry } from '../model/versionEntry';
 import { VersionPaging } from '../model/versionPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Versions service.
@@ -48,16 +50,10 @@ params (majorVersion and comment) on a subsequent file content update.
     * @return Promise<{}>
     */
     deleteVersion(nodeId: string, versionId: string): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(versionId, 'versionId');
 
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in deleteVersion");
-        }
-
-        if (versionId === undefined || versionId === null) {
-            throw new Error("Required param 'versionId' in deleteVersion");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'versionId': versionId
@@ -93,16 +89,10 @@ params (majorVersion and comment) on a subsequent file content update.
         * @return Promise<VersionEntry>
         */
     getVersion(nodeId: string, versionId: string): Promise<VersionEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(versionId, 'versionId');
 
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in getVersion");
-        }
-
-        if (versionId === undefined || versionId === null) {
-            throw new Error("Required param 'versionId' in getVersion");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'versionId': versionId
@@ -155,16 +145,11 @@ params (majorVersion and comment) on a subsequent file content update.
         * @return Promise<{}>
         */
     getVersionContent(nodeId: string, versionId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(versionId, 'versionId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in getVersionContent");
-        }
-
-        if (versionId === undefined || versionId === null) {
-            throw new Error("Required param 'versionId' in getVersionContent");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'versionId': versionId
@@ -226,20 +211,18 @@ params (majorVersion and comment) on a subsequent file content update.
         * @return Promise<VersionPaging>
         */
     listVersionHistory(nodeId: string, opts?: any): Promise<VersionPaging> {
+        throwIfNotDefined(nodeId, 'nodeId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in listVersionHistory");
-        }
 
         let pathParams = {
             'nodeId': nodeId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv'),
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems']
         };
@@ -288,27 +271,19 @@ params (majorVersion and comment) on a subsequent file content update.
         * @return Promise<VersionEntry>
         */
     revertVersion(nodeId: string, versionId: string, revertBody: RevertBody, opts?: any): Promise<VersionEntry> {
+        throwIfNotDefined(nodeId, 'nodeId');
+        throwIfNotDefined(versionId, 'versionId');
+        throwIfNotDefined(revertBody, 'revertBody');
+
         opts = opts || {};
         let postBody = revertBody;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in revertVersion");
-        }
-
-        if (versionId === undefined || versionId === null) {
-            throw new Error("Required param 'versionId' in revertVersion");
-        }
-
-        if (revertBody === undefined || revertBody === null) {
-            throw new Error("Required param 'revertBody' in revertVersion");
-        }
 
         let pathParams = {
             'nodeId': nodeId, 'versionId': versionId
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/content-rest-api/docs/AuditApi.md
+++ b/src/api/content-rest-api/docs/AuditApi.md
@@ -61,11 +61,7 @@ auditApi.deleteAuditEntriesForAuditApp(auditApplicationIdwhere).then(() => {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **auditApplicationId** | **string**| The identifier of an audit application. | 
- **where** | **string**| Audit entries to permanently delete for an audit application, given an inclusive time period or range of ids. For example:
-
-*   where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')
-*   where=(id BETWEEN ('1234', '4321')
- | 
+ **where** | **string**| Audit entries to permanently delete for an audit application, given an inclusive time period or range of ids. For example: <br><br><ul><li>where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')</li><li>where=(id BETWEEN ('1234', '4321')</li></ul>| 
 
 ### Return type
 
@@ -169,18 +165,7 @@ auditApi.getAuditApp(auditApplicationIdopts).then((data) => {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **auditApplicationId** | **string**| The identifier of an audit application. | 
- **fields** | [**string**](string.md)| A list of field names.
-
-You can use this parameter to restrict the fields
-returned within a response if, for example, you want to save on overall bandwidth.
-
-The list applies to a returned individual
-entity or entries within a collection.
-
-If the API method also supports the **include**
-parameter, then the fields specified in the **include**
-parameter are returned in addition to those specified in the **fields** parameter.
- | [optional] 
+ **fields** | [**string**](string.md)| A list of field names.<br><br>You can use this parameter to restrict the fields returned within a response if, for example, you want to save on overall bandwidth.<br><br>The list applies to a returned individual entity or entries within a collection.<br><br>If the API method also supports the **include** parameter, then the fields specified in the **include** parameter are returned in addition to those specified in the **fields** parameter. | [optional] 
 
 ### Return type
 
@@ -240,18 +225,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **auditApplicationId** | **string**| The identifier of an audit application. | 
  **auditEntryId** | **string**| The identifier of an audit entry. | 
- **fields** | [**string**](string.md)| A list of field names.
-
-You can use this parameter to restrict the fields
-returned within a response if, for example, you want to save on overall bandwidth.
-
-The list applies to a returned individual
-entity or entries within a collection.
-
-If the API method also supports the **include**
-parameter, then the fields specified in the **include**
-parameter are returned in addition to those specified in the **fields** parameter.
- | [optional] 
+ **fields** | [**string**](string.md)| A list of field names.<br><br>You can use this parameter to restrict the fields returned within a response if, for example, you want to save on overall bandwidth.<br><br>The list applies to a returned individual entity or entries within a collection.<br><br>If the API method also supports the **include** parameter, then the fields specified in the **include** parameter are returned in addition to those specified in the **fields** parameter. | [optional] 
 
 ### Return type
 
@@ -322,24 +296,9 @@ auditApi.listAuditApps(opts).then((data) => {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **skipCount** | **number**| The number of entities that exist in the collection before those included in this list.
-If not supplied then the default value is 0.
- | [optional] [default to 0]
- **maxItems** | **number**| The maximum number of items to return in the list.
-If not supplied then the default value is 100.
- | [optional] [default to 100]
- **fields** | [**string**](string.md)| A list of field names.
-
-You can use this parameter to restrict the fields
-returned within a response if, for example, you want to save on overall bandwidth.
-
-The list applies to a returned individual
-entity or entries within a collection.
-
-If the API method also supports the **include**
-parameter, then the fields specified in the **include**
-parameter are returned in addition to those specified in the **fields** parameter.
- | [optional] 
+ **skipCount** | **number**| The number of entities that exist in the collection before those included in this list.<br>If not supplied then the default value is 0. | [optional] [default to 0]
+ **maxItems** | **number**| The maximum number of items to return in the list.<br>If not supplied then the default value is 100. | [optional] [default to 100]
+ **fields** | [**string**](string.md)| A list of field names.<br><br>You can use this parameter to restrict the fields returned within a response if, for example, you want to save on overall bandwidth.<br><br>The list applies to a returned individual entity or entries within a collection.<br><br>If the API method also supports the **include** parameter, then the fields specified in the **include** parameter are returned in addition to those specified in the **fields** parameter. | [optional] 
 
 ### Return type
 
@@ -443,49 +402,12 @@ auditApi.listAuditEntriesForAuditApp(auditApplicationIdopts).then((data) => {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **auditApplicationId** | **string**| The identifier of an audit application. | 
- **skipCount** | **number**| The number of entities that exist in the collection before those included in this list.
-If not supplied then the default value is 0.
- | [optional] [default to 0]
- **orderBy** | [**string**](string.md)| A string to control the order of the entities returned in a list. You can use the **orderBy** parameter to
-sort the list by one or more fields.
-
-Each field has a default sort order, which is normally ascending order. Read the API method implementation notes
-above to check if any fields used in this method have a descending default search order.
-
-To sort the entities in a specific order, you can use the **ASC** and **DESC** keywords for any field.
- | [optional] 
- **maxItems** | **number**| The maximum number of items to return in the list.
-If not supplied then the default value is 100.
- | [optional] [default to 100]
- **where** | **string**| Optionally filter the list. Here are some examples:
-
-*   where=(createdByUser='jbloggs')
-
-*   where=(id BETWEEN ('1234', '4321')
-
-*   where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')
-
-*   where=(createdByUser='jbloggs' and createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')
-
-*   where=(valuesKey='/alfresco-access/login/user')
-
-*   where=(valuesKey='/alfresco-access/transaction/action' and valuesValue='DELETE')
- | [optional] 
- **include** | [**string**](string.md)| Returns additional information about the audit entry. The following optional fields can be requested:
-* values
- | [optional] 
- **fields** | [**string**](string.md)| A list of field names.
-
-You can use this parameter to restrict the fields
-returned within a response if, for example, you want to save on overall bandwidth.
-
-The list applies to a returned individual
-entity or entries within a collection.
-
-If the API method also supports the **include**
-parameter, then the fields specified in the **include**
-parameter are returned in addition to those specified in the **fields** parameter.
- | [optional] 
+ **skipCount** | **number**| The number of entities that exist in the collection before those included in this list.<br>If not supplied then the default value is 0. | [optional] [default to 0]
+ **orderBy** | [**string**](string.md)| A string to control the order of the entities returned in a list. You can use the **orderBy** parameter to sort the list by one or more fields.<br><br>Each field has a default sort order, which is normally ascending order. Read the API method implementation notes above to check if any fields used in this method have a descending default search order.<br><br>To sort the entities in a specific order, you can use the **ASC** and **DESC** keywords for any field. | [optional] 
+ **maxItems** | **number**| The maximum number of items to return in the list.<br>If not supplied then the default value is 100. | [optional] [default to 100]
+ **where** | **string**| Optionally filter the list. Here are some examples:<br><ul><li>where=(createdByUser='jbloggs')</li><li>where=(id BETWEEN ('1234', '4321')</li><li>where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')</li><li>where=(createdByUser='jbloggs' and createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')</li><li>where=(valuesKey='/alfresco-access/login/user')</li><li>where=(valuesKey='/alfresco-access/transaction/action' and valuesValue='DELETE')</li></ul> | [optional] 
+ **include** | [**string**](string.md)| Returns additional information about the audit entry. The following optional fields can be requested:<ul><li>values</li></ul> | [optional] 
+ **fields** | [**string**](string.md)| A list of field names.<br><br>You can use this parameter to restrict the fields returned within a response if, for example, you want to save on overall bandwidth.<br><br>The list applies to a returned individual entity or entries within a collection.<br><br>If the API method also supports the **include** parameter, then the fields specified in the **include** parameter are returned in addition to those specified in the **fields** parameter. | [optional] 
 
 ### Return type
 
@@ -576,43 +498,12 @@ auditApi.listAuditEntriesForNode(nodeIdopts).then((data) => {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **nodeId** | **string**| The identifier of a node. | 
- **skipCount** | **number**| The number of entities that exist in the collection before those included in this list.
-If not supplied then the default value is 0.
- | [optional] [default to 0]
- **orderBy** | [**string**](string.md)| A string to control the order of the entities returned in a list. You can use the **orderBy** parameter to
-sort the list by one or more fields.
-
-Each field has a default sort order, which is normally ascending order. Read the API method implementation notes
-above to check if any fields used in this method have a descending default search order.
-
-To sort the entities in a specific order, you can use the **ASC** and **DESC** keywords for any field.
- | [optional] 
- **maxItems** | **number**| The maximum number of items to return in the list.
-If not supplied then the default value is 100.
- | [optional] [default to 100]
- **where** | **string**| Optionally filter the list. Here are some examples:
-
-*   where=(createdByUser='-me-')
-
-*   where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')
-
-*   where=(createdByUser='jbloggs' and createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')
- | [optional] 
- **include** | [**string**](string.md)| Returns additional information about the audit entry. The following optional fields can be requested:
-* values
- | [optional] 
- **fields** | [**string**](string.md)| A list of field names.
-
-You can use this parameter to restrict the fields
-returned within a response if, for example, you want to save on overall bandwidth.
-
-The list applies to a returned individual
-entity or entries within a collection.
-
-If the API method also supports the **include**
-parameter, then the fields specified in the **include**
-parameter are returned in addition to those specified in the **fields** parameter.
- | [optional] 
+ **skipCount** | **number**| The number of entities that exist in the collection before those included in this list.<br>If not supplied then the default value is 0. | [optional] [default to 0]
+ **orderBy** | [**string**](string.md)| A string to control the order of the entities returned in a list. You can use the **orderBy** parameter to sort the list by one or more fields.<br><br>Each field has a default sort order, which is normally ascending order. Read the API method implementation notes above to check if any fields used in this method have a descending default search order.<br><br>To sort the entities in a specific order, you can use the **ASC** and **DESC** keywords for any field. | [optional] 
+ **maxItems** | **number**| The maximum number of items to return in the list.<br>If not supplied then the default value is 100. | [optional] [default to 100]
+ **where** | **string**| Optionally filter the list. Here are some examples:<br><ul><li>where=(createdByUser='-me-')</li><li>where=(createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')</li><li>where=(createdByUser='jbloggs' and createdAt BETWEEN ('2017-06-02T12:13:51.593+01:00' , '2017-06-04T10:05:16.536+01:00')</li></ul> | [optional] 
+ **include** | [**string**](string.md)| Returns additional information about the audit entry. The following optional fields can be requested:<ul><li>values</li></ul> | [optional] 
+ **fields** | [**string**](string.md)| A list of field names.<br><br>You can use this parameter to restrict the fields returned within a response if, for example, you want to save on overall bandwidth.<br><br>The list applies to a returned individual entity or entries within a collection.<br><br>If the API method also supports the **include** parameter, then the fields specified in the **include** parameter are returned in addition to those specified in the **fields** parameter. | [optional] 
 
 ### Return type
 
@@ -678,18 +569,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **auditApplicationId** | **string**| The identifier of an audit application. | 
  **auditAppBodyUpdate** | [**AuditBodyUpdate**](AuditBodyUpdate.md)| The audit application to update. | 
- **fields** | [**string**](string.md)| A list of field names.
-
-You can use this parameter to restrict the fields
-returned within a response if, for example, you want to save on overall bandwidth.
-
-The list applies to a returned individual
-entity or entries within a collection.
-
-If the API method also supports the **include**
-parameter, then the fields specified in the **include**
-parameter are returned in addition to those specified in the **fields** parameter.
- | [optional] 
+ **fields** | [**string**](string.md)| A list of field names.<br><br>You can use this parameter to restrict the fields returned within a response if, for example, you want to save on overall bandwidth.<br><br>The list applies to a returned individual entity or entries within a collection.<br><br>If the API method also supports the **include** parameter, then the fields specified in the **include** parameter are returned in addition to those specified in the **fields** parameter. | [optional] 
 
 ### Return type
 

--- a/src/api/content-rest-api/model/pagination.ts
+++ b/src/api/content-rest-api/model/pagination.ts
@@ -15,6 +15,18 @@
 * limitations under the License.
 */
 
+export interface PaginatedList<T> {
+    list: {
+        entries: Array<{ entry: T }>;
+        pagination: Pagination;
+    };
+}
+
+export interface PaginatedEntries<T> {
+    entries: T[];
+    pagination: Pagination;
+}
+
 export class Pagination {
     /**
      * The number of objects in the entries array.

--- a/src/api/gs-classification-rest-api/api/classificationGuides.api.ts
+++ b/src/api/gs-classification-rest-api/api/classificationGuides.api.ts
@@ -24,6 +24,8 @@ import { TopicBody } from '../model/topicBody';
 import { TopicEntry } from '../model/topicEntry';
 import { TopicPaging } from '../model/topicPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Classificationguides service.
@@ -73,12 +75,9 @@ export class ClassificationGuidesApi extends BaseApi {
         * @return Promise<ClassificationGuideEntry>
         */
     createClassificationGuide(classificationGuide: ClassificationGuideBody): Promise<ClassificationGuideEntry> {
+        throwIfNotDefined(classificationGuide, 'classificationGuide');
 
         let postBody = classificationGuide;
-
-        if (classificationGuide === undefined || classificationGuide === null) {
-            throw new Error("Required param 'classificationGuide' in createClassificationGuide");
-        }
 
         let pathParams = {
 
@@ -118,23 +117,18 @@ export class ClassificationGuidesApi extends BaseApi {
         * @return Promise<TopicEntry>
         */
     createSubtopic(topicId: string, topic: TopicBody, opts?: any): Promise<TopicEntry> {
+        throwIfNotDefined(topicId, 'topicId');
+        throwIfNotDefined(topic, 'topic');
+
         opts = opts || {};
         let postBody = topic;
-
-        if (topicId === undefined || topicId === null) {
-            throw new Error("Required param 'topicId' in createSubtopic");
-        }
-
-        if (topic === undefined || topic === null) {
-            throw new Error("Required param 'topic' in createSubtopic");
-        }
 
         let pathParams = {
             'topicId': topicId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv')
         };
 
         let headerParams = {
@@ -168,23 +162,18 @@ export class ClassificationGuidesApi extends BaseApi {
         * @return Promise<TopicEntry>
         */
     createTopic(classificationGuideId: string, topic: TopicBody, opts?: any): Promise<TopicEntry> {
+        throwIfNotDefined(classificationGuideId, 'classificationGuideId');
+        throwIfNotDefined(topic, 'topic');
+
         opts = opts || {};
         let postBody = topic;
-
-        if (classificationGuideId === undefined || classificationGuideId === null) {
-            throw new Error("Required param 'classificationGuideId' in createTopic");
-        }
-
-        if (topic === undefined || topic === null) {
-            throw new Error("Required param 'topic' in createTopic");
-        }
 
         let pathParams = {
             'classificationGuideId': classificationGuideId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv')
         };
 
         let headerParams = {
@@ -210,12 +199,9 @@ export class ClassificationGuidesApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteClassificationGuide(classificationGuideId: string): Promise<any> {
+        throwIfNotDefined(classificationGuideId, 'classificationGuideId');
 
         let postBody = null;
-
-        if (classificationGuideId === undefined || classificationGuideId === null) {
-            throw new Error("Required param 'classificationGuideId' in deleteClassificationGuide");
-        }
 
         let pathParams = {
             'classificationGuideId': classificationGuideId
@@ -247,12 +233,9 @@ export class ClassificationGuidesApi extends BaseApi {
         * @return Promise<{}>
         */
     deleteTopic(topicId: string): Promise<any> {
+        throwIfNotDefined(topicId, 'topicId');
 
         let postBody = null;
-
-        if (topicId === undefined || topicId === null) {
-            throw new Error("Required param 'topicId' in deleteTopic");
-        }
 
         let pathParams = {
             'topicId': topicId
@@ -308,10 +291,10 @@ export class ClassificationGuidesApi extends BaseApi {
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
             'where': opts['where']
         };
 
@@ -360,22 +343,20 @@ export class ClassificationGuidesApi extends BaseApi {
         * @return Promise<SubtopicPaging>
         */
     listSubtopics(topicId: string, opts?: any): Promise<SubtopicPaging> {
+        throwIfNotDefined(topicId, 'topicId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (topicId === undefined || topicId === null) {
-            throw new Error("Required param 'topicId' in listSubtopics");
-        }
 
         let pathParams = {
             'topicId': topicId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
             'where': opts['where'],
             'includeSource': opts['includeSource']
         };
@@ -425,22 +406,20 @@ export class ClassificationGuidesApi extends BaseApi {
         * @return Promise<TopicPaging>
         */
     listTopics(classificationGuideId: string, opts?: any): Promise<TopicPaging> {
+        throwIfNotDefined(classificationGuideId, 'classificationGuideId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (classificationGuideId === undefined || classificationGuideId === null) {
-            throw new Error("Required param 'classificationGuideId' in listTopics");
-        }
 
         let pathParams = {
             'classificationGuideId': classificationGuideId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'orderBy': this.apiClient.buildCollectionParam(opts['orderBy'], 'csv'),
+            'orderBy': buildCollectionParam(opts['orderBy'], 'csv'),
             'where': opts['where'],
             'includeSource': opts['includeSource']
         };
@@ -468,12 +447,9 @@ export class ClassificationGuidesApi extends BaseApi {
         * @return Promise<ClassificationGuideEntry>
         */
     showClassificationGuideById(classificationGuideId: string): Promise<ClassificationGuideEntry> {
+        throwIfNotDefined(classificationGuideId, 'classificationGuideId');
 
         let postBody = null;
-
-        if (classificationGuideId === undefined || classificationGuideId === null) {
-            throw new Error("Required param 'classificationGuideId' in showClassificationGuideById");
-        }
 
         let pathParams = {
             'classificationGuideId': classificationGuideId
@@ -512,19 +488,17 @@ export class ClassificationGuidesApi extends BaseApi {
         * @return Promise<TopicEntry>
         */
     showTopicById(topicId: string, opts?: any): Promise<TopicEntry> {
+        throwIfNotDefined(topicId, 'topicId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (topicId === undefined || topicId === null) {
-            throw new Error("Required param 'topicId' in showTopicById");
-        }
 
         let pathParams = {
             'topicId': topicId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv')
         };
 
         let headerParams = {
@@ -551,16 +525,10 @@ export class ClassificationGuidesApi extends BaseApi {
         * @return Promise<ClassificationGuideEntry>
         */
     updateClassificationGuide(classificationGuideId: string, classificationGuide: ClassificationGuideBody): Promise<ClassificationGuideEntry> {
+        throwIfNotDefined(classificationGuideId, 'classificationGuideId');
+        throwIfNotDefined(classificationGuide, 'classificationGuide');
 
         let postBody = classificationGuide;
-
-        if (classificationGuideId === undefined || classificationGuideId === null) {
-            throw new Error("Required param 'classificationGuideId' in updateClassificationGuide");
-        }
-
-        if (classificationGuide === undefined || classificationGuide === null) {
-            throw new Error("Required param 'classificationGuide' in updateClassificationGuide");
-        }
 
         let pathParams = {
             'classificationGuideId': classificationGuideId
@@ -603,23 +571,18 @@ export class ClassificationGuidesApi extends BaseApi {
         * @return Promise<TopicEntry>
         */
     updateTopic(topicId: string, topic: TopicBody, opts?: any): Promise<TopicEntry> {
+        throwIfNotDefined(topicId, 'topicId');
+        throwIfNotDefined(topic, 'topic');
+
         opts = opts || {};
         let postBody = topic;
-
-        if (topicId === undefined || topicId === null) {
-            throw new Error("Required param 'topicId' in updateTopic");
-        }
-
-        if (topic === undefined || topic === null) {
-            throw new Error("Required param 'topic' in updateTopic");
-        }
 
         let pathParams = {
             'topicId': topicId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/gs-classification-rest-api/api/classificationReasons.api.ts
+++ b/src/api/gs-classification-rest-api/api/classificationReasons.api.ts
@@ -19,6 +19,8 @@ import { ClassificationReasonBody } from '../model/classificationReasonBody';
 import { ClassificationReasonEntry } from '../model/classificationReasonEntry';
 import { ClassificationReasonsPaging } from '../model/classificationReasonsPaging';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Classificationreasons service.
@@ -76,12 +78,9 @@ JSON
     * @return Promise<ClassificationReasonEntry>
     */
     createClassificationReason(classificationReason: ClassificationReasonBody): Promise<ClassificationReasonEntry> {
+        throwIfNotDefined(classificationReason, 'classificationReason');
 
         let postBody = classificationReason;
-
-        if (classificationReason === undefined || classificationReason === null) {
-            throw new Error("Required param 'classificationReason' in createClassificationReason");
-        }
 
         let pathParams = {
 
@@ -113,12 +112,9 @@ JSON
         * @return Promise<{}>
         */
     deleteClassificationReason(classificationReasonId: string): Promise<any> {
+        throwIfNotDefined(classificationReasonId, 'classificationReasonId');
 
         let postBody = null;
-
-        if (classificationReasonId === undefined || classificationReasonId === null) {
-            throw new Error("Required param 'classificationReasonId' in deleteClassificationReason");
-        }
 
         let pathParams = {
             'classificationReasonId': classificationReasonId
@@ -174,7 +170,7 @@ JSON
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -200,12 +196,9 @@ JSON
         * @return Promise<ClassificationReasonEntry>
         */
     showClassificationReasonById(classificationReasonId: string): Promise<ClassificationReasonEntry> {
+        throwIfNotDefined(classificationReasonId, 'classificationReasonId');
 
         let postBody = null;
-
-        if (classificationReasonId === undefined || classificationReasonId === null) {
-            throw new Error("Required param 'classificationReasonId' in showClassificationReasonById");
-        }
 
         let pathParams = {
             'classificationReasonId': classificationReasonId
@@ -238,16 +231,10 @@ JSON
         * @return Promise<ClassificationReasonEntry>
         */
     updateClassificationReason(classificationReasonId: string, classificationReason: ClassificationReasonBody): Promise<ClassificationReasonEntry> {
+        throwIfNotDefined(classificationReasonId, 'classificationReasonId');
+        throwIfNotDefined(classificationReason, 'classificationReason');
 
         let postBody = classificationReason;
-
-        if (classificationReasonId === undefined || classificationReasonId === null) {
-            throw new Error("Required param 'classificationReasonId' in updateClassificationReason");
-        }
-
-        if (classificationReason === undefined || classificationReason === null) {
-            throw new Error("Required param 'classificationReason' in updateClassificationReason");
-        }
 
         let pathParams = {
             'classificationReasonId': classificationReasonId

--- a/src/api/gs-classification-rest-api/api/declassificationExemptions.api.ts
+++ b/src/api/gs-classification-rest-api/api/declassificationExemptions.api.ts
@@ -19,6 +19,7 @@ import { DeclassificationExemptionBody } from '../model/declassificationExemptio
 import { DeclassificationExemptionEntry } from '../model/declassificationExemptionEntry';
 import { DeclassificationExemptionsPaging } from '../model/declassificationExemptionsPaging';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Declassificationexemptions service.
@@ -76,12 +77,9 @@ JSON
     * @return Promise<DeclassificationExemptionEntry>
     */
     createDeclassificationExemption(declassificationExemption: DeclassificationExemptionBody): Promise<DeclassificationExemptionEntry> {
+        throwIfNotDefined(declassificationExemption, 'declassificationExemption');
 
         let postBody = declassificationExemption;
-
-        if (declassificationExemption === undefined || declassificationExemption === null) {
-            throw new Error("Required param 'declassificationExemption' in createDeclassificationExemption");
-        }
 
         let pathParams = {
 
@@ -113,12 +111,9 @@ JSON
         * @return Promise<{}>
         */
     deleteDeclassificationExemption(declassificationExemptionId: string): Promise<any> {
+        throwIfNotDefined(declassificationExemptionId, 'declassificationExemptionId');
 
         let postBody = null;
-
-        if (declassificationExemptionId === undefined || declassificationExemptionId === null) {
-            throw new Error("Required param 'declassificationExemptionId' in deleteDeclassificationExemption");
-        }
 
         let pathParams = {
             'declassificationExemptionId': declassificationExemptionId
@@ -187,12 +182,9 @@ JSON
         * @return Promise<DeclassificationExemptionEntry>
         */
     showDeclassificationExemptionById(declassificationExemptionId: string): Promise<DeclassificationExemptionEntry> {
+        throwIfNotDefined(declassificationExemptionId, 'declassificationExemptionId');
 
         let postBody = null;
-
-        if (declassificationExemptionId === undefined || declassificationExemptionId === null) {
-            throw new Error("Required param 'declassificationExemptionId' in showDeclassificationExemptionById");
-        }
 
         let pathParams = {
             'declassificationExemptionId': declassificationExemptionId
@@ -225,16 +217,10 @@ JSON
         * @return Promise<DeclassificationExemptionEntry>
         */
     updateDeclassificationExemption(declassificationExemptionId: string, declassificationExemption: DeclassificationExemptionBody): Promise<DeclassificationExemptionEntry> {
+        throwIfNotDefined(declassificationExemptionId, 'declassificationExemptionId');
+        throwIfNotDefined(declassificationExemption, 'declassificationExemption');
 
         let postBody = declassificationExemption;
-
-        if (declassificationExemptionId === undefined || declassificationExemptionId === null) {
-            throw new Error("Required param 'declassificationExemptionId' in updateDeclassificationExemption");
-        }
-
-        if (declassificationExemption === undefined || declassificationExemption === null) {
-            throw new Error("Required param 'declassificationExemption' in updateDeclassificationExemption");
-        }
 
         let pathParams = {
             'declassificationExemptionId': declassificationExemptionId

--- a/src/api/gs-classification-rest-api/api/defaultClassificationValues.api.ts
+++ b/src/api/gs-classification-rest-api/api/defaultClassificationValues.api.ts
@@ -18,6 +18,7 @@
 import { DeclassificationDate } from '../model/declassificationDate';
 import { BaseApi } from './base.api';
 import { DateAlfresco } from '../../../../src/api/content-rest-api/model/dateAlfresco';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Defaultclassificationvalues service.
@@ -33,12 +34,9 @@ export class DefaultClassificationValuesApi extends BaseApi {
     * @return Promise<DeclassificationDate>
     */
     calculateDefaultDeclassificationDate(nodeId: string): Promise<DeclassificationDate> {
+        throwIfNotDefined(nodeId, 'nodeId');
 
         let postBody = null;
-
-        if (nodeId === undefined || nodeId === null) {
-            throw new Error("Required param 'nodeId' in calculateDefaultDeclassificationDate");
-        }
 
         let pathParams = {
             'nodeId': nodeId

--- a/src/api/gs-classification-rest-api/api/securityControlSettings.api.ts
+++ b/src/api/gs-classification-rest-api/api/securityControlSettings.api.ts
@@ -18,6 +18,7 @@
 import { SecurityControlSettingBody } from '../model/securityControlSettingBody';
 import { SecurityControlSettingEntry } from '../model/securityControlSettingEntry';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Securitycontrolsettings service.
@@ -35,12 +36,9 @@ export class SecurityControlSettingsApi extends BaseApi {
     * @return Promise<SecurityControlSettingEntry>
     */
     getSecurityControlSetting(securityControlSettingKey: string): Promise<SecurityControlSettingEntry> {
+        throwIfNotDefined(securityControlSettingKey, 'securityControlSettingKey');
 
         let postBody = null;
-
-        if (securityControlSettingKey === undefined || securityControlSettingKey === null) {
-            throw new Error("Required param 'securityControlSettingKey' in getSecurityControlSetting");
-        }
 
         let pathParams = {
             'securityControlSettingKey': securityControlSettingKey
@@ -75,16 +73,10 @@ export class SecurityControlSettingsApi extends BaseApi {
         * @return Promise<SecurityControlSettingEntry>
         */
     updateSecurityControlSetting(securityControlSettingKey: string, securityControlSettingValue: SecurityControlSettingBody): Promise<SecurityControlSettingEntry> {
+        throwIfNotDefined(securityControlSettingKey, 'securityControlSettingKey');
+        throwIfNotDefined(securityControlSettingValue, 'securityControlSettingValue');
 
         let postBody = securityControlSettingValue;
-
-        if (securityControlSettingKey === undefined || securityControlSettingKey === null) {
-            throw new Error("Required param 'securityControlSettingKey' in updateSecurityControlSetting");
-        }
-
-        if (securityControlSettingValue === undefined || securityControlSettingValue === null) {
-            throw new Error("Required param 'securityControlSettingValue' in updateSecurityControlSetting");
-        }
 
         let pathParams = {
             'securityControlSettingKey': securityControlSettingKey

--- a/src/api/gs-core-rest-api/api/filePlans.api.ts
+++ b/src/api/gs-core-rest-api/api/filePlans.api.ts
@@ -21,6 +21,8 @@ import { RecordCategoryEntry } from '../model/recordCategoryEntry';
 import { RecordCategoryPaging } from '../model/recordCategoryPaging';
 import { RootCategoryBodyCreate } from '../model/rootCategoryBodyCreate';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Fileplans service.
@@ -112,16 +114,11 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<RecordCategoryEntry>
     */
     createFilePlanCategories(filePlanId: string, nodeBodyCreate: RootCategoryBodyCreate, opts?: any): Promise<RecordCategoryEntry> {
+        throwIfNotDefined(filePlanId, 'filePlanId');
+        throwIfNotDefined(nodeBodyCreate, 'nodeBodyCreate');
+
         opts = opts || {};
         let postBody = nodeBodyCreate;
-
-        if (filePlanId === undefined || filePlanId === null) {
-            throw new Error("Required param 'filePlanId' in createFilePlanCategories");
-        }
-
-        if (nodeBodyCreate === undefined || nodeBodyCreate === null) {
-            throw new Error("Required param 'nodeBodyCreate' in createFilePlanCategories");
-        }
 
         let pathParams = {
             'filePlanId': filePlanId
@@ -129,8 +126,8 @@ parameter are returned in addition to those specified in the **fields** paramete
 
         let queryParams = {
             'autoRename': opts['autoRename'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -178,20 +175,18 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<FilePlanEntry>
         */
     getFilePlan(filePlanId: string, opts?: any): Promise<FilePlanEntry> {
+        throwIfNotDefined(filePlanId, 'filePlanId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (filePlanId === undefined || filePlanId === null) {
-            throw new Error("Required param 'filePlanId' in getFilePlan");
-        }
 
         let pathParams = {
             'filePlanId': filePlanId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -245,12 +240,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RecordCategoryPaging>
         */
     getFilePlanCategories(filePlanId: string, opts?: any): Promise<RecordCategoryPaging> {
+        throwIfNotDefined(filePlanId, 'filePlanId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (filePlanId === undefined || filePlanId === null) {
-            throw new Error("Required param 'filePlanId' in getFilePlanCategories");
-        }
 
         let pathParams = {
             'filePlanId': filePlanId
@@ -259,9 +252,9 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'includeSource': opts['includeSource'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -318,24 +311,19 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<FilePlanEntry>
         */
     updateFilePlan(filePlanId: string, filePlanBodyUpdate: FilePlanBodyUpdate, opts?: any): Promise<FilePlanEntry> {
+        throwIfNotDefined(filePlanId, 'filePlanId');
+        throwIfNotDefined(filePlanBodyUpdate, 'filePlanBodyUpdate');
+
         opts = opts || {};
         let postBody = filePlanBodyUpdate;
-
-        if (filePlanId === undefined || filePlanId === null) {
-            throw new Error("Required param 'filePlanId' in updateFilePlan");
-        }
-
-        if (filePlanBodyUpdate === undefined || filePlanBodyUpdate === null) {
-            throw new Error("Required param 'filePlanBodyUpdate' in updateFilePlan");
-        }
 
         let pathParams = {
             'filePlanId': filePlanId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/gs-core-rest-api/api/files.api.ts
+++ b/src/api/gs-core-rest-api/api/files.api.ts
@@ -17,6 +17,8 @@
 
 import { RecordEntry } from '../model/recordEntry';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Files service.
@@ -52,12 +54,10 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<RecordEntry>
     */
     declareRecord(fileId: string, opts?: any): Promise<RecordEntry> {
+        throwIfNotDefined(fileId, 'fileId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (fileId === undefined || fileId === null) {
-            throw new Error("Required param 'fileId' in declareRecord");
-        }
 
         let pathParams = {
             'fileId': fileId
@@ -65,8 +65,8 @@ parameter are returned in addition to those specified in the **fields** paramete
 
         let queryParams = {
             'hideRecord': opts['hideRecord'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/gs-core-rest-api/api/gsSites.api.ts
+++ b/src/api/gs-core-rest-api/api/gsSites.api.ts
@@ -19,6 +19,8 @@ import { RMSiteBodyCreate } from '../model/rMSiteBodyCreate';
 import { RMSiteBodyUpdate } from '../model/rMSiteBodyUpdate';
 import { RMSiteEntry } from '../model/rMSiteEntry';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Gssites service.
@@ -51,12 +53,10 @@ When you create the RM site, the **filePlan** structure is also created includin
     * @return Promise<RMSiteEntry>
     */
     createRMSite(siteBodyCreate: RMSiteBodyCreate, opts?: any): Promise<RMSiteEntry> {
+        throwIfNotDefined(siteBodyCreate, 'siteBodyCreate');
+
         opts = opts || {};
         let postBody = siteBodyCreate;
-
-        if (siteBodyCreate === undefined || siteBodyCreate === null) {
-            throw new Error("Required param 'siteBodyCreate' in createRMSite");
-        }
 
         let pathParams = {
 
@@ -145,7 +145,7 @@ When you create the RM site, the **filePlan** structure is also created includin
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -188,19 +188,17 @@ When you create the RM site, the **filePlan** structure is also created includin
         * @return Promise<RMSiteEntry>
         */
     updateRMSite(siteBodyUpdate: RMSiteBodyUpdate, opts?: any): Promise<RMSiteEntry> {
+        throwIfNotDefined(siteBodyUpdate, 'siteBodyUpdate');
+
         opts = opts || {};
         let postBody = siteBodyUpdate;
-
-        if (siteBodyUpdate === undefined || siteBodyUpdate === null) {
-            throw new Error("Required param 'siteBodyUpdate' in updateRMSite");
-        }
 
         let pathParams = {
 
         };
 
         let queryParams = {
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/gs-core-rest-api/api/recordCategories.api.ts
+++ b/src/api/gs-core-rest-api/api/recordCategories.api.ts
@@ -21,6 +21,8 @@ import { RecordCategoryChildEntry } from '../model/recordCategoryChildEntry';
 import { RecordCategoryChildPaging } from '../model/recordCategoryChildPaging';
 import { RecordCategoryEntry } from '../model/recordCategoryEntry';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Recordcategories service.
@@ -149,16 +151,11 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<RecordCategoryChildEntry>
     */
     createRecordCategoryChild(recordCategoryId: string, nodeBodyCreate: RMNodeBodyCreateWithRelativePath, opts?: any): Promise<RecordCategoryChildEntry> {
+        throwIfNotDefined(recordCategoryId, 'recordCategoryId');
+        throwIfNotDefined(nodeBodyCreate, 'nodeBodyCreate');
+
         opts = opts || {};
         let postBody = nodeBodyCreate;
-
-        if (recordCategoryId === undefined || recordCategoryId === null) {
-            throw new Error("Required param 'recordCategoryId' in createRecordCategoryChild");
-        }
-
-        if (nodeBodyCreate === undefined || nodeBodyCreate === null) {
-            throw new Error("Required param 'nodeBodyCreate' in createRecordCategoryChild");
-        }
 
         let pathParams = {
             'recordCategoryId': recordCategoryId
@@ -166,8 +163,8 @@ parameter are returned in addition to those specified in the **fields** paramete
 
         let queryParams = {
             'autoRename': opts['autoRename'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -194,12 +191,9 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteRecordCategory(recordCategoryId: string): Promise<any> {
+        throwIfNotDefined(recordCategoryId, 'recordCategoryId');
 
         let postBody = null;
-
-        if (recordCategoryId === undefined || recordCategoryId === null) {
-            throw new Error("Required param 'recordCategoryId' in deleteRecordCategory");
-        }
 
         let pathParams = {
             'recordCategoryId': recordCategoryId
@@ -256,21 +250,19 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RecordCategoryEntry>
         */
     getRecordCategory(recordCategoryId: string, opts?: any): Promise<RecordCategoryEntry> {
+        throwIfNotDefined(recordCategoryId, 'recordCategoryId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (recordCategoryId === undefined || recordCategoryId === null) {
-            throw new Error("Required param 'recordCategoryId' in getRecordCategory");
-        }
 
         let pathParams = {
             'recordCategoryId': recordCategoryId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'relativePath': opts['relativePath'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -339,12 +331,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RecordCategoryChildPaging>
         */
     listRecordCategoryChildren(recordCategoryId: string, opts?: any): Promise<RecordCategoryChildPaging> {
+        throwIfNotDefined(recordCategoryId, 'recordCategoryId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (recordCategoryId === undefined || recordCategoryId === null) {
-            throw new Error("Required param 'recordCategoryId' in listRecordCategoryChildren");
-        }
 
         let pathParams = {
             'recordCategoryId': recordCategoryId
@@ -354,10 +344,10 @@ parameter are returned in addition to those specified in the **fields** paramete
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'relativePath': opts['relativePath'],
             'includeSource': opts['includeSource'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -421,24 +411,19 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RecordCategoryEntry>
         */
     updateRecordCategory(recordCategoryId: string, recordCategoryBodyUpdate: FilePlanComponentBodyUpdate, opts?: any): Promise<RecordCategoryEntry> {
+        throwIfNotDefined(recordCategoryId, 'recordCategoryId');
+        throwIfNotDefined(recordCategoryBodyUpdate, 'recordCategoryBodyUpdate');
+
         opts = opts || {};
         let postBody = recordCategoryBodyUpdate;
-
-        if (recordCategoryId === undefined || recordCategoryId === null) {
-            throw new Error("Required param 'recordCategoryId' in updateRecordCategory");
-        }
-
-        if (recordCategoryBodyUpdate === undefined || recordCategoryBodyUpdate === null) {
-            throw new Error("Required param 'recordCategoryBodyUpdate' in updateRecordCategory");
-        }
 
         let pathParams = {
             'recordCategoryId': recordCategoryId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/gs-core-rest-api/api/recordFolders.api.ts
+++ b/src/api/gs-core-rest-api/api/recordFolders.api.ts
@@ -21,6 +21,8 @@ import { RecordEntry } from '../model/recordEntry';
 import { RecordFolderAssociationPaging } from '../model/recordFolderAssociationPaging';
 import { RecordFolderEntry } from '../model/recordFolderEntry';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Recordfolders service.
@@ -142,24 +144,19 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<RecordEntry>
     */
     createRecordFolderChild(recordFolderId: string, recordBodyCreate: RMNodeBodyCreate, opts?: any): Promise<RecordEntry> {
+        throwIfNotDefined(recordFolderId, 'recordFolderId');
+        throwIfNotDefined(recordBodyCreate, 'recordBodyCreate');
+
         opts = opts || {};
         let postBody = recordBodyCreate;
-
-        if (recordFolderId === undefined || recordFolderId === null) {
-            throw new Error("Required param 'recordFolderId' in createRecordFolderChild");
-        }
-
-        if (recordBodyCreate === undefined || recordBodyCreate === null) {
-            throw new Error("Required param 'recordBodyCreate' in createRecordFolderChild");
-        }
 
         let pathParams = {
             'recordFolderId': recordFolderId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -186,12 +183,9 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteRecordFolder(recordFolderId: string): Promise<any> {
+        throwIfNotDefined(recordFolderId, 'recordFolderId');
 
         let postBody = null;
-
-        if (recordFolderId === undefined || recordFolderId === null) {
-            throw new Error("Required param 'recordFolderId' in deleteRecordFolder");
-        }
 
         let pathParams = {
             'recordFolderId': recordFolderId
@@ -246,20 +240,18 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RecordFolderEntry>
         */
     getRecordFolder(recordFolderId: string, opts?: any): Promise<RecordFolderEntry> {
+        throwIfNotDefined(recordFolderId, 'recordFolderId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (recordFolderId === undefined || recordFolderId === null) {
-            throw new Error("Required param 'recordFolderId' in getRecordFolder");
-        }
 
         let pathParams = {
             'recordFolderId': recordFolderId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -325,12 +317,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RecordFolderAssociationPaging>
         */
     listRecordFolderChildren(recordFolderId: string, opts?: any): Promise<RecordFolderAssociationPaging> {
+        throwIfNotDefined(recordFolderId, 'recordFolderId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (recordFolderId === undefined || recordFolderId === null) {
-            throw new Error("Required param 'recordFolderId' in listRecordFolderChildren");
-        }
 
         let pathParams = {
             'recordFolderId': recordFolderId
@@ -340,9 +330,9 @@ parameter are returned in addition to those specified in the **fields** paramete
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'includeSource': opts['includeSource'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -406,24 +396,19 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RecordFolderEntry>
         */
     updateRecordFolder(recordFolderId: string, recordFolderBodyUpdate: FilePlanComponentBodyUpdate, opts?: any): Promise<RecordFolderEntry> {
+        throwIfNotDefined(recordFolderId, 'recordFolderId');
+        throwIfNotDefined(recordFolderBodyUpdate, 'recordFolderBodyUpdate');
+
         opts = opts || {};
         let postBody = recordFolderBodyUpdate;
-
-        if (recordFolderId === undefined || recordFolderId === null) {
-            throw new Error("Required param 'recordFolderId' in updateRecordFolder");
-        }
-
-        if (recordFolderBodyUpdate === undefined || recordFolderBodyUpdate === null) {
-            throw new Error("Required param 'recordFolderBodyUpdate' in updateRecordFolder");
-        }
 
         let pathParams = {
             'recordFolderId': recordFolderId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/gs-core-rest-api/api/records.api.ts
+++ b/src/api/gs-core-rest-api/api/records.api.ts
@@ -19,6 +19,8 @@ import { FilePlanComponentBodyUpdate } from '../model/filePlanComponentBodyUpdat
 import { RecordEntry } from '../model/recordEntry';
 import { RequestBodyFile } from '../model/requestBodyFile';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Records service.
@@ -54,20 +56,18 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<RecordEntry>
     */
     completeRecord(recordId: string, opts?: any): Promise<RecordEntry> {
+        throwIfNotDefined(recordId, 'recordId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (recordId === undefined || recordId === null) {
-            throw new Error("Required param 'recordId' in completeRecord");
-        }
 
         let pathParams = {
             'recordId': recordId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -94,12 +94,9 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteRecord(recordId: string): Promise<any> {
+        throwIfNotDefined(recordId, 'recordId');
 
         let postBody = null;
-
-        if (recordId === undefined || recordId === null) {
-            throw new Error("Required param 'recordId' in deleteRecord");
-        }
 
         let pathParams = {
             'recordId': recordId
@@ -158,24 +155,19 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RecordEntry>
         */
     fileRecord(recordId: string, nodeBodyFile: RequestBodyFile, opts?: any): Promise<RecordEntry> {
+        throwIfNotDefined(recordId, 'recordId');
+        throwIfNotDefined(nodeBodyFile, 'nodeBodyFile');
+
         opts = opts || {};
         let postBody = nodeBodyFile;
-
-        if (recordId === undefined || recordId === null) {
-            throw new Error("Required param 'recordId' in fileRecord");
-        }
-
-        if (nodeBodyFile === undefined || nodeBodyFile === null) {
-            throw new Error("Required param 'nodeBodyFile' in fileRecord");
-        }
 
         let pathParams = {
             'recordId': recordId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -225,20 +217,18 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RecordEntry>
         */
     getRecord(recordId: string, opts?: any): Promise<RecordEntry> {
+        throwIfNotDefined(recordId, 'recordId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (recordId === undefined || recordId === null) {
-            throw new Error("Required param 'recordId' in getRecord");
-        }
 
         let pathParams = {
             'recordId': recordId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -280,12 +270,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     getRecordContent(recordId: string, opts?: any): Promise<any> {
+        throwIfNotDefined(recordId, 'recordId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (recordId === undefined || recordId === null) {
-            throw new Error("Required param 'recordId' in getRecordContent");
-        }
 
         let pathParams = {
             'recordId': recordId
@@ -357,24 +345,19 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<RecordEntry>
         */
     updateRecord(recordId: string, recordBodyUpdate: FilePlanComponentBodyUpdate, opts?: any): Promise<RecordEntry> {
+        throwIfNotDefined(recordId, 'recordId');
+        throwIfNotDefined(recordBodyUpdate, 'recordBodyUpdate');
+
         opts = opts || {};
         let postBody = recordBodyUpdate;
-
-        if (recordId === undefined || recordId === null) {
-            throw new Error("Required param 'recordId' in updateRecord");
-        }
-
-        if (recordBodyUpdate === undefined || recordBodyUpdate === null) {
-            throw new Error("Required param 'recordBodyUpdate' in updateRecord");
-        }
 
         let pathParams = {
             'recordId': recordId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/gs-core-rest-api/api/transferContainers.api.ts
+++ b/src/api/gs-core-rest-api/api/transferContainers.api.ts
@@ -19,6 +19,8 @@ import { TransferContainerAssociationPaging } from '../model/transferContainerAs
 import { TransferContainerBodyUpdate } from '../model/transferContainerBodyUpdate';
 import { TransferContainerEntry } from '../model/transferContainerEntry';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Transfercontainers service.
@@ -56,20 +58,18 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<TransferContainerEntry>
     */
     getTransferContainer(transferContainerId: string, opts?: any): Promise<TransferContainerEntry> {
+        throwIfNotDefined(transferContainerId, 'transferContainerId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (transferContainerId === undefined || transferContainerId === null) {
-            throw new Error("Required param 'transferContainerId' in getTransferContainer");
-        }
 
         let pathParams = {
             'transferContainerId': transferContainerId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -124,12 +124,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<TransferContainerAssociationPaging>
         */
     listTransfers(transferContainerId: string, opts?: any): Promise<TransferContainerAssociationPaging> {
+        throwIfNotDefined(transferContainerId, 'transferContainerId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (transferContainerId === undefined || transferContainerId === null) {
-            throw new Error("Required param 'transferContainerId' in listTransfers");
-        }
 
         let pathParams = {
             'transferContainerId': transferContainerId
@@ -138,9 +136,9 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'includeSource': opts['includeSource'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -201,24 +199,19 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<TransferContainerEntry>
         */
     updateTransferContainer(transferContainerId: string, nodeBodyUpdate: TransferContainerBodyUpdate, opts?: any): Promise<TransferContainerEntry> {
+        throwIfNotDefined(transferContainerId, 'transferContainerId');
+        throwIfNotDefined(nodeBodyUpdate, 'nodeBodyUpdate');
+
         opts = opts || {};
         let postBody = nodeBodyUpdate;
-
-        if (transferContainerId === undefined || transferContainerId === null) {
-            throw new Error("Required param 'transferContainerId' in updateTransferContainer");
-        }
-
-        if (nodeBodyUpdate === undefined || nodeBodyUpdate === null) {
-            throw new Error("Required param 'nodeBodyUpdate' in updateTransferContainer");
-        }
 
         let pathParams = {
             'transferContainerId': transferContainerId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/gs-core-rest-api/api/transfers.api.ts
+++ b/src/api/gs-core-rest-api/api/transfers.api.ts
@@ -18,6 +18,8 @@
 import { TransferAssociationPaging } from '../model/transferAssociationPaging';
 import { TransferEntry } from '../model/transferEntry';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Transfers service.
@@ -57,20 +59,18 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<TransferEntry>
     */
     getTransfer(transferId: string, opts?: any): Promise<TransferEntry> {
+        throwIfNotDefined(transferId, 'transferId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (transferId === undefined || transferId === null) {
-            throw new Error("Required param 'transferId' in getTransfer");
-        }
 
         let pathParams = {
             'transferId': transferId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -126,12 +126,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<TransferAssociationPaging>
         */
     listTransfersChildren(transferId: string, opts?: any): Promise<TransferAssociationPaging> {
+        throwIfNotDefined(transferId, 'transferId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (transferId === undefined || transferId === null) {
-            throw new Error("Required param 'transferId' in listTransfersChildren");
-        }
 
         let pathParams = {
             'transferId': transferId
@@ -140,9 +138,9 @@ parameter are returned in addition to those specified in the **fields** paramete
         let queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'includeSource': opts['includeSource'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/gs-core-rest-api/api/unfiledContainers.api.ts
+++ b/src/api/gs-core-rest-api/api/unfiledContainers.api.ts
@@ -20,6 +20,8 @@ import { UnfiledContainerAssociationPaging } from '../model/unfiledContainerAsso
 import { UnfiledContainerEntry } from '../model/unfiledContainerEntry';
 import { UnfiledRecordContainerBodyUpdate } from '../model/unfiledRecordContainerBodyUpdate';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Unfiledcontainers service.
@@ -152,16 +154,11 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<UnfiledContainerAssociationPaging>
     */
     createUnfiledContainerChildren(unfiledContainerId: string, nodeBodyCreate: RMNodeBodyCreate, opts?: any): Promise<UnfiledContainerAssociationPaging> {
+        throwIfNotDefined(unfiledContainerId, 'unfiledContainerId');
+        throwIfNotDefined(nodeBodyCreate, 'nodeBodyCreate');
+
         opts = opts || {};
         let postBody = nodeBodyCreate;
-
-        if (unfiledContainerId === undefined || unfiledContainerId === null) {
-            throw new Error("Required param 'unfiledContainerId' in createUnfiledContainerChildren");
-        }
-
-        if (nodeBodyCreate === undefined || nodeBodyCreate === null) {
-            throw new Error("Required param 'nodeBodyCreate' in createUnfiledContainerChildren");
-        }
 
         let pathParams = {
             'unfiledContainerId': unfiledContainerId
@@ -169,8 +166,8 @@ parameter are returned in addition to those specified in the **fields** paramete
 
         let queryParams = {
             'autoRename': opts['autoRename'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -218,20 +215,18 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<UnfiledContainerEntry>
         */
     getUnfiledContainer(unfiledContainerId: string, opts?: any): Promise<UnfiledContainerEntry> {
+        throwIfNotDefined(unfiledContainerId, 'unfiledContainerId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (unfiledContainerId === undefined || unfiledContainerId === null) {
-            throw new Error("Required param 'unfiledContainerId' in getUnfiledContainer");
-        }
 
         let pathParams = {
             'unfiledContainerId': unfiledContainerId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -293,12 +288,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<UnfiledContainerAssociationPaging>
         */
     listUnfiledContainerChildren(unfiledContainerId: string, opts?: any): Promise<UnfiledContainerAssociationPaging> {
+        throwIfNotDefined(unfiledContainerId, 'unfiledContainerId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (unfiledContainerId === undefined || unfiledContainerId === null) {
-            throw new Error("Required param 'unfiledContainerId' in listUnfiledContainerChildren");
-        }
 
         let pathParams = {
             'unfiledContainerId': unfiledContainerId
@@ -308,9 +301,9 @@ parameter are returned in addition to those specified in the **fields** paramete
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'includeSource': opts['includeSource'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -372,24 +365,19 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<UnfiledContainerEntry>
         */
     updateUnfiledContainer(unfiledContainerId: string, unfiledContainerBodyUpdate: UnfiledRecordContainerBodyUpdate, opts?: any): Promise<UnfiledContainerEntry> {
+        throwIfNotDefined(unfiledContainerId, 'unfiledContainerId');
+        throwIfNotDefined(unfiledContainerBodyUpdate, 'unfiledContainerBodyUpdate');
+
         opts = opts || {};
         let postBody = unfiledContainerBodyUpdate;
-
-        if (unfiledContainerId === undefined || unfiledContainerId === null) {
-            throw new Error("Required param 'unfiledContainerId' in updateUnfiledContainer");
-        }
-
-        if (unfiledContainerBodyUpdate === undefined || unfiledContainerBodyUpdate === null) {
-            throw new Error("Required param 'unfiledContainerBodyUpdate' in updateUnfiledContainer");
-        }
 
         let pathParams = {
             'unfiledContainerId': unfiledContainerId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/gs-core-rest-api/api/unfiledRecordFolders.api.ts
+++ b/src/api/gs-core-rest-api/api/unfiledRecordFolders.api.ts
@@ -20,6 +20,8 @@ import { UnfiledRecordFolderAssociationPaging } from '../model/unfiledRecordFold
 import { UnfiledRecordFolderBodyUpdate } from '../model/unfiledRecordFolderBodyUpdate';
 import { UnfiledRecordFolderEntry } from '../model/unfiledRecordFolderEntry';
 import { BaseApi } from './base.api';
+import { buildCollectionParam } from '../../../alfrescoApiClient';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Unfiledrecordfolders service.
@@ -152,16 +154,11 @@ parameter are returned in addition to those specified in the **fields** paramete
     * @return Promise<UnfiledRecordFolderAssociationPaging>
     */
     createUnfiledRecordFolderChildren(unfiledRecordFolderId: string, nodeBodyCreate: RMNodeBodyCreateWithRelativePath, opts?: any): Promise<UnfiledRecordFolderAssociationPaging> {
+        throwIfNotDefined(unfiledRecordFolderId, 'unfiledRecordFolderId');
+        throwIfNotDefined(nodeBodyCreate, 'nodeBodyCreate');
+
         opts = opts || {};
         let postBody = nodeBodyCreate;
-
-        if (unfiledRecordFolderId === undefined || unfiledRecordFolderId === null) {
-            throw new Error("Required param 'unfiledRecordFolderId' in createUnfiledRecordFolderChildren");
-        }
-
-        if (nodeBodyCreate === undefined || nodeBodyCreate === null) {
-            throw new Error("Required param 'nodeBodyCreate' in createUnfiledRecordFolderChildren");
-        }
 
         let pathParams = {
             'unfiledRecordFolderId': unfiledRecordFolderId
@@ -169,8 +166,8 @@ parameter are returned in addition to those specified in the **fields** paramete
 
         let queryParams = {
             'autoRename': opts['autoRename'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'include': buildCollectionParam(opts['include'], 'csv'),
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -197,12 +194,9 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<{}>
         */
     deleteUnfiledRecordFolder(unfiledRecordFolderId: string): Promise<any> {
+        throwIfNotDefined(unfiledRecordFolderId, 'unfiledRecordFolderId');
 
         let postBody = null;
-
-        if (unfiledRecordFolderId === undefined || unfiledRecordFolderId === null) {
-            throw new Error("Required param 'unfiledRecordFolderId' in deleteUnfiledRecordFolder");
-        }
 
         let pathParams = {
             'unfiledRecordFolderId': unfiledRecordFolderId
@@ -258,21 +252,19 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<UnfiledRecordFolderEntry>
         */
     getUnfiledRecordFolder(unfiledRecordFolderId: string, opts?: any): Promise<UnfiledRecordFolderEntry> {
+        throwIfNotDefined(unfiledRecordFolderId, 'unfiledRecordFolderId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (unfiledRecordFolderId === undefined || unfiledRecordFolderId === null) {
-            throw new Error("Required param 'unfiledRecordFolderId' in getUnfiledRecordFolder");
-        }
 
         let pathParams = {
             'unfiledRecordFolderId': unfiledRecordFolderId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'relativePath': opts['relativePath'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -336,12 +328,10 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<UnfiledRecordFolderAssociationPaging>
         */
     listUnfiledRecordFolderChildren(unfiledRecordFolderId: string, opts?: any): Promise<UnfiledRecordFolderAssociationPaging> {
+        throwIfNotDefined(unfiledRecordFolderId, 'unfiledRecordFolderId');
+
         opts = opts || {};
         let postBody = null;
-
-        if (unfiledRecordFolderId === undefined || unfiledRecordFolderId === null) {
-            throw new Error("Required param 'unfiledRecordFolderId' in listUnfiledRecordFolderChildren");
-        }
 
         let pathParams = {
             'unfiledRecordFolderId': unfiledRecordFolderId
@@ -351,10 +341,10 @@ parameter are returned in addition to those specified in the **fields** paramete
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
             'where': opts['where'],
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'relativePath': opts['relativePath'],
             'includeSource': opts['includeSource'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {
@@ -418,25 +408,20 @@ parameter are returned in addition to those specified in the **fields** paramete
         * @return Promise<UnfiledRecordFolderEntry>
         */
     updateUnfiledRecordFolder(unfiledRecordFolderId: string, unfiledRecordFolderBodyUpdate: UnfiledRecordFolderBodyUpdate, opts?: any): Promise<UnfiledRecordFolderEntry> {
+        throwIfNotDefined(unfiledRecordFolderId, 'unfiledRecordFolderId');
+        throwIfNotDefined(unfiledRecordFolderBodyUpdate, 'unfiledRecordFolderBodyUpdate');
+
         opts = opts || {};
         let postBody = unfiledRecordFolderBodyUpdate;
-
-        if (unfiledRecordFolderId === undefined || unfiledRecordFolderId === null) {
-            throw new Error("Required param 'unfiledRecordFolderId' in updateUnfiledRecordFolder");
-        }
-
-        if (unfiledRecordFolderBodyUpdate === undefined || unfiledRecordFolderBodyUpdate === null) {
-            throw new Error("Required param 'unfiledRecordFolderBodyUpdate' in updateUnfiledRecordFolder");
-        }
 
         let pathParams = {
             'unfiledRecordFolderId': unfiledRecordFolderId
         };
 
         let queryParams = {
-            'include': this.apiClient.buildCollectionParam(opts['include'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv'),
             'includeSource': opts['includeSource'],
-            'fields': this.apiClient.buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv')
         };
 
         let headerParams = {

--- a/src/api/search-rest-api/api/search.api.ts
+++ b/src/api/search-rest-api/api/search.api.ts
@@ -18,6 +18,7 @@
 import { ResultSetPaging } from '../model/resultSetPaging';
 import { SearchRequest } from '../model/searchRequest';
 import { BaseApi } from './base.api';
+import { throwIfNotDefined } from '../../../assert';
 
 /**
 * Search service.
@@ -328,12 +329,9 @@ The example above changes the highlighting prefix and postfix from the
     * @return Promise<ResultSetPaging>
     */
     search(queryBody: SearchRequest): Promise<ResultSetPaging> {
+        throwIfNotDefined(queryBody, 'queryBody');
 
         let postBody = queryBody;
-
-        if (queryBody === undefined || queryBody === null) {
-            throw new Error("Required param 'queryBody' in search");
-        }
 
         let pathParams = {
 

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -17,6 +17,6 @@
 
 export function throwIfNotDefined(param: any, name: string) {
     if (param === null || param === undefined) {
-        throw new Error(`Missing param ${name}`);
+        throw new Error(`Missing param '${name}'`);
     }
 }

--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,0 +1,22 @@
+/*!
+* @license
+* Copyright 2018 Alfresco Software, Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+export function throwIfNotDefined(param: any, name: string) {
+    if (param === null || param === undefined) {
+        throw new Error(`Missing param ${name}`);
+    }
+}

--- a/src/authentication/processAuth.ts
+++ b/src/authentication/processAuth.ts
@@ -40,8 +40,6 @@ export class ProcessAuth extends AlfrescoApiClient {
         this.className = 'ProcessAuth';
 
         if (!this.isBrowser()) {
-            console.log('this.defaultHeaders() ' + this.defaultHeaders);
-
             this.defaultHeaders = {
                 'user-agent': 'alfresco-js-api'
             };

--- a/src/authentication/processAuth.ts
+++ b/src/authentication/processAuth.ts
@@ -32,16 +32,20 @@ export class ProcessAuth extends AlfrescoApiClient {
         'basicAuth': { ticket: '' }, type: 'activiti'
     };
 
-    defaultHeaders = {
-        'user-agent': 'superagent'
-    };
-
     constructor(config: AlfrescoApiConfig) {
         super();
         this.storage = new Storage();
         this.storage.setDomainPrefix(config.domainPrefix);
 
         this.className = 'ProcessAuth';
+
+        if (!this.isBrowser()) {
+            console.log('this.defaultHeaders() ' + this.defaultHeaders);
+
+            this.defaultHeaders = {
+                'user-agent': 'alfresco-js-api'
+            };
+        }
 
         this.setConfig(config);
     }

--- a/src/authentication/processAuth.ts
+++ b/src/authentication/processAuth.ts
@@ -32,6 +32,10 @@ export class ProcessAuth extends AlfrescoApiClient {
         'basicAuth': { ticket: '' }, type: 'activiti'
     };
 
+    defaultHeaders = {
+        'user-agent': 'superagent'
+    };
+
     constructor(config: AlfrescoApiConfig) {
         super();
         this.storage = new Storage();

--- a/test/content-services/queriesApi.spec.ts
+++ b/test/content-services/queriesApi.spec.ts
@@ -32,7 +32,7 @@ describe('Queries', function () {
             let badCall = () => {
                 this.alfrescoJsApi.core.queriesApi.findNodes();
             };
-            expect(badCall).to.throw('Required param \'term\' in findNodes');
+            expect(badCall).to.throw(`Missing param 'term'`);
         });
 
         it('should invoke error handler on a server error', function (done) {


### PR DESCRIPTION
# Fix 

remove console.log from the auth (#585)
Table is broken. (#596)
[ADF-5006] Fix user agent warning  (#579)
use defaultheader only in node
[ACA-2755] sso public url (#576)

# Bump Version

Bump @types/superagent from 4.1.4 to 4.1.5
Bump commander from 4.1.0 to 4.1.1
Bump rollup from 1.30.1 to 1.31.0
Bump @types/node from 13.5.3 to 13.7.0
Bump @types/node from 13.5.2 to 13.5.3
Bump @types/mocha from 5.2.7 to 7.0.1
Bump @types/chai from 4.2.7 to 4.2.8
Bump @types/node from 13.5.1 to 13.5.2
Bump @types/node from 13.5.0 to 13.5.1
Bump rimraf from 3.0.0 to 3.0.1
Bump mocha from 7.0.0 to 7.0.1
Bump cspell from 4.0.44 to 4.0.46
Bump rollup from 1.29.1 to 1.30.1
Bump @types/node from 13.1.8 to 13.5.0
Bump sinon from 8.1.0 to 8.1.1
