### PR TITLE
reduce umd bundle size by 16%

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   "bundlesize": [
     {
       "path": "./dist/global/alfresco-js-api.umd.min.js",
-      "maxSize": "55 kB"
+      "maxSize": "45 kB"
     }
   ],
   "nyc": {

--- a/tools/rollup-bundle.js
+++ b/tools/rollup-bundle.js
@@ -8,6 +8,7 @@ module.exports = async function rollupBundle(options) {
 
     const inputOptions = {
         input: options.input,
+        external: ['superagent', 'minimatch', 'event-emitter'],
         plugins: [
             resolve(),
             options.minify ? terser({
@@ -27,7 +28,12 @@ module.exports = async function rollupBundle(options) {
             id: '@alfresco/js-api'
         },
         sourcemap: true,
-        sourcemapFile: `${dest}.map`
+        sourcemapFile: `${dest}.map`,
+        globals: {
+            'superagent': 'superagent',
+            'minimatch': 'minimatch',
+            'event-emitter': 'event-emitter'
+        }
     }
 
     try {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

Do not bundle the following external dependencies:

- superagent
- minimatch
- event-emitter

Reduce the `maxSize` rule to 44KB (from 55KB)

Size before:

```
alfresco-js-api.umd.min.js: 48.46KB < maxSize 55KB (gzip) 
```

Size after:

```
alfresco-js-api.umd.min.js: 40.75KB < maxSize 45KB (gzip) 
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
