### PR TITLE
Add that node 12 is required in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,8 @@ alfrescoJsApi.nodes
 
 # Development
 
+NodeJs versions newer that version 12 may have build errors.
+
 To run the build
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -117,5 +117,8 @@
   },
   "keywords": [
     "alfresco"
-  ]
+  ],
+  "volta": {
+    "node": "12.22.1"
+  }
 }


### PR DESCRIPTION
The build seems fail with later versions of node.

Also add volta config for a node version that currently works and can be updated when later node versions are supported.

**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
