### PR TITLE
[ADF-155] Add count optional property to tag model

### DIFF
--- a/src/api/content-rest-api/docs/Tag.md
+++ b/src/api/content-rest-api/docs/Tag.md
@@ -5,5 +5,5 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **string** |  | [default to null]
 **tag** | **string** |  | [default to null]
-
+**count** | **number** |  | [optional, default to null]
 

--- a/src/api/content-rest-api/model/tag.ts
+++ b/src/api/content-rest-api/model/tag.ts
@@ -18,6 +18,7 @@
 export class Tag {
     id: string;
     tag: string;
+    count?: number;
 
     constructor(input?: any) {
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
No count property for the Tag model.


**What is the new behavior?**
The count property is needed when using the use of `include=count` when calling the API.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-155