### PR TITLE
Fix refresh when in not silent mode

### DIFF
--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -168,7 +168,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
                 this.implicitLogin();
             }
 
-            if(this.isValidAccessToken()) {
+            if(this.isValidToken() && this.isValidAccessToken()) {
                 let accessToken = this.storage.getItem('access_token');
                 this.setToken(accessToken, null);
             }

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -167,8 +167,11 @@ export class Oauth2Auth extends AlfrescoApiClient {
             if (this.config.oauth2.silentLogin && !this.isPublicUrl()) {
                 this.implicitLogin();
             }
-            let accessToken = this.storage.getItem('access_token');
-            this.setToken(accessToken, null);
+
+            if(this.isValidAccessToken()) {
+                let accessToken = this.storage.getItem('access_token');
+                this.setToken(accessToken, null);
+            }
         }
 
     }

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -167,6 +167,8 @@ export class Oauth2Auth extends AlfrescoApiClient {
             if (this.config.oauth2.silentLogin && !this.isPublicUrl()) {
                 this.implicitLogin();
             }
+            let accessToken = this.storage.getItem('access_token');
+            this.setToken(accessToken, null);
         }
 
     }
@@ -257,9 +259,6 @@ export class Oauth2Auth extends AlfrescoApiClient {
     implicitLogin() {
         if (!this.isValidToken() || !this.isValidAccessToken()) {
             this.redirectLogin();
-        } else {
-            let accessToken = this.storage.getItem('access_token');
-            this.setToken(accessToken, null);
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

We don't get the access token from the storage when init the js-api if si not in silent login, that is a problem when this mode is on and wee refresh
**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
