### PR TITLE
[ACA-100] New method to retrieve a node's version's content

### DIFF
--- a/src/api/content-rest-api/api/content.api.ts
+++ b/src/api/content-rest-api/api/content.api.ts
@@ -99,6 +99,22 @@ export class ContentApi extends BaseApi {
     }
 
     /**
+     * Get content URL for the given nodeId and versionId
+     *
+     * @param  nodeId The ID of the document node
+     * @param versionId The ID of the version
+     * @param  [attachment=false] Retrieve content as an attachment for download
+     * @param  [ticket] Custom ticket to use for authentication
+     * @returns The URL address pointing to the content.
+     */
+    getVersionContentUrl(nodeId: string, versionId: string, attachment?: boolean, ticket?: string): string {
+        return this.apiClient.basePath + '/nodes/' + nodeId +
+            '/versions/' + versionId + '/content' +
+            '?attachment=' + (attachment ? 'true' : 'false') +
+            this.apiClient.getAlfTicket(ticket);
+    }
+
+    /**
      * Get content url for the given shared link id
      *
      * @param linkId - The ID of the shared link

--- a/test/alfrescoContent.spec.ts
+++ b/test/alfrescoContent.spec.ts
@@ -9,6 +9,7 @@ describe('AlfrescoContent', () => {
     const nodesUrl = hostEcm + '/alfresco/api/-default-/public/alfresco/versions/1/nodes/';
     const sharedLinksUrl = hostEcm + '/alfresco/api/-default-/public/alfresco/versions/1/shared-links/';
     const nodeId = '1a0b110f-1e09-4ca2-b367-fe25e4964a4';
+    const versionId = '1.1';
 
     let authResponseMock: any;
     let contentApi: ContentApi;
@@ -124,9 +125,62 @@ describe('AlfrescoContent', () => {
         let contentUrl = contentApi.getRenditionUrl(nodeId, encoding, true, 'custom_ticket');
 
         expect(contentUrl).to.be.equal(nodesUrl + nodeId +
-            '/renditions/' + encoding +
-            '/content?attachment=true' +
-            '&alf_ticket=custom_ticket');
+                                           '/renditions/' + encoding +
+                                           '/content?attachment=true' +
+                                           '&alf_ticket=custom_ticket');
+    });
+
+    it('outputs version rendition url', () => {
+        const encoding = 'pdf';
+        let contentUrl = contentApi.getVersionRenditionUrl(nodeId, versionId, encoding);
+
+        expect(contentUrl).to.be.equal(nodesUrl + nodeId + '/versions/' + versionId +
+                                           '/renditions/' + encoding +
+                                           '/content?attachment=false' +
+                                           '&alf_ticket=TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1');
+    });
+
+    it('outputs version rendition url as attachment', () => {
+        const encoding = 'pdf';
+        let contentUrl = contentApi.getVersionRenditionUrl(nodeId, versionId, encoding, true);
+
+        expect(contentUrl).to.be.equal(nodesUrl + nodeId + '/versions/' + versionId +
+                                           '/renditions/' + encoding +
+                                           '/content?attachment=true' +
+                                           '&alf_ticket=TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1');
+    });
+
+    it('outputs version rendition url with custom ticket', () => {
+        const encoding = 'pdf';
+        let contentUrl = contentApi.getVersionRenditionUrl(nodeId, versionId, encoding, true, 'custom_ticket');
+
+        expect(contentUrl).to.be.equal(nodesUrl + nodeId + '/versions/' + versionId +
+                                           '/renditions/' + encoding +
+                                           '/content?attachment=true' +
+                                           '&alf_ticket=custom_ticket');
+    });
+
+    it('outputs version content url', () => {
+        let contentUrl = contentApi.getVersionContentUrl(nodeId, versionId);
+
+        expect(contentUrl).to.be.equal(nodesUrl + nodeId + '/versions/' + versionId +
+                                           '/content?attachment=false' +
+                                           '&alf_ticket=TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1');
+    });
+
+    it('outputs version content url as attachment', () => {
+        let contentUrl = contentApi.getVersionContentUrl(nodeId, versionId, true);
+
+        expect(contentUrl).to.be.equal(nodesUrl + nodeId + '/versions/' + versionId +
+                                           '/content?attachment=true' +
+                                           '&alf_ticket=TICKET_4479f4d3bb155195879bfbb8d5206f433488a1b1');
+    });
+
+    it('outputs version content url with custom ticket', () => {
+        let contentUrl = contentApi.getVersionContentUrl(nodeId, versionId, true, 'custom_ticket');
+        expect(contentUrl).to.be.equal(nodesUrl + nodeId + '/versions/' + versionId +
+                                           '/content?attachment=true' +
+                                           '&alf_ticket=custom_ticket');
     });
 
     it('should output shared link content url', () => {


### PR DESCRIPTION
…it tests for the 2 new methods.

**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ACA-100


**What is the new behavior?**

Now I have a method that returns me the content url for a node's version

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
