### PR TITLE
[MNT-23143] withCredentials reflected in isBpmLoggedIn

### DIFF
--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -466,7 +466,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
             if (this.isOauthConfiguration()) {
                 return this.oauth2Auth.isLoggedIn();
             } else {
-                return this.processAuth.isLoggedIn();
+                return this.config.withCredentials ? true : this.processAuth.isLoggedIn();
             }
         }
         return false;

--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -466,7 +466,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
             if (this.isOauthConfiguration()) {
                 return this.oauth2Auth.isLoggedIn();
             } else {
-                return this.config.withCredentials ? true : this.processAuth.isLoggedIn();
+                return this.processAuth.isLoggedIn();
             }
         }
         return false;
@@ -477,7 +477,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
             if (this.isOauthConfiguration()) {
                 return this.oauth2Auth.isLoggedIn();
             } else {
-                return this.contentAuth.isLoggedIn();
+                return this.config.withCredentials ? true : this.contentAuth.isLoggedIn();
             }
         }
         return false;

--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -452,9 +452,9 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
             if (this.isBpmConfiguration()) {
                 return this.processAuth.isLoggedIn();
             } else if (this.isEcmConfiguration()) {
-                return this.contentAuth.isLoggedIn();
+                return this.config.withCredentials ? true : this.contentAuth.isLoggedIn();
             } else if (this.isEcmBpmConfiguration()) {
-                return this.contentAuth.isLoggedIn() && this.processAuth.isLoggedIn();
+                return this.config.withCredentials ? true : (this.contentAuth.isLoggedIn() && this.processAuth.isLoggedIn());
             } else {
                 return false;
             }

--- a/test/alfrescoApi.spec.ts
+++ b/test/alfrescoApi.spec.ts
@@ -96,6 +96,22 @@ describe('Basic configuration test', () => {
             expect(alfrescoJsApi.processClient.isWithCredentials()).equal(true);
         });
 
+        it('should withCredentials true parameter with hostBpm should be reflected in isBpmLoggedIn', () => {
+            const hostBpm = 'http://127.0.0.1:9999';
+            const authBpmMock = new BpmAuthMock(hostBpm);
+
+            authBpmMock.get200Response();
+
+            const alfrescoJsApi = new AlfrescoApi({
+                hostBpm: hostBpm,
+                contextRootBpm: 'activiti-app',
+                provider: 'BPM',
+                withCredentials: true
+            } as AlfrescoApiConfig);
+
+            expect(alfrescoJsApi.isBpmLoggedIn()).equal(true);
+        });
+
         it('should withCredentials false parameter should be reflected in the clients', () => {
             const config = {
                 hostEcm: 'http://testServer.com:1616',

--- a/test/alfrescoApi.spec.ts
+++ b/test/alfrescoApi.spec.ts
@@ -96,20 +96,15 @@ describe('Basic configuration test', () => {
             expect(alfrescoJsApi.processClient.isWithCredentials()).equal(true);
         });
 
-        it('should withCredentials true parameter with hostBpm should be reflected in isBpmLoggedIn', () => {
-            const hostBpm = 'http://127.0.0.1:9999';
-            const authBpmMock = new BpmAuthMock(hostBpm);
-
-            authBpmMock.get200Response();
-
+        it('should withCredentials true parameter with hostEcm should be reflected in isEcmLoggedIn', () => {
+            const hostEcm = 'http://127.0.0.1:8080';
             const alfrescoJsApi = new AlfrescoApi({
-                hostBpm: hostBpm,
-                contextRootBpm: 'activiti-app',
-                provider: 'BPM',
+                hostEcm,
+                provider: 'ECM',
                 withCredentials: true
             } as AlfrescoApiConfig);
 
-            expect(alfrescoJsApi.isBpmLoggedIn()).equal(true);
+            expect(alfrescoJsApi.isEcmLoggedIn()).equal(true);
         });
 
         it('should withCredentials false parameter should be reflected in the clients', () => {

--- a/test/alfrescoApi.spec.ts
+++ b/test/alfrescoApi.spec.ts
@@ -107,6 +107,28 @@ describe('Basic configuration test', () => {
             expect(alfrescoJsApi.isEcmLoggedIn()).equal(true);
         });
 
+        it('should withCredentials true parameter with hostEcm should be reflected in isLoggedIn', () => {
+            const hostEcm = 'http://127.0.0.1:8080';
+            const alfrescoJsApi = new AlfrescoApi({
+                hostEcm,
+                provider: 'ECM',
+                withCredentials: true
+            } as AlfrescoApiConfig);
+
+            expect(alfrescoJsApi.isLoggedIn()).equal(true);
+        });
+
+        it('should withCredentials true parameter with ALL provider should be reflected in isLoggedIn', () => {
+            const hostEcm = 'http://127.0.0.1:8080';
+            const alfrescoJsApi = new AlfrescoApi({
+                hostEcm,
+                provider: 'ALL',
+                withCredentials: true
+            } as AlfrescoApiConfig);
+
+            expect(alfrescoJsApi.isLoggedIn()).equal(true);
+        });
+
         it('should withCredentials false parameter should be reflected in the clients', () => {
             const config = {
                 hostEcm: 'http://testServer.com:1616',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Description is provided here -> https://alfresco.atlassian.net/browse/MNT-23143

**What is the new behavior?**

withCredentials param is correctly reflected in isBpmLoggedIn method.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
