### PR TITLE
Feat/extract http client from alfresco api client

### DIFF
--- a/api-codegen/src/main/resources/api-code-gen/base.api.mustache
+++ b/api-codegen/src/main/resources/api-code-gen/base.api.mustache
@@ -1,10 +1,10 @@
 {{>licenseInfo}}
 
 import { ApiClient } from '../../../api-clients/api-client';
-import { HttpClient } from '../../../api-clients/http-client.interface';
+import { LegacyHttpClient } from '../../../api-clients/http-client.interface';
 
 export abstract class BaseApi extends ApiClient {
-    get apiClient(): HttpClient {
+    get apiClient(): LegacyHttpClient {
         return this.httpClient ?? this.alfrescoApi.contentClient;
     }
 }

--- a/index.ts
+++ b/index.ts
@@ -45,3 +45,4 @@ export * from './src/to-deprecate/alfresco-api-type';
 
 export * from './src/api-clients/api-client';
 export * from './src/api-clients/http-client.interface';
+export * from './src/utils';

--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -25,6 +25,7 @@ import { Storage } from './storage';
 import { AlfrescoApiConfig } from './alfrescoApiConfig';
 import { Authentication } from './authentication/authentication';
 import { AlfrescoApiType } from './to-deprecate/alfresco-api-type';
+import { HttpClient } from './api-clients/http-client.interface';
 
 export class AlfrescoApi implements Emitter, AlfrescoApiType {
     __type = 'legacy-client';
@@ -51,7 +52,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
 
     username: string;
 
-    constructor(config?: AlfrescoApiConfig) {
+    constructor(config?: AlfrescoApiConfig, public httpClient?: HttpClient) {
         ee(this);
 
         if (config) {
@@ -71,7 +72,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
 
         this.clientsFactory();
 
-        this.processClient = new ProcessClient(this.config);
+        this.processClient = new ProcessClient(this.config, this.httpClient);
 
         this.errorListeners();
         this.initAuth(config);
@@ -87,7 +88,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
         if (this.isOauthConfiguration()) {
 
             if (!this.oauth2Auth) {
-                this.oauth2Auth = new Oauth2Auth(this.config, this);
+                this.oauth2Auth = new Oauth2Auth(this.config, this, this.httpClient);
             } else {
                 this.oauth2Auth.setConfig(this.config, this);
             }
@@ -100,7 +101,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
         } else {
 
             if (!this.processAuth) {
-                this.processAuth = new ProcessAuth(this.config);
+                this.processAuth = new ProcessAuth(this.config, this.httpClient);
             } else {
                 this.processAuth.setConfig(this.config);
             }
@@ -110,7 +111,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
             });
 
             if (!this.contentAuth) {
-                this.contentAuth = new ContentAuth(this.config, this);
+                this.contentAuth = new ContentAuth(this.config, this, this.httpClient);
             } else {
                 this.contentAuth.setConfig(config);
             }
@@ -126,43 +127,43 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
 
     private clientsFactory() {
         if (!this.contentPrivateClient) {
-            this.contentPrivateClient = new ContentClient(this.config, `/api/${this.config.tenant}/private/alfresco/versions/1`);
+            this.contentPrivateClient = new ContentClient(this.config, `/api/${this.config.tenant}/private/alfresco/versions/1`, this.httpClient);
         } else {
             this.contentPrivateClient.setConfig(this.config, `/api/${this.config.tenant}/private/alfresco/versions/1`);
         }
 
         if (!this.contentClient) {
-            this.contentClient = new ContentClient(this.config, `/api/${this.config.tenant}/public/alfresco/versions/1`);
+            this.contentClient = new ContentClient(this.config, `/api/${this.config.tenant}/public/alfresco/versions/1`, this.httpClient);
         } else {
             this.contentClient.setConfig(this.config, `/api/${this.config.tenant}/public/alfresco/versions/1`);
         }
 
         if (!this.authClient) {
-            this.authClient = new ContentClient(this.config, `/api/${this.config.tenant}/public/authentication/versions/1`);
+            this.authClient = new ContentClient(this.config, `/api/${this.config.tenant}/public/authentication/versions/1`, this.httpClient);
         } else {
             this.authClient.setConfig(this.config, `/api/${this.config.tenant}/public/authentication/versions/1`);
         }
 
         if (!this.searchClient) {
-            this.searchClient = new ContentClient(this.config, `/api/${this.config.tenant}/public/search/versions/1`);
+            this.searchClient = new ContentClient(this.config, `/api/${this.config.tenant}/public/search/versions/1`, this.httpClient);
         } else {
             this.searchClient.setConfig(this.config, `/api/${this.config.tenant}/public/search/versions/1`);
         }
 
         if (!this.discoveryClient) {
-            this.discoveryClient = new ContentClient(this.config, `/api`);
+            this.discoveryClient = new ContentClient(this.config, `/api`, this.httpClient);
         } else {
             this.discoveryClient.setConfig(this.config, `/api`);
         }
 
         if (!this.gsClient) {
-            this.gsClient = new ContentClient(this.config, `/api/${this.config.tenant}/public/gs/versions/1`);
+            this.gsClient = new ContentClient(this.config, `/api/${this.config.tenant}/public/gs/versions/1`, this.httpClient);
         } else {
             this.gsClient.setConfig(this.config, `/api/${this.config.tenant}/public/gs/versions/1`);
         }
 
         if (!this.processClient) {
-            this.processClient = new ProcessClient(this.config);
+            this.processClient = new ProcessClient(this.config, this.httpClient);
         } else {
             this.processClient.setConfig(this.config);
         }

--- a/src/api-clients/api-client.ts
+++ b/src/api-clients/api-client.ts
@@ -15,21 +15,20 @@
 * limitations under the License.
 */
 
-import { AlfrescoApiType } from "../to-deprecate/alfresco-api-type";
-import { HttpClient, RequestOptions } from "./http-client.interface";
+import { AlfrescoApiType } from '../to-deprecate/alfresco-api-type';
+import { LegacyHttpClient, RequestOptions } from './http-client.interface';
 
 export abstract class ApiClient {
-
     protected alfrescoApi: AlfrescoApiType;
-    protected httpClient: HttpClient;
+    protected httpClient: LegacyHttpClient;
 
-    get apiClient(): HttpClient {
+    get apiClient(): LegacyHttpClient {
         return this.httpClient;
     }
 
     constructor(legacyApi?: AlfrescoApiType);
-    constructor(httpClient: HttpClient);
-    constructor(httpClient?: AlfrescoApiType & HttpClient) {
+    constructor(httpClient: LegacyHttpClient);
+    constructor(httpClient?: AlfrescoApiType & LegacyHttpClient) {
         if (httpClient?.__type === 'legacy-client') {
             // TODO: remove legacyApi?: AlfrescoApi option and clean up this code. BREAKING CHANGE!
             this.alfrescoApi = httpClient;

--- a/src/api-clients/http-client.interface.ts
+++ b/src/api-clients/http-client.interface.ts
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+import { Authentication } from '../authentication/authentication';
+import { Emitter } from 'event-emitter';
+
 export interface RequestOptions {
     path: string;
     httpMethod?: string;
@@ -29,6 +32,8 @@ export interface RequestOptions {
     contextRoot?: string;
     responseType?: string;
     url?: string;
+    readonly accept?: string;
+    readonly contentType?: string;
 }
 
 export interface HttpClientConfig {
@@ -36,7 +41,8 @@ export interface HttpClientConfig {
     host?: string; // Should be mandatory but can't make it because of AlfrescoApiConfig incompatibility 😕
     servicePath?: string; // Should be mandatory but can't make it because of AlfrescoApiConfig incompatibility 😕
 }
-export interface HttpClient {
+
+export interface LegacyHttpClient {
     basePath: string;
     config: HttpClientConfig;
 
@@ -76,4 +82,25 @@ export interface HttpClient {
         contextRoot?: string,
         responseType?: string
     ): Promise<any>;
+}
+
+export interface SecurityOptions {
+    readonly isBpmRequest: boolean;
+    readonly enableCsrf?: boolean;
+    readonly withCredentials?: boolean;
+    readonly authentications: Authentication;
+    readonly defaultHeaders: Record<string, string>;
+}
+
+export interface Emitters {
+    readonly eventEmitter: Emitter;
+    readonly apiClientEmitter: Emitter;
+}
+
+export interface HttpClient {
+    request<T = any>(url: string, options: RequestOptions, security: SecurityOptions, emitters: Emitters): Promise<T>;
+    post<T = any>(url: string, options: RequestOptions, security: SecurityOptions, emitters: Emitters): Promise<T>;
+    put<T = any>(url: string, options: RequestOptions, security: SecurityOptions, emitters: Emitters): Promise<T>;
+    get<T = any>(url: string, options: RequestOptions, security: SecurityOptions, emitters: Emitters): Promise<T>;
+    delete<T = void>(url: string, options: RequestOptions, security: SecurityOptions, emitters: Emitters): Promise<T>;
 }

--- a/src/api/activiti-rest-api/api/base.api.ts
+++ b/src/api/activiti-rest-api/api/base.api.ts
@@ -16,10 +16,10 @@
 */
 
 import { ApiClient } from '../../../api-clients/api-client';
-import { HttpClient } from '../../../api-clients/http-client.interface';
+import { LegacyHttpClient } from '../../../api-clients/http-client.interface';
 
 export abstract class BaseApi extends ApiClient {
-    override get apiClient(): HttpClient {
+    override get apiClient(): LegacyHttpClient {
         return this.httpClient ?? this.alfrescoApi.processClient;
     }
 }

--- a/src/api/auth-rest-api/api/base.api.ts
+++ b/src/api/auth-rest-api/api/base.api.ts
@@ -16,10 +16,10 @@
 */
 
 import { ApiClient } from '../../../api-clients/api-client';
-import { HttpClient } from '../../../api-clients/http-client.interface';
+import { LegacyHttpClient } from '../../../api-clients/http-client.interface';
 
 export abstract class BaseApi extends ApiClient {
-    override get apiClient(): HttpClient {
+    override get apiClient(): LegacyHttpClient {
         return this.httpClient ?? this.alfrescoApi.authClient;
     }
 }

--- a/src/api/content-custom-api/api/base.api.ts
+++ b/src/api/content-custom-api/api/base.api.ts
@@ -16,26 +16,25 @@
 */
 
 import { ApiClient } from '../../../api-clients/api-client';
-import { HttpClient, RequestOptions } from '../../../api-clients/http-client.interface';
+import { LegacyHttpClient, RequestOptions } from '../../../api-clients/http-client.interface';
 import { AlfrescoApiType, LegacyTicketApi } from '../../../to-deprecate/alfresco-api-type';
 
 export abstract class BaseApi extends ApiClient {
-
-    declare protected httpClient: HttpClient & LegacyTicketApi;
+    protected declare httpClient: LegacyHttpClient & LegacyTicketApi;
 
     /** @deprecated */
     constructor(legacyApi?: AlfrescoApiType);
-    constructor(httpClient: HttpClient & LegacyTicketApi );
-    constructor(httpClient?: AlfrescoApiType | (HttpClient & LegacyTicketApi)) {
+    constructor(httpClient: LegacyHttpClient & LegacyTicketApi);
+    constructor(httpClient?: AlfrescoApiType | (LegacyHttpClient & LegacyTicketApi)) {
         super(httpClient as AlfrescoApiType);
     }
 
     // TODO: Find a way to remove this hack from the legacy version :/
-    get apiClientPrivate(): HttpClient & LegacyTicketApi {
+    get apiClientPrivate(): LegacyHttpClient & LegacyTicketApi {
         return this.httpClient ?? this.alfrescoApi.contentPrivateClient;
     }
 
-    override get apiClient(): HttpClient & LegacyTicketApi {
+    override get apiClient(): LegacyHttpClient & LegacyTicketApi {
         return this.httpClient ?? this.alfrescoApi.contentClient;
     }
 

--- a/src/api/content-rest-api/api/base.api.ts
+++ b/src/api/content-rest-api/api/base.api.ts
@@ -16,10 +16,10 @@
 */
 
 import { ApiClient } from '../../../api-clients/api-client';
-import { HttpClient } from '../../../api-clients/http-client.interface';
+import { LegacyHttpClient } from '../../../api-clients/http-client.interface';
 
 export abstract class BaseApi extends ApiClient {
-    override get apiClient(): HttpClient {
+    override get apiClient(): LegacyHttpClient {
         return this.httpClient ?? this.alfrescoApi.contentClient;
     }
 }

--- a/src/api/discovery-rest-api/api/base.api.ts
+++ b/src/api/discovery-rest-api/api/base.api.ts
@@ -16,10 +16,10 @@
 */
 
 import { ApiClient } from '../../../api-clients/api-client';
-import { HttpClient } from '../../../api-clients/http-client.interface';
+import { LegacyHttpClient } from '../../../api-clients/http-client.interface';
 
 export abstract class BaseApi extends ApiClient {
-    override get apiClient(): HttpClient {
+    override get apiClient(): LegacyHttpClient {
         return this.httpClient ?? this.alfrescoApi.discoveryClient;
     }
 }

--- a/src/api/gs-classification-rest-api/api/base.api.ts
+++ b/src/api/gs-classification-rest-api/api/base.api.ts
@@ -16,10 +16,10 @@
 */
 
 import { ApiClient } from '../../../api-clients/api-client';
-import { HttpClient } from '../../../api-clients/http-client.interface';
+import { LegacyHttpClient } from '../../../api-clients/http-client.interface';
 
 export abstract class BaseApi extends ApiClient {
-    override get apiClient(): HttpClient {
+    override get apiClient(): LegacyHttpClient {
         return this.httpClient ?? this.alfrescoApi.gsClient;
     }
 }

--- a/src/api/gs-core-rest-api/api/base.api.ts
+++ b/src/api/gs-core-rest-api/api/base.api.ts
@@ -16,10 +16,10 @@
 */
 
 import { ApiClient } from '../../../api-clients/api-client';
-import { HttpClient } from '../../../api-clients/http-client.interface';
+import { LegacyHttpClient } from '../../../api-clients/http-client.interface';
 
 export abstract class BaseApi extends ApiClient {
-    override get apiClient(): HttpClient {
+    override get apiClient(): LegacyHttpClient {
         return this.httpClient ?? this.alfrescoApi.gsClient;
     }
 }

--- a/src/api/model-rest-api/api/base.api.ts
+++ b/src/api/model-rest-api/api/base.api.ts
@@ -16,10 +16,10 @@
 */
 
 import { ApiClient } from '../../../api-clients/api-client';
-import { HttpClient } from '../../../api-clients/http-client.interface';
+import { LegacyHttpClient } from '../../../api-clients/http-client.interface';
 
 export abstract class BaseApi extends ApiClient {
-    override get apiClient(): HttpClient {
+    override get apiClient(): LegacyHttpClient {
         return this.httpClient ?? this.alfrescoApi.contentClient;
     }
 }

--- a/src/api/search-rest-api/api/base.api.ts
+++ b/src/api/search-rest-api/api/base.api.ts
@@ -16,10 +16,10 @@
 */
 
 import { ApiClient } from '../../../api-clients/api-client';
-import { HttpClient } from '../../../api-clients/http-client.interface';
+import { LegacyHttpClient } from '../../../api-clients/http-client.interface';
 
 export abstract class BaseApi extends ApiClient {
-    override get apiClient(): HttpClient {
+    override get apiClient(): LegacyHttpClient {
         return this.httpClient ?? this.alfrescoApi.searchClient;
     }
 }

--- a/src/authentication/contentAuth.ts
+++ b/src/authentication/contentAuth.ts
@@ -22,6 +22,7 @@ import { AlfrescoApiConfig } from '../alfrescoApiConfig';
 import { Authentication } from './authentication';
 import { Storage } from '../storage';
 import { AlfrescoApiType } from '../../src/to-deprecate/alfresco-api-type';
+import { HttpClient } from '../api-clients/http-client.interface';
 
 export class ContentAuth extends AlfrescoApiClient {
 
@@ -31,8 +32,8 @@ export class ContentAuth extends AlfrescoApiClient {
 
     authApi: AuthenticationApi;
 
-    constructor(config: AlfrescoApiConfig, alfrescoApi: AlfrescoApiType) {
-        super();
+    constructor(config: AlfrescoApiConfig, alfrescoApi: AlfrescoApiType, httpClient?: HttpClient) {
+        super(undefined, httpClient);
         this.className = 'ContentAuth';
         this.storage = new Storage();
         this.storage.setDomainPrefix(config.domainPrefix);

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -22,6 +22,7 @@ import { Authentication } from './authentication';
 import { AuthenticationApi } from '../api/auth-rest-api/api/authentication.api';
 import { AlfrescoApi } from '../alfrescoApi';
 import { Storage } from '../storage';
+import { HttpClient } from '../api-clients/http-client.interface';
 
 declare const Buffer: any;
 declare const require: any;
@@ -71,8 +72,8 @@ export class Oauth2Auth extends AlfrescoApiClient {
 
     iFrameHashListener: any;
 
-    constructor(config: AlfrescoApiConfig, alfrescoApi: AlfrescoApi) {
-        super();
+    constructor(config: AlfrescoApiConfig, alfrescoApi: AlfrescoApi, httpClient?: HttpClient) {
+        super(undefined, httpClient);
         this.storage = new Storage();
 
         this.className = 'Oauth2Auth';

--- a/src/authentication/processAuth.ts
+++ b/src/authentication/processAuth.ts
@@ -20,6 +20,8 @@ import { AlfrescoApiClient } from '../alfrescoApiClient';
 import { AlfrescoApiConfig } from '../alfrescoApiConfig';
 import { Authentication } from './authentication';
 import { Storage } from '../storage';
+import { HttpClient } from '../api-clients/http-client.interface';
+import { isBrowser } from '../utils';
 
 export class ProcessAuth extends AlfrescoApiClient {
 
@@ -30,14 +32,14 @@ export class ProcessAuth extends AlfrescoApiClient {
         'basicAuth': { ticket: '' }, type: 'activiti'
     };
 
-    constructor(config: AlfrescoApiConfig) {
-        super();
+    constructor(config: AlfrescoApiConfig, httpClient?: HttpClient) {
+        super(undefined, httpClient);
         this.storage = new Storage();
         this.storage.setDomainPrefix(config.domainPrefix);
 
         this.className = 'ProcessAuth';
 
-        if (!this.isBrowser()) {
+        if (!isBrowser()) {
             this.defaultHeaders = {
                 'user-agent': 'alfresco-js-api'
             };

--- a/src/contentClient.ts
+++ b/src/contentClient.ts
@@ -18,14 +18,15 @@
 import { AlfrescoApiClient } from './alfrescoApiClient';
 import { AlfrescoApiConfig } from './alfrescoApiConfig';
 import { Authentication } from './authentication/authentication';
+import { HttpClient } from './api-clients/http-client.interface';
 
 export class ContentClient extends AlfrescoApiClient {
 
     className = 'ContentClient';
     servicePath: string;
 
-    constructor(config: AlfrescoApiConfig, servicePath: string) {
-        super();
+    constructor(config: AlfrescoApiConfig, servicePath: string, httpClient?: HttpClient) {
+        super(undefined, httpClient);
 
         this.setConfig(config, servicePath);
     }

--- a/src/processClient.ts
+++ b/src/processClient.ts
@@ -18,13 +18,14 @@
 import { AlfrescoApiConfig } from './alfrescoApiConfig';
 import { AlfrescoApiClient } from './alfrescoApiClient';
 import { Authentication } from './authentication/authentication';
+import { HttpClient } from './api-clients/http-client.interface';
 
 export class ProcessClient extends AlfrescoApiClient {
 
     className = 'ProcessClient';
 
-    constructor(config: AlfrescoApiConfig) {
-        super();
+    constructor(config: AlfrescoApiConfig, httpClient?: HttpClient) {
+        super(undefined, httpClient);
 
         this.setConfig(config);
     }

--- a/src/superagentHttpClient.ts
+++ b/src/superagentHttpClient.ts
@@ -1,0 +1,374 @@
+/*!
+ * @license
+ * Copyright 2018 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ee, { Emitter } from 'event-emitter';
+import superagent, { Response } from 'superagent';
+import { Authentication } from './authentication/authentication';
+import { RequestOptions, HttpClient, SecurityOptions, Emitters } from './api-clients/http-client.interface';
+import { Oauth2 } from './authentication/oauth2';
+import { BasicAuth } from './authentication/basicAuth';
+import { isBrowser, paramToString } from './utils';
+
+declare const Blob: any;
+declare const Buffer: any;
+
+const isProgressEvent = (event: ProgressEvent | unknown): event is ProgressEvent => Object.prototype.hasOwnProperty.call(event, 'lengthComputable');
+
+export class SuperagentHttpClient implements HttpClient {
+    /**
+     * The default HTTP timeout for all API calls.
+     */
+    timeout: number | { deadline?: number; response?: number } = undefined;
+
+    post<T = any>(url: string, options: RequestOptions, securityOptions: SecurityOptions, emitters: Emitters): Promise<T> {
+        return this.request<T>(url, { ...options, httpMethod: 'POST' }, securityOptions, emitters);
+    }
+
+    put<T = any>(url: string, options: RequestOptions, securityOptions: SecurityOptions, emitters: Emitters): Promise<T> {
+        return this.request<T>(url, { ...options, httpMethod: 'PUT' }, securityOptions, emitters);
+    }
+
+    get<T = any>(url: string, options: RequestOptions, securityOptions: SecurityOptions, emitters: Emitters): Promise<T> {
+        return this.request<T>(url, { ...options, httpMethod: 'GET' }, securityOptions, emitters);
+    }
+
+    delete<T = void>(url: string, options: RequestOptions, securityOptions: SecurityOptions, emitters: Emitters): Promise<T> {
+        return this.request<T>(url, { ...options, httpMethod: 'DELETE' }, securityOptions, emitters);
+    }
+
+    request<T = any>(url: string, options: RequestOptions, securityOptions: SecurityOptions, emitters: Emitters): Promise<T> {
+        const { httpMethod, queryParams, headerParams, formParams, bodyParam, contentType, accept, responseType, returnType } = options;
+        const { eventEmitter, apiClientEmitter } = emitters;
+
+        let request = this.buildRequest(
+            httpMethod,
+            url,
+            queryParams,
+            headerParams,
+            formParams,
+            bodyParam,
+            contentType,
+            accept,
+            responseType,
+            eventEmitter,
+            returnType,
+            securityOptions
+        );
+
+        if (returnType === 'Binary') {
+            request = request.buffer(true).parse(superagent.parse['application/octet-stream']);
+        }
+
+        const promise: any = new Promise((resolve, reject) => {
+            request.on('abort', () => {
+                eventEmitter.emit('abort');
+            });
+            request.end((error: any, response: Response) => {
+                if (error) {
+                    apiClientEmitter.emit('error', error);
+                    eventEmitter.emit('error', error);
+
+                    if (error.status === 401) {
+                        apiClientEmitter.emit('unauthorized');
+                        eventEmitter.emit('unauthorized');
+                    }
+
+                    if (response && response.text) {
+                        error = error || {};
+                        reject(Object.assign(error, { message: response.text }));
+                    } else {
+                        reject({ error: error });
+                    }
+                } else {
+                    if (securityOptions.isBpmRequest) {
+                        if (response.header && response.header.hasOwnProperty('set-cookie')) {
+                            // mutate the passed value from AlfrescoApiClient class for backward compatibility
+                            securityOptions.authentications.cookie = response.header['set-cookie'][0];
+                        }
+                    }
+                    let data = {};
+                    if (response.type === 'text/html') {
+                        data = SuperagentHttpClient.deserialize(response);
+                    } else {
+                        data = SuperagentHttpClient.deserialize(response, returnType);
+                    }
+
+                    eventEmitter.emit('success', data);
+                    resolve(data);
+                }
+            });
+        });
+
+        promise.abort = function () {
+            request.abort();
+            return this;
+        };
+
+        return promise;
+    }
+
+    private buildRequest(
+        httpMethod: string,
+        url: string,
+        queryParams: { [key: string]: any },
+        headerParams: { [key: string]: any },
+        formParams: { [key: string]: any },
+        // eslint-disable-next-line @typescript-eslint/ban-types
+        bodyParam: string | Object,
+        contentType: string,
+        accept: string,
+        responseType: string,
+        eventEmitter: ee.Emitter,
+        returnType: string,
+        securityOptions: SecurityOptions
+    ) {
+        const request = superagent(httpMethod, url);
+
+        const { isBpmRequest, authentications, defaultHeaders = {}, enableCsrf, withCredentials = false } = securityOptions;
+
+        // apply authentications
+        this.applyAuthToRequest(request, authentications);
+
+        // set query parameters
+        request.query(SuperagentHttpClient.normalizeParams(queryParams));
+
+        // set header parameters
+        request.set(defaultHeaders).set(SuperagentHttpClient.normalizeParams(headerParams));
+
+        if (isBpmRequest && enableCsrf) {
+            this.setCsrfToken(request);
+        }
+
+        if (withCredentials) {
+            request.withCredentials();
+        }
+
+        // add cookie for activiti
+        if (isBpmRequest) {
+            request.withCredentials();
+            if (securityOptions.authentications.cookie) {
+                if (!isBrowser()) {
+                    request.set('Cookie', securityOptions.authentications.cookie);
+                }
+            }
+        }
+
+        // set request timeout
+        request.timeout(this.timeout);
+
+        if (contentType && contentType !== 'multipart/form-data') {
+            request.type(contentType);
+        } else if (!(request as any).header['Content-Type'] && contentType !== 'multipart/form-data') {
+            request.type('application/json');
+        }
+
+        if (contentType === 'application/x-www-form-urlencoded') {
+            request.send(SuperagentHttpClient.normalizeParams(formParams)).on('progress', (event: any) => {
+                this.progress(event, eventEmitter);
+            });
+        } else if (contentType === 'multipart/form-data') {
+            const _formParams = SuperagentHttpClient.normalizeParams(formParams);
+            for (const key in _formParams) {
+                if (_formParams.hasOwnProperty(key)) {
+                    if (SuperagentHttpClient.isFileParam(_formParams[key])) {
+                        // file field
+                        request.attach(key, _formParams[key]).on('progress', (event: ProgressEvent) => {
+                            // jshint ignore:line
+                            this.progress(event, eventEmitter);
+                        });
+                    } else {
+                        request.field(key, _formParams[key]).on('progress', (event: ProgressEvent) => {
+                            // jshint ignore:line
+                            this.progress(event, eventEmitter);
+                        });
+                    }
+                }
+            }
+        } else if (bodyParam) {
+            request.send(bodyParam).on('progress', (event: any) => {
+                this.progress(event, eventEmitter);
+            });
+        }
+
+        if (accept) {
+            request.accept(accept);
+        }
+
+        if (returnType === 'blob' || returnType === 'Blob' || responseType === 'blob' || responseType === 'Blob') {
+            request.responseType('blob');
+        } else if (returnType === 'String') {
+            request.responseType('string');
+        }
+
+        return request;
+    }
+
+    setCsrfToken(request: any): void {
+        const token = SuperagentHttpClient.createCSRFToken();
+        request.set('X-CSRF-TOKEN', token);
+
+        if (!isBrowser()) {
+            request.set('Cookie', 'CSRF-TOKEN=' + token + ';path=/');
+        }
+
+        try {
+            document.cookie = 'CSRF-TOKEN=' + token + ';path=/';
+        } catch (err) {
+            /* continue regardless of error */
+        }
+    }
+
+    /**
+     * Applies authentication headers to the request.
+     * @param {Object} request The request object created by a <code>superagent()</code> call.
+     */
+    private applyAuthToRequest(request: any, authentications: Authentication) {
+        if (authentications) {
+            switch (authentications.type) {
+                case 'basic': {
+                    const basicAuth: BasicAuth = authentications.basicAuth;
+                    if (basicAuth.username || basicAuth.password) {
+                        request.auth(basicAuth.username ? encodeURI(basicAuth.username) : '', basicAuth.password ? encodeURI(basicAuth.password) : '');
+                    }
+                    break;
+                }
+                case 'activiti': {
+                    if (authentications.basicAuth.ticket) {
+                        request.set({ Authorization: authentications.basicAuth.ticket });
+                    }
+                    break;
+                }
+                case 'oauth2': {
+                    const oauth2: Oauth2 = authentications.oauth2;
+                    if (oauth2.accessToken) {
+                        request.set({ Authorization: 'Bearer ' + oauth2.accessToken });
+                    }
+                    break;
+                }
+                default:
+                    throw new Error('Unknown authentication type: ' + authentications.type);
+            }
+        }
+    }
+
+    private progress(event: ProgressEvent | unknown, eventEmitter: Emitter): void {
+        if (isProgressEvent(event)) {
+            const percent = Math.round((event.loaded / event.total) * 100);
+
+            const progress = {
+                total: event.total,
+                loaded: event.loaded,
+                percent,
+            };
+
+            eventEmitter.emit('progress', progress);
+        }
+    }
+
+    private static createCSRFToken(a?: any): string {
+        return a ? (a ^ ((Math.random() * 16) >> (a / 4))).toString(16) : ([1e16] + (1e16).toString()).replace(/[01]/g, SuperagentHttpClient.createCSRFToken);
+    }
+
+    /**
+     * Deserializes an HTTP response body into a value of the specified type.
+     * @param {Object} response A SuperAgent response object.
+     * @param {(String|string[]|Object.<String, Object>|Function)} returnType The type to return. Pass a string for simple types
+     * or the constructor function for a complex type. Pass an array containing the type name to return an array of that type. To
+     * return an object, pass an object with one property whose name is the key type and whose value is the corresponding value type:
+     * all properties on <code>data<code> will be converted to this type.
+     * @returns A value of the specified type.
+     */
+    private static deserialize(response: any, returnType?: any): any {
+        if (response === null) {
+            return null;
+        }
+
+        let data = response.body;
+
+        if (data === null) {
+            data = response.text;
+        }
+
+        if (returnType) {
+            if (returnType === 'blob' && isBrowser()) {
+                data = new Blob([data], { type: response.header['content-type'] });
+            } else if (returnType === 'blob' && !isBrowser()) {
+                data = new Buffer.from(data, 'binary');
+            } else if (Array.isArray(data)) {
+                data = data.map((element) => {
+                    return new returnType(element);
+                });
+            } else {
+                data = new returnType(data);
+            }
+        }
+
+        return data;
+    }
+
+    /**
+     * Normalizes parameter values:
+     * <ul>
+     * <li>remove nils</li>
+     * <li>keep files and arrays</li>
+     * <li>format to string with `paramToString` for other cases</li>
+     * </ul>
+     * @param {Object.<String, Object>} params The parameters as object properties.
+     * @returns {Object.<String, Object>} normalized parameters.
+     */
+    private static normalizeParams(params: { [key: string]: any }): { [key: string]: any } {
+        const newParams: { [key: string]: any } = {};
+
+        for (const key in params) {
+            if (params.hasOwnProperty(key) && params[key] !== undefined && params[key] !== null) {
+                const value = params[key];
+                if (SuperagentHttpClient.isFileParam(value) || Array.isArray(value)) {
+                    newParams[key] = value;
+                } else {
+                    newParams[key] = paramToString(value);
+                }
+            }
+        }
+        return newParams;
+    }
+
+    /**
+     * Checks whether the given parameter value represents file-like content.
+     * @param param The parameter to check.
+     * @returns <code>true</code> if <code>param</code> represents a file.
+     */
+    private static isFileParam(param: any): boolean {
+        // Buffer in Node.js
+        if (typeof Buffer === 'function' && (param instanceof Buffer || param.path)) {
+            return true;
+        }
+        // Blob in browser
+        if (typeof Blob === 'function' && param instanceof Blob) {
+            return true;
+        }
+        // File in browser (it seems File object is also instance of Blob, but keep this for safe)
+        if (typeof File === 'function' && param instanceof File) {
+            return true;
+        }
+        // Safari fix
+        if (typeof File === 'object' && param instanceof File) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/to-deprecate/alfresco-api-type.ts
+++ b/src/to-deprecate/alfresco-api-type.ts
@@ -15,28 +15,28 @@
 * limitations under the License.
 */
 
-import { AlfrescoApiConfig } from "../alfrescoApiConfig";
-import { HttpClient } from "../api-clients/http-client.interface";
+import { AlfrescoApiConfig } from '../alfrescoApiConfig';
+import { LegacyHttpClient } from '../api-clients/http-client.interface';
 
 export interface LegacyTicketApi {
-    getAlfTicket(ticket: string): string
+    getAlfTicket(ticket: string): string;
 }
 
 // Extracted from existing AlfrescoApi:
 export interface AlfrescoApiType {
     __type: string;
     config: AlfrescoApiConfig;
-    contentClient: HttpClient & LegacyTicketApi;
-    contentPrivateClient: HttpClient & LegacyTicketApi;
-    processClient: HttpClient;
-    searchClient: HttpClient;
-    discoveryClient: HttpClient;
-    gsClient: HttpClient;
-    authClient: HttpClient;
-    processAuth: HttpClient;
+    contentClient: LegacyHttpClient & LegacyTicketApi;
+    contentPrivateClient: LegacyHttpClient & LegacyTicketApi;
+    processClient: LegacyHttpClient;
+    searchClient: LegacyHttpClient;
+    discoveryClient: LegacyHttpClient;
+    gsClient: LegacyHttpClient;
+    authClient: LegacyHttpClient;
+    processAuth: LegacyHttpClient;
 
     setConfig(config: AlfrescoApiConfig): void;
-    changeWithCredentialsConfig(withCredentials: boolean) : void;
+    changeWithCredentialsConfig(withCredentials: boolean): void;
     changeCsrfConfig(disableCsrf: boolean): void;
     changeEcmHost(hostEcm: string): void;
     changeBpmHost(hostBpm: string): void;
@@ -62,5 +62,5 @@ export interface AlfrescoApiType {
     isOauthConfiguration(): boolean;
     isPublicUrl(): boolean;
     isEcmBpmConfiguration(): boolean;
-    reply(event: string, callback ?: any): void;
+    reply(event: string, callback?: any): void;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './is-browser';
+export * from './param-to-string';

--- a/src/utils/is-browser.ts
+++ b/src/utils/is-browser.ts
@@ -1,0 +1,20 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const isBrowser = (): boolean => {
+    return typeof window !== 'undefined' && typeof window.document !== 'undefined';
+};

--- a/src/utils/param-to-string.ts
+++ b/src/utils/param-to-string.ts
@@ -1,0 +1,31 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns a string representation for an actual parameter.
+ * @param param The actual parameter.
+ * @returns The string representation of <code>param</code>.
+ */
+export function paramToString(param: any): string {
+    if (param === undefined || param === null) {
+        return '';
+    }
+    if (param instanceof Date) {
+        return param.toJSON();
+    }
+    return param.toString();
+}

--- a/test/alfrescoApiClient.spec.ts
+++ b/test/alfrescoApiClient.spec.ts
@@ -1,4 +1,4 @@
-import { AlfrescoApiClient, AlfrescoApiCompatibility as AlfrescoApi, AlfrescoApiConfig, FormValueRepresentation } from '../index';
+import { AlfrescoApiCompatibility as AlfrescoApi, AlfrescoApiConfig } from '../index';
 import { DateAlfresco } from  '../index';
 import { EcmAuthMock } from '../test/mockObjects';
 
@@ -9,28 +9,6 @@ chai.use(require('chai-datetime'));
 describe('Alfresco Core API Client', () => {
 
     describe('type conversion', () => {
-
-        const client = new AlfrescoApiClient();
-
-        it('should create a request with response type blob', () => {
-            const queryParams = {};
-            const headerParams = {};
-            const formParams = {};
-
-            const contentTypes = ['application/json'];
-            const accepts = ['application/json'];
-            const responseType = 'blob';
-            const url = '/fake-api/enterprise/process-instances/';
-            const httpMethod = 'GET';
-
-            const response = client.buildRequest(httpMethod, url, queryParams, headerParams, formParams, null,
-                                               contentTypes, accepts, responseType, null, null);
-
-            expect(response.url).equal('/fake-api/enterprise/process-instances/');
-            expect(response.header.Accept).equal('application/json');
-            expect(response.header['Content-Type']).equal('application/json');
-            expect(response._responseType).equal('blob');
-        });
 
         it('should return the username after login', (done) => {
             const authResponseEcmMock = new EcmAuthMock('http://127.0.0.1:8080');
@@ -86,30 +64,6 @@ describe('Alfresco Core API Client', () => {
             expect(DateAlfresco.parseDate('2015-11-17T03:33:17+02')).to.equalTime(new Date(Date.UTC(2015, 10, 17, 1, 33, 17)));
         });
 
-    });
-
-    describe('Deserializes', () => {
-
-        it('should the deserializer return an array of object when the response is an array', () => {
-            const client = new AlfrescoApiClient();
-            const data = {
-                body: [
-                    {
-                        id: '1',
-                        name: 'test1'
-                    },
-                    {
-                        id: '2',
-                        name: 'test2'
-                    }
-                ]
-            };
-            const result = client.deserialize(data, FormValueRepresentation);
-            const isArray = Array.isArray(result);
-            const isObject = (result[0] instanceof (FormValueRepresentation));
-            expect(isArray).to.equal(true);
-            expect(isObject).to.equal(true);
-        });
     });
 
 });

--- a/test/bpmAuth.spec.ts
+++ b/test/bpmAuth.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { AlfrescoApiConfig } from '../src/alfrescoApiConfig';
 import { ProcessAuth } from '../src/authentication/processAuth';
+import { SuperagentHttpClient } from '../src/superagentHttpClient';
 import { BpmAuthMock } from './mockObjects';
 
 describe('Bpm Auth test', () => {
@@ -249,7 +250,7 @@ describe('Bpm Auth test', () => {
             let setCsrfTokenStub: any;
 
             beforeEach(() => {
-                setCsrfTokenStub = sinon.stub(ProcessAuth.prototype, 'setCsrfToken');
+                setCsrfTokenStub = sinon.stub(SuperagentHttpClient.prototype, 'setCsrfToken');
             });
 
             afterEach(() => {

--- a/test/superagentHttpClient.spec.ts
+++ b/test/superagentHttpClient.spec.ts
@@ -1,0 +1,76 @@
+import { FormValueRepresentation } from '../index';
+import { SuperagentHttpClient } from '../src/superagentHttpClient';
+
+const expect = require('chai').expect;
+
+describe('SuperagentHttpClient', () => {
+    describe('#buildRequest', () => {
+        const client = new SuperagentHttpClient();
+
+        it('should create a request with response type blob', () => {
+            const queryParams = {};
+            const headerParams = {};
+            const formParams = {};
+
+            const contentTypes = 'application/json';
+            const accepts = 'application/json';
+            const responseType = 'blob';
+            const url = '/fake-api/enterprise/process-instances/';
+            const httpMethod = 'GET';
+            const securityOptions = {
+                isBpmRequest: false,
+                enableCsrf: false,
+                withCredentials: false,
+                authentications: {
+                    basicAuth: {
+                        ticket: '',
+                    },
+                    type: 'basic',
+                },
+                defaultHeaders: {},
+            };
+
+            const response: any = client['buildRequest'](
+                httpMethod,
+                url,
+                queryParams,
+                headerParams,
+                formParams,
+                null,
+                contentTypes,
+                accepts,
+                responseType,
+                null,
+                null,
+                securityOptions
+            );
+
+            expect(response.url).equal('/fake-api/enterprise/process-instances/');
+            expect(response.header.Accept).equal('application/json');
+            expect(response.header['Content-Type']).equal('application/json');
+            expect(response._responseType).equal('blob');
+        });
+    });
+
+    describe('#deserialize', () => {
+        it('should the deserializer return an array of object when the response is an array', () => {
+            const data = {
+                body: [
+                    {
+                        id: '1',
+                        name: 'test1',
+                    },
+                    {
+                        id: '2',
+                        name: 'test2',
+                    },
+                ],
+            };
+            const result = SuperagentHttpClient['deserialize'](data, FormValueRepresentation);
+            const isArray = Array.isArray(result);
+            const isObject = result[0] instanceof FormValueRepresentation;
+            expect(isArray).to.equal(true);
+            expect(isObject).to.equal(true);
+        });
+    });
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Currently we are not able to provide custom implementation for http client, and all calls are made with superagent

**What is the new behavior?**

We are able to create AlfrescoApi instance with custom http client.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
