### PR TITLE
Fix hang setinterval for missing logout

### DIFF
--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -558,6 +558,8 @@ export class Oauth2Auth extends AlfrescoApiClient {
             } catch (e) {
             }
         }, this.config.oauth2.refreshTokenTimeout);
+
+        this.refreshTokenIntervalPolling.unref();
     }
 
     /**

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -83,7 +83,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
             }
 
             if (!this.config.oauth2.refreshTokenTimeout) {
-                this.config.oauth2.refreshTokenTimeout = 30000;
+                this.config.oauth2.refreshTokenTimeout = 300000;
             }
 
             if (!this.config.oauth2.redirectSilentIframeUri) {
@@ -104,11 +104,10 @@ export class Oauth2Auth extends AlfrescoApiClient {
                 this.exchangeTicketListener(alfrescoApi);
             }
 
-            this.initOauth(); // jshint ignore:line
+            this.initOauth();
         }
     }
 
-    // Init Core - Init Js-api -
     initOauth() {
         if (!this.config.oauth2.implicitFlow && this.isValidAccessToken()) {
             const accessToken = this.storage.getItem('access_token');
@@ -553,8 +552,11 @@ export class Oauth2Auth extends AlfrescoApiClient {
     }
 
     pollingRefreshToken() {
-        this.refreshTokenIntervalPolling = setInterval(() => {
-            this.refreshToken();
+        this.refreshTokenIntervalPolling = setInterval(async () => {
+            try {
+                await this.refreshToken();
+            } catch (e) {
+            }
         }, this.config.oauth2.refreshTokenTimeout);
     }
 

--- a/test/oauth2Auth.spec.ts
+++ b/test/oauth2Auth.spec.ts
@@ -140,6 +140,37 @@ describe('Oauth2  test', () => {
             oauth2Auth.login('admin', 'admin');
         });
 
+        it('should not hang thee app also if teh logout is missing', function(done)  {
+            this.timeout(3000);
+            oauth2Mock.get200Response();
+
+            const oauth2Auth = new Oauth2Auth(
+                <AlfrescoApiConfig> {
+                    oauth2: {
+                        'host': 'http://myOauthUrl:30081/auth/realms/springboot',
+                        'clientId': 'activiti',
+                        'scope': 'openid',
+                        'secret': '',
+                        'redirectUri': '/',
+                        'redirectUriLogout': '/logout',
+                        'implicitFlow': false,
+                        'refreshTokenTimeout': 100
+                    },
+                    authType: 'OAUTH'
+                },
+                alfrescoJsApi
+            );
+
+            const refreshSpy = chai.spy.on(oauth2Auth, 'refreshToken');
+
+            setTimeout(() => {
+                expect(refreshSpy).to.have.been.called.min(2);
+                done();
+            }, 600);
+
+            oauth2Auth.login('admin', 'admin');
+        });
+
         it('should emit a token_issued event if login is ok ', (done) => {
             oauth2Mock.get200Response();
 

--- a/test/oauth2Auth.spec.ts
+++ b/test/oauth2Auth.spec.ts
@@ -140,7 +140,7 @@ describe('Oauth2  test', () => {
             oauth2Auth.login('admin', 'admin');
         });
 
-        it('should not hang thee app also if teh logout is missing', function(done)  {
+        it('should not hang the app also if teh logout is missing', function(done)  {
             this.timeout(3000);
             oauth2Mock.get200Response();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
In general, node wait for all timeouts and interval to finish before to end the app unless we unrefer it 
https://nodejs.org/api/timers.html#timers_unref
**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
