### PR TITLE
[APPS-1732] Removed AuthorityType and clearance parameters from GET AuthorityClearance endpoint

### DIFF
--- a/src/api/gs-classification-rest-api/api/authorityClearance.api.ts
+++ b/src/api/gs-classification-rest-api/api/authorityClearance.api.ts
@@ -28,21 +28,17 @@ import {
 export class AuthorityClearanceApi extends BaseApi {
     /**
      * Get the authority clearances for a single user/group
-     * @param authorityType The identifier for the authorityType. Can be 'USER/GROUP'
      * @param authorityId The name for the authority for which the clearance is to be fetched. Can be left blank in which case it will fetch it for all users with pagination
-     * @param clearance The clearance level for the authority. Can be TS (Top Secret), S (Secret), or C (Confidential)
      * @param opts.skipCount The number of entities that exist in the collection before those included in this list.
      * @param opts.maxItems The maximum number of items to return in the list.
      * @return Promise<AuthorityClearanceGroupPaging>
      */
-    getAuthorityClearanceForAuthority(authorityId: string, authorityType?: string, clearance?: string, opts?: any): Promise<AuthorityClearanceGroupPaging> {
+    getAuthorityClearanceForAuthority(authorityId: string, opts?: any): Promise<AuthorityClearanceGroupPaging> {
         let body = null;
         let pathParams = {
             'authorityId': authorityId
         };
         let queryParams = {
-            'authorityType': authorityType ? authorityType : null,
-            'clearance': clearance ? clearance : null,
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems']
         };

--- a/test/governance-services/authorityClearanceApi.spec.ts
+++ b/test/governance-services/authorityClearanceApi.spec.ts
@@ -53,7 +53,7 @@ describe('Authority Clearance API test', () => {
     it('get authority clearances for an authority', async () => {
         let nodeId = 'testAuthorityId';
         authorityClearanceMock.get200AuthorityClearanceForAuthority(nodeId);
-        await authorityClearanceApi.getAuthorityClearanceForAuthority(nodeId, null, null, DEFAULT_OPTS).then((response: AuthorityClearanceGroupPaging) => {
+        await authorityClearanceApi.getAuthorityClearanceForAuthority(nodeId, DEFAULT_OPTS).then((response: AuthorityClearanceGroupPaging) => {
             expect(response.list.entries[0].entry.id).equal('securityGroupFruits');
             expect(response.list.entries[0].entry.displayLabel).equal('Security Group FRUITS');
             expect(response.list.entries[0].entry.type).equal('USER_REQUIRES_ALL');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
GET Authority clearances endpoint had extra parameters for authorityType and clearance. These parameters are no longer necessary and can be removed.


**What is the new behavior?**
Removed extra parameters from GET Authority clearnces endpoint


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
