### PR TITLE
workaround for minimatch

### DIFF
--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -360,7 +360,7 @@ export class AlfrescoApiClient implements ee.Emitter {
             url = this.buildUrl(path, pathParams);
         }
         return this.callHostApi(path, httpMethod, pathParams, queryParams, headerParams, formParams, bodyParam,
-            contentTypes, accepts, returnType, contextRoot, responseType, url);
+                                contentTypes, accepts, returnType, contextRoot, responseType, url);
     }
 
     request<T = any>(options: RequestOptions): Promise<T> {
@@ -441,7 +441,7 @@ export class AlfrescoApiClient implements ee.Emitter {
         const url = this.buildUrlCustomBasePath(path, '', pathParams);
 
         return this.callHostApi(path, httpMethod, pathParams, queryParams, headerParams, formParams, bodyParam,
-            contentTypes, accepts, returnType, contextRoot, responseType, url);
+                                contentTypes, accepts, returnType, contextRoot, responseType, url);
     }
 
     /**
@@ -479,7 +479,7 @@ export class AlfrescoApiClient implements ee.Emitter {
         const eventEmitter: any = ee({});
 
         let request = this.buildRequest(httpMethod, url, queryParams, headerParams, formParams, bodyParam,
-            contentTypes, accepts, responseType, eventEmitter, returnType);
+                                        contentTypes, accepts, responseType, eventEmitter, returnType);
 
         if (returnType === 'Binary') {
             request = request.buffer(true).parse(superagent.parse['application/octet-stream']);

--- a/src/api/activiti-rest-api/api/processInstances.api.ts
+++ b/src/api/activiti-rest-api/api/processInstances.api.ts
@@ -228,7 +228,7 @@ export class ProcessInstancesApi extends BaseApi {
         return this.apiClient.callApi(
             '/api/enterprise/process-instances/{processInstanceId}/decision-tasks', 'GET',
             pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts)
+            contentTypes, accepts);
     }
      /**
      * Get historic variables for a process instance

--- a/src/api/activiti-rest-api/model/systemPropertiesRepresentation.ts
+++ b/src/api/activiti-rest-api/model/systemPropertiesRepresentation.ts
@@ -19,7 +19,7 @@ export class SystemPropertiesRepresentation {
     allowInvolveByEmail?: boolean;
     disableJavaScriptEventsInFormEditor?: boolean;
     logoutDisabled?: boolean;
-    authConfiguration: { authUrl: string, realm: string, clientId: string, useBrowserLogout: boolean}
+    authConfiguration: { authUrl: string, realm: string, clientId: string, useBrowserLogout: boolean};
 
     constructor(input?: any) {
 

--- a/src/authentication/contentAuth.ts
+++ b/src/authentication/contentAuth.ts
@@ -123,7 +123,7 @@ export class ContentAuth extends AlfrescoApiClient {
                     promise.emit('success');
                     resolve(data.entry.id);
                 },
-                (error) => {
+                                               (error) => {
                     if (error.status === 401) {
                         promise.emit('unauthorized');
                     }

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -23,7 +23,7 @@ import { AuthenticationApi } from '../api/auth-rest-api/api/authentication.api';
 import { AlfrescoApi } from '../alfrescoApi';
 import { Storage } from '../storage';
 
-// tslint:disable-next-line: no-var-requires
+// tslint:disable-next-line
 const minimatch = require('minimatch');
 
 declare let window: Window;

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -19,10 +19,12 @@ import ee from 'event-emitter';
 import { AlfrescoApiClient } from '../alfrescoApiClient';
 import { AlfrescoApiConfig } from '../alfrescoApiConfig';
 import { Authentication } from './authentication';
-import minimatch from 'minimatch';
 import { AuthenticationApi } from '../api/auth-rest-api/api/authentication.api';
 import { AlfrescoApi } from '../alfrescoApi';
 import { Storage } from '../storage';
+
+// tslint:disable-next-line: no-var-requires
+const minimatch = require('minimatch');
 
 declare let window: Window;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

workaround for minimatch to support old versions of typescript and ng-packgr

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
