### PR TITLE
support custom api calls with generic api

### DIFF
--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -377,7 +377,8 @@ export class AlfrescoApiClient implements ee.Emitter {
             options.accepts,
             options.returnType,
             options.contextRoot,
-            options.responseType
+            options.responseType,
+            options.url
         );
     }
 

--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -40,6 +40,7 @@ export interface RequestOptions {
     returnType?: any;
     contextRoot?: string;
     responseType?: string;
+    url?: string;
 }
 
 /**
@@ -349,15 +350,15 @@ export class AlfrescoApiClient implements ee.Emitter {
      * constructor for a complex type.   * @returns {Promise} A Promise object.
      */
     callApi(path: string, httpMethod: string, pathParams?: any, queryParams?: any, headerParams?: any, formParams?: any, bodyParam?: any,
-            contentTypes?: string[], accepts?: string[], returnType?: any, contextRoot?: string, responseType?: string): Promise<any> {
+            contentTypes?: string[], accepts?: string[], returnType?: any, contextRoot?: string, responseType?: string, url?: string): Promise<any> {
 
-        let url;
-
-        if (contextRoot) {
-            const basePath = `${this.host}/${contextRoot}`;
-            url = this.buildUrlCustomBasePath(basePath, path, pathParams);
-        } else {
-            url = this.buildUrl(path, pathParams);
+        if (!url) {
+            if (contextRoot) {
+                const basePath = `${this.host}/${contextRoot}`;
+                url = this.buildUrlCustomBasePath(basePath, path, pathParams);
+            } else {
+                url = this.buildUrl(path, pathParams);
+            }
         }
         return this.callHostApi(path, httpMethod, pathParams, queryParams, headerParams, formParams, bodyParam,
                                 contentTypes, accepts, returnType, contextRoot, responseType, url);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

provides support for `url` parameter (emulating the `callCustomApi` calls) with the generic methods
especially useful with oauth client and private api calls

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
