### PR TITLE
[AAE-4745] Add iframe for refresh the token when we refresh the browser

### DIFF
--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -115,7 +115,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
         }
 
         if (this.config.oauth2.implicitFlow) {
-            this.checkFragment(null, 'nonce');
+            this.checkFragment({ nonceKey: 'nonce' });
         }
     }
 
@@ -132,48 +132,48 @@ export class Oauth2Auth extends AlfrescoApiClient {
     checkFragment(externalHash?: any, nonceKey?: string): any {// jshint ignore:line
         this.hashFragmentParams = this.getHashFragmentParams(externalHash);
 
-        if (externalHash === undefined && this.isValidAccessToken()) {
+        if (this.hashFragmentParams && this.hashFragmentParams.error === undefined) {
+            this.useFragmentTimeLogin(nonceKey);
+        } else {
+            this.refreshBrowserLogin();
+        }
+    }
+
+    private refreshBrowserLogin() {
+        if (this.config.oauth2.silentLogin && !this.isPublicUrl()) {
+            this.implicitLogin();
+        }
+
+        if (this.isValidToken() && this.isValidAccessToken()) {
             let accessToken = this.storage.getItem('access_token');
             this.setToken(accessToken, null);
             this.silentRefresh();
-            return accessToken;
+        }
+    }
+
+    private useFragmentTimeLogin(nonceKey: string) {
+        let accessToken = this.hashFragmentParams.access_token;
+        let idToken = this.hashFragmentParams.id_token;
+        let sessionState = this.hashFragmentParams.session_state;
+        let expiresIn = this.hashFragmentParams.expires_in;
+
+        if (!sessionState) {
+            throw('session state not present');
         }
 
-        if (this.hashFragmentParams && this.hashFragmentParams.error === undefined) {
-            let accessToken = this.hashFragmentParams.access_token;
-            let idToken = this.hashFragmentParams.id_token;
-            let sessionState = this.hashFragmentParams.session_state;
-            let expiresIn = this.hashFragmentParams.expires_in;
-
-            if (!sessionState) {
-                throw('session state not present');
+        try {
+            const jwt = this.processJWTToken(idToken, nonceKey);
+            if (jwt) {
+                this.storeIdToken(idToken, jwt.payload.exp);
+                this.storeAccessToken(accessToken, expiresIn);
+                this.authentications.basicAuth.username = jwt.payload.preferred_username;
+                this.saveUsername(jwt.payload.preferred_username);
+                this.silentRefresh();
+                return accessToken;
             }
-
-            try {
-                const jwt = this.processJWTToken(idToken, nonceKey);
-                if (jwt) {
-                    this.storeIdToken(idToken, jwt.payload.exp);
-                    this.storeAccessToken(accessToken, expiresIn);
-                    this.authentications.basicAuth.username = jwt.payload.preferred_username;
-                    this.saveUsername(jwt.payload.preferred_username);
-                    this.silentRefresh();
-                    return accessToken;
-                }
-            } catch (error) {
-                throw('Validation JWT error' + error);
-            }
-
-        } else {
-            if (this.config.oauth2.silentLogin && !this.isPublicUrl()) {
-                this.implicitLogin();
-            }
-
-            if (this.isValidToken() && this.isValidAccessToken()) {
-                let accessToken = this.storage.getItem('access_token');
-                this.setToken(accessToken, null);
-            }
+        } catch (error) {
+            throw('Validation JWT error' + error);
         }
-
     }
 
     isPublicUrl(): boolean {
@@ -212,7 +212,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
 
             if (payload.nonce !== savedNonce) {
                 console.log('Failing nonce JWT is not corresponding' + payload.nonce);
-                return ;
+                return;
             }
 
             return {
@@ -560,7 +560,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
                 await this.refreshToken();
             } catch (e) {
             }
-        },                                             this.config.oauth2.refreshTokenTimeout);
+        }, this.config.oauth2.refreshTokenTimeout);
 
         this.refreshTokenIntervalPolling.unref();
     }

--- a/test/oauth2AuthImplicitFlow.spec.ts
+++ b/test/oauth2AuthImplicitFlow.spec.ts
@@ -23,7 +23,7 @@ describe('Oauth2 Implicit flow test', () => {
     it('should throw an error if redirectUri is not present', (done) => {
         try {
             oauth2Auth = new Oauth2Auth(
-                <any>{
+                <any> {
                     oauth2: {
                         host: 'http://myOauthUrl:30081/auth/realms/springboot',
                         clientId: 'activiti',
@@ -42,6 +42,11 @@ describe('Oauth2 Implicit flow test', () => {
 
     it('should redirect to login if access token is not valid', (done) => {
         window = globalAny.window = { location: {} };
+        globalAny.document = {
+            getElementById: () => {
+                return ''
+            }
+        };
 
         oauth2Auth = new Oauth2Auth(
             {
@@ -68,7 +73,11 @@ describe('Oauth2 Implicit flow test', () => {
 
     it('should not loop over redirection when redirectUri contains hash and token is not valid ', (done) => {
         window = globalAny.window = { location: {} };
-
+        globalAny.document = {
+            getElementById: () => {
+                return ''
+            }
+        };
         oauth2Auth = new Oauth2Auth(
             {
                 oauth2: {
@@ -97,7 +106,11 @@ describe('Oauth2 Implicit flow test', () => {
 
     it('should not redirect to login if access token is valid', (done) => {
         window = globalAny.window = { location: {} };
-
+        globalAny.document = {
+            getElementById: () => {
+                return ''
+            }
+        };
         oauth2Auth = new Oauth2Auth(
             {
                 oauth2: {
@@ -130,8 +143,13 @@ describe('Oauth2 Implicit flow test', () => {
     });
 
     it('should set the loginFragment to redirect after the login if it is present', (done) => {
-        window = globalAny.window = { };
-        window.location = <Location> { hash : 'asfasfasfa'};
+        window = globalAny.window = {};
+        globalAny.document = {
+            getElementById: () => {
+                return ''
+            }
+        };
+        window.location = <Location> { hash: 'asfasfasfa' };
 
         Object.defineProperty(window.location, 'hash', {
             writable: true,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
The iframe for refresh the token doesn't get create once you refresh your browser


**What is the new behavior?**
The iframe for refresh the token get create once you refresh your browser



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
