### PR TITLE
Support custom OAuth endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,9 @@ refreshTokenTimeout|  millisecond value, after how many millisecond you want ref
 redirectSilentIframeUri|  url to be redirect after silent refresh login| /assets/silent-refresh.html |
 silentLogin|  direct execute the implicit login without the need to call AlfrescoJsApi.implicitLogin() method|   false|
 publicUrls | list of public urls that don't need authorization. It is possible too pass absolute paths and string patterns that are valid for [minimatch](https://github.com/isaacs/minimatch#readme) |
+authorizationUrl| authorization url, relative to the host| /protocol/openid-connect/auth|
+tokenUrl| token url, relative to the host| /protocol/openid-connect/token|
+logoutUrl| logout url, relative to the host| /protocol/openid-connect/logout|
 
 The api/js-api will automatically redirect you to the login page anf refresh the token if necessary
 

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -32,6 +32,10 @@ declare let window: Window;
 
 export class Oauth2Auth extends AlfrescoApiClient {
 
+    static readonly DEFAULT_AUTHORIZATION_URL = '/protocol/openid-connect/auth';
+    static readonly DEFAULT_TOKEN_URL = '/protocol/openid-connect/token';
+    static readonly DEFAULT_LOGOUT_URL = '/protocol/openid-connect/logout';
+
     private refreshTokenIntervalPolling: any;
     private refreshTokenTimeoutIframe: any;
     private checkAccessToken = true;
@@ -39,7 +43,11 @@ export class Oauth2Auth extends AlfrescoApiClient {
 
     hashFragmentParams: any;
     token: string;
-    discovery: any = {};
+    discovery: {
+        loginUrl?: string;
+        logoutUrl?: string;
+        tokenEndpoint?: string;
+    } = {};
 
     authentications: Authentication = {
         'oauth2': { accessToken: '' }, type: 'oauth2', 'basicAuth': {}
@@ -121,9 +129,9 @@ export class Oauth2Auth extends AlfrescoApiClient {
     }
 
     discoveryUrls() {
-        this.discovery.loginUrl = `${this.host}/protocol/openid-connect/auth`;
-        this.discovery.logoutUrl = `${this.host}/protocol/openid-connect/logout`;
-        this.discovery.tokenEndpoint = `${this.host}/protocol/openid-connect/token`;
+        this.discovery.loginUrl = this.host + (this.config.oauth2.authorizationUrl || Oauth2Auth.DEFAULT_AUTHORIZATION_URL);
+        this.discovery.logoutUrl = this.host + (this.config.oauth2.logoutUrl || Oauth2Auth.DEFAULT_LOGOUT_URL);
+        this.discovery.tokenEndpoint = this.host + (this.config.oauth2.tokenUrl || Oauth2Auth.DEFAULT_TOKEN_URL);
     }
 
     hasContentProvider(): boolean {

--- a/src/authentication/oauth2Config.ts
+++ b/src/authentication/oauth2Config.ts
@@ -19,6 +19,9 @@ export interface Oauth2Config {
     clientId: string;
     secret?: string;
     host: string;
+    authorizationUrl?: string;
+    tokenUrl?: string;
+    logoutUrl?: string;
     scope: string;
     implicitFlow?: boolean;
     redirectUri: string;

--- a/test/oauth2Auth.spec.ts
+++ b/test/oauth2Auth.spec.ts
@@ -30,6 +30,59 @@ describe('Oauth2  test', () => {
         });
     });
 
+    describe('Discovery urls', () => {
+        const authType = 'OAUTH';
+        const host = 'http://dummy/auth';
+        const clientId = 'dummy';
+        const scope = 'openid';
+        const redirectUri = '/';
+
+        it('should have default urls', async () => {
+            const oauth2Auth = new Oauth2Auth(
+                <AlfrescoApiConfig> {
+                    oauth2: {
+                        host,
+                        clientId,
+                        scope,
+                        redirectUri
+                    },
+                    authType
+                },
+                alfrescoJsApi
+            );
+
+            expect(oauth2Auth.discovery.loginUrl).to.be.equal(host + Oauth2Auth.DEFAULT_AUTHORIZATION_URL);
+            expect(oauth2Auth.discovery.tokenEndpoint).to.be.equal(host + Oauth2Auth.DEFAULT_TOKEN_URL);
+            expect(oauth2Auth.discovery.logoutUrl).to.be.equal(host + Oauth2Auth.DEFAULT_LOGOUT_URL);
+        });
+
+        it('should be possible to override the default urls', async () => {
+            const authorizationUrl = '/custom-login';
+            const logoutUrl = '/custom-logout';
+            const tokenUrl = '/custom-token';
+            const oauth2Auth = new Oauth2Auth(
+                <AlfrescoApiConfig> {
+                    oauth2: {
+                        host,
+                        authorizationUrl,
+                        logoutUrl,
+                        tokenUrl,
+                        clientId,
+                        scope,
+                        redirectUri
+                    },
+                    authType
+                },
+                alfrescoJsApi
+            );
+
+            expect(oauth2Auth.discovery.loginUrl).to.be.equal(host + authorizationUrl);
+            expect(oauth2Auth.discovery.tokenEndpoint).to.be.equal(host + tokenUrl);
+            expect(oauth2Auth.discovery.logoutUrl).to.be.equal(host + logoutUrl);
+        });
+
+    });
+
     describe('With Authentication', () => {
 
         it('should be possible have different user login in different instance of the oauth2Auth class', async () => {


### PR DESCRIPTION
This just adds support for custom OAuth endpoints (authorization, token and logout) so we can use other OIC providers.
 
There's a related ticket about `authPath` not working (https://github.com/Alfresco/alfresco-js-api/issues/830).
I could easily add back support for it if needed/wanted.

- [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

- [ ] Bugfix  
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [X] No

