### PR TITLE
[MNT-22840] Use ticket parameter instead of alf_ticket when withCredentials configuration is enabled

### DIFF
--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -706,10 +706,12 @@ export class AlfrescoApiClient implements ee.Emitter, HttpClient {
 
     getAlfTicket(ticket: string): string {
         let alfTicketFragment = '';
+        const ticketParam = this.isWithCredentials() ? '&ticket=' : '&alf_ticket=';
+
         if (ticket) {
-            alfTicketFragment = '&alf_ticket=' + ticket;
+            alfTicketFragment = ticketParam + ticket;
         } else if (this.config.ticketEcm) {
-            alfTicketFragment = '&alf_ticket=' + this.config.ticketEcm;
+            alfTicketFragment = ticketParam + this.config.ticketEcm;
         }
 
         return alfTicketFragment;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

There are operations (as preview or download a document), where the URL sends the alf_ticket parameter. When Kerberos is enabled and ADW is accessed without SSO, these operations fail as the alf_ticket parameter doesn't work.

**What is the new behavior?**

If auth.withCredentials config is enabled, the ticket parameter is now sent instead of alf_ticket. The operations as preview or download a document now work.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
