### PR TITLE
[MNT-22286] Fix cut params on redirect

### DIFF
--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -330,7 +330,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
 
         this.storage.setItem('nonce', nonce);
 
-        const afterLoginUriSegment = this.isRedirectionUrl() ? window.location.hash.split('&')[0] : '';
+        const afterLoginUriSegment = this.isRedirectionUrl() ? window.location.hash : '';
         if (afterLoginUriSegment && afterLoginUriSegment !== '/') {
             this.storage.setItem('loginFragment', afterLoginUriSegment.replace('#', '').trim());
         }

--- a/test/oauth2AuthImplicitFlow.spec.ts
+++ b/test/oauth2AuthImplicitFlow.spec.ts
@@ -180,7 +180,7 @@ describe('Oauth2 Implicit flow test', () => {
         oauth2Auth.on('implicit_redirect', () => {
             expect(window.location.href).contain('http://myOauthUrl:30081/auth/realms/springboot/protocol/' +
                 'openid-connect/auth?');
-            expect(setItemSpy).to.have.been.called.with('loginFragment', '/redirect-path');
+            expect(setItemSpy).to.have.been.called.with('loginFragment', '/redirect-path&session_state=eqfqwfqwf');
             done();
         });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
when you get redirected the redirect removes everything after the first ampersand.




**What is the new behavior?**
when you get redirected the redirect the whole URL is used



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
