### PR TITLE
(fix) getNodeContent throwing error 

### DIFF
--- a/src/api/content-rest-api/api/nodes.api.ts
+++ b/src/api/content-rest-api/api/nodes.api.ts
@@ -853,7 +853,7 @@ Single part request supported, for example: bytes=1-10.
         return this.apiClient.callApi(
             '/nodes/{nodeId}/content', 'GET',
             pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts , Blob);
+            contentTypes, accepts , 'blob'https://github.com/Alfresco/alfresco-js-api/issues/903);
     }
 /**
     * List node children

--- a/src/api/content-rest-api/api/nodes.api.ts
+++ b/src/api/content-rest-api/api/nodes.api.ts
@@ -853,7 +853,7 @@ Single part request supported, for example: bytes=1-10.
         return this.apiClient.callApi(
             '/nodes/{nodeId}/content', 'GET',
             pathParams, queryParams, headerParams, formParams, postBody,
-            contentTypes, accepts , 'blob'https://github.com/Alfresco/alfresco-js-api/issues/903);
+            contentTypes, accepts , 'blob');
     }
 /**
     * List node children


### PR DESCRIPTION
https://github.com/Alfresco/alfresco-js-api/issues/903

**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/Alfresco/alfresco-js-api/issues/903


**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
