### PR TITLE
Accept BodyTag array in createTagForNode

### DIFF
--- a/src/api-legacy/content-rest-api/src/api/tagsApi.ts
+++ b/src/api-legacy/content-rest-api/src/api/tagsApi.ts
@@ -39,7 +39,7 @@ export class TagsApi  {
      * @param {module:model/TagBody} tagBody The new tag
      * data is of type: {module:model/TagEntry}
      */
-    addTag(nodeId: string, tagBody: TagBody): Promise<TagEntry> {
+    addTag(nodeId: string, tagBody: TagBody[]): Promise<TagEntry> {
         return this.tagsApi.createTagForNode(nodeId, tagBody);
     }
 

--- a/src/api-legacy/content-rest-api/src/api/tagsApi.ts
+++ b/src/api-legacy/content-rest-api/src/api/tagsApi.ts
@@ -39,7 +39,7 @@ export class TagsApi  {
      * @param {module:model/TagBody} tagBody The new tag
      * data is of type: {module:model/TagEntry}
      */
-    addTag(nodeId: string, tagBody: TagBody[]): Promise<TagEntry> {
+    addTag(nodeId: string, tagBody: TagBody|TagBody[]): Promise<TagEntry> {
         return this.tagsApi.createTagForNode(nodeId, tagBody);
     }
 

--- a/src/api/content-rest-api/api/tags.api.ts
+++ b/src/api/content-rest-api/api/tags.api.ts
@@ -95,7 +95,7 @@ parameter are returned in addition to those specified in the **fields** paramete
 
     * @return Promise<TagEntry>
     */
-    createTagForNode(nodeId: string, tagBodyCreate: TagBody, opts?: any): Promise<TagEntry> {
+    createTagForNode(nodeId: string, tagBodyCreate: TagBody[], opts?: any): Promise<TagEntry> {
         throwIfNotDefined(nodeId, 'nodeId');
         throwIfNotDefined(tagBodyCreate, 'tagBodyCreate');
 

--- a/src/api/content-rest-api/api/tags.api.ts
+++ b/src/api/content-rest-api/api/tags.api.ts
@@ -95,7 +95,7 @@ parameter are returned in addition to those specified in the **fields** paramete
 
     * @return Promise<TagEntry>
     */
-    createTagForNode(nodeId: string, tagBodyCreate: TagBody[], opts?: any): Promise<TagEntry> {
+    createTagForNode(nodeId: string, tagBodyCreate: TagBody|TagBody[], opts?: any): Promise<TagEntry> {
         throwIfNotDefined(nodeId, 'nodeId');
         throwIfNotDefined(tagBodyCreate, 'tagBodyCreate');
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format) - **I can't reach the guidelines!**
- [ ] Tests for the changes have been added (for bug fixes / features) - **Test suite is broken for me**
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation
- [x] Other... Please describe: aligning features with documentation

**What is the current behavior?** (You can also link to an open issue here)

See issue #628
I also can't build my project with webpack because of that issue.
REST API works with both a single TagBody and a TagBody array, so it's a simple matter of allowing the array type in the function signature.

**What is the new behavior?**

`createTagForNode` and the legacy `addTag` accept a single TagBody as well as an array. 

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No


**Other information**:
As I mentioned at the beginning, I didn't create tests because I can't even run the existing tests with `npm test`:
```
test/performance/test-angular-old/src/app/app.component.spec.ts:1:32 - error TS2307: Cannot find module '@angular/core/testing'.
...
test/performance/test-angular-old/src/app/app.component.spec.ts:14:5 - error TS2304: Cannot find name 'expect'.
...
...
```

Anyway, I used my modified version in my project and it works flawlessly.