### PR TITLE
[ACS-4231] Add unit tests to categories API

### DIFF
--- a/src/api/content-rest-api/api/categories.api.ts
+++ b/src/api/content-rest-api/api/categories.api.ts
@@ -136,7 +136,7 @@ export class CategoriesApi extends BaseApi {
         const accepts = ['application/json'];
 
         return this.apiClient.callApi(
-            '/category/{categoryId}', 'GET',
+            '/categories/{categoryId}', 'GET',
             pathParams, queryParams, headerParams, formParams, postBody,
             contentTypes, accepts , CategoryEntry);
     }

--- a/src/api/content-rest-api/docs/CategoriesApi.md
+++ b/src/api/content-rest-api/docs/CategoriesApi.md
@@ -5,7 +5,7 @@ All URIs are relative to *https://localhost/alfresco/api/-default-/public/alfres
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**getSubcategories**](CategoriesApi.md#getSubcategories) | **GET** /categories/{categoryId}/subcategories | List of subcategories within category
-[**getCategory**](CategoriesApi.md#getCategory) | **GET** /category/{categoryId} | Get a category
+[**getCategory**](CategoriesApi.md#getCategory) | **GET** /categories/{categoryId} | Get a category
 [**getCategoryLinksForNode**](CategoriesApi.md#getCategoryLinksForNode) | **GET** /nodes/{nodeId}/category-links | List of categories that node is assigned to
 [**deleteCategory**](CategoriesApi.md#deleteCategory) | **DELETE** /categories/{categoryId} | Deletes the category
 [**unlinkNodeFromCategory**](CategoriesApi.md#unlinkNodeFromCategory) | **DELETE** /nodes/{nodeId}/category-links/{categoryId} | Unassign a node from category

--- a/src/api/content-rest-api/docs/CategoryLinkBody.md
+++ b/src/api/content-rest-api/docs/CategoryLinkBody.md
@@ -3,6 +3,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **string** |  | [default to null]
+**categoryId** | **string** |  | [default to null]
 
 

--- a/src/api/content-rest-api/model/CategoryLinkBody.ts
+++ b/src/api/content-rest-api/model/CategoryLinkBody.ts
@@ -16,7 +16,7 @@
 */
 
 export class CategoryLinkBody {
-    id: string;
+    categoryId: string;
 
     constructor(input?: any) {
         if (input) {

--- a/test/content-services/categoriesApi.spec.ts
+++ b/test/content-services/categoriesApi.spec.ts
@@ -27,81 +27,81 @@ describe('Categories', () => {
         categoriesApi = new CategoriesApi(alfrescoJsApi);
     });
 
-    it('get subcategories for category with categoryId should return 200 if all if ok', (done) => {
+    it('should return 200 while getting subcategories for category with categoryId if all is ok', (done) => {
         categoriesMock.get200ResponseSubcategories('-root-');
         categoriesApi.getSubcategories('-root-').then((response: CategoryPaging) => {
-            expect(response.list.pagination.count).to.be.equal(2);
-            expect(response.list.entries[0].entry.parentId).to.be.equal('-root-');
-            expect(response.list.entries[0].entry.id).to.be.equal('testId1');
+            expect(response.list.pagination.count).equal(2);
+            expect(response.list.entries[0].entry.parentId).equal('-root-');
+            expect(response.list.entries[0].entry.id).equal('testId1');
             done();
         });
     });
 
-    it('get subcategories for not existing category should return 404', (done) => {
+    it('should return 404 while getting subcategories for not existing category', (done) => {
         categoriesMock.get404SubcategoryNotExist('notExistingId');
         categoriesApi.getSubcategories('notExistingId').then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(404);
+                expect(error.status).equal(404);
                 done();
             }
         );
     });
 
-    it('get category with nodeId should return 200 if category exists', (done) => {
+    it('should return 200 while getting category with categoryId if category exists', (done) => {
         categoriesMock.get200ResponseCategory('testId1');
         categoriesApi.getCategory('testId1').then((response: CategoryEntry) => {
-            expect(response.entry.parentId).to.be.equal('-root-');
-            expect(response.entry.id).to.be.equal('testId1');
+            expect(response.entry.parentId).equal('-root-');
+            expect(response.entry.id).equal('testId1');
             done();
         });
     });
 
-    it('get category for not existing category should return 404', (done) => {
+    it('should return 404 while getting category with categoryId when category not exists', (done) => {
         categoriesMock.get404CategoryNotExist('notExistingId');
         categoriesApi.getCategory('notExistingId').then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(404);
+                expect(error.status).equal(404);
                 done();
             }
         );
     });
 
-    it('get category linked to node with nodeId should return 200 if node has some categories assigned', (done) => {
-        categoriesMock.get200ResponseNodeCategoryLinks('80a94ac8-3ece-47ad-864e-5d939424c47c');
-        categoriesApi.getCategoryLinksForNode('80a94ac8-3ece-47ad-864e-5d939424c47c').then((response: CategoryPaging) => {
-            expect(response.list.entries[0].entry.parentId).to.be.equal('80a94ac8-3ece-47ad-864e-5d939424c47c');
-            expect(response.list.entries[0].entry.id).to.be.equal('testId1');
+    it('should return 200 while getting categories linked to node with nodeId if node has some categories assigned', (done) => {
+        categoriesMock.get200ResponseNodeCategoryLinks('testNode');
+        categoriesApi.getCategoryLinksForNode('testNode').then((response: CategoryPaging) => {
+            expect(response.list.entries[0].entry.parentId).equal('testNode');
+            expect(response.list.entries[0].entry.id).equal('testId1');
             done();
         });
     });
 
-    it('getting categories linked to node should return 403 if current user does not have permission to get from node', (done) => {
-        categoriesMock.get403NodeCategoryLinksPermissionDenied('80a94ac8-3ece-47ad-864e-5d939424c47c');
-        categoriesApi.getCategoryLinksForNode('80a94ac8-3ece-47ad-864e-5d939424c47c').then(
+    it('should return 403 while getting categories linked to node with nodeId if user has no rights to get from node', (done) => {
+        categoriesMock.get403NodeCategoryLinksPermissionDenied('testNode');
+        categoriesApi.getCategoryLinksForNode('testNode').then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(403);
+                expect(error.status).equal(403);
                 done();
             }
         );
     });
 
-    it('getting categories linked to node should return 404 if node with nodeId does not exist', (done) => {
-        categoriesMock.get404NodeNotExist('80a94ac8-3ece-47ad-864e-5d939424c47c');
-        categoriesApi.getCategoryLinksForNode('80a94ac8-3ece-47ad-864e-5d939424c47c').then(
+    it('should return 404 while getting categories linked to node with nodeId if node does not exist', (done) => {
+        categoriesMock.get404NodeNotExist('testNode');
+        categoriesApi.getCategoryLinksForNode('testNode').then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(404);
+                expect(error.status).equal(404);
                 done();
             }
         );
     });
 
     it('should return 204 after unlinking category', (done) => {
-        categoriesMock.get204CategoryUnlinked('80a94ac8-3ece-47ad-864e-5d939424c47c', 'testId1');
-        categoriesApi.unlinkNodeFromCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', 'testId1').then(
+        categoriesMock.get204CategoryUnlinked('testNode', 'testId1');
+        categoriesApi.unlinkNodeFromCategory('testNode', 'testId1').then(
             (response: any) => {
                 expect(response.noContent);
                 done();
@@ -109,127 +109,127 @@ describe('Categories', () => {
         );
     });
 
-    it('unlinking category should return 404 if category with categoryId or node with nodeId does not exist', (done) => {
-        categoriesMock.get404CategoryUnlinkNotFound('80a94ac8-3ece-47ad-864e-5d939424c47c', 'testId1');
-        categoriesApi.unlinkNodeFromCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', 'testId1').then(
+    it('should return 404 while unlinking category if category with categoryId or node with nodeId does not exist', (done) => {
+        categoriesMock.get404CategoryUnlinkNotFound('testNode', 'testId1');
+        categoriesApi.unlinkNodeFromCategory('testNode', 'testId1').then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(404);
+                expect(error.status).equal(404);
                 done();
             }
         );
     });
 
-    it('unlinking category should return 403 if user has no rights to unlink', (done) => {
-        categoriesMock.get403CategoryUnlinkPermissionDenied('80a94ac8-3ece-47ad-864e-5d939424c47c', 'testId1');
-        categoriesApi.unlinkNodeFromCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', 'testId1').then(
+    it('should return 403 while unlinking category if user has no rights to unlink', (done) => {
+        categoriesMock.get403CategoryUnlinkPermissionDenied('testNode', 'testId1');
+        categoriesApi.unlinkNodeFromCategory('testNode', 'testId1').then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(403);
+                expect(error.status).equal(403);
                 done();
             }
         );
     });
 
-    it('update category should return 200 if all is ok', (done) => {
+    it('should return 200 while updating category if all is ok', (done) => {
         categoriesMock.get200ResponseCategoryUpdated('testId1');
         categoriesApi.updateCategory('testId1', { name: 'testName1' }).then((response: CategoryEntry) => {
-            expect(response.entry.id).to.be.equal('testId1');
-            expect(response.entry.name).to.be.equal('testName1');
+            expect(response.entry.id).equal('testId1');
+            expect(response.entry.name).equal('testName1');
             done();
         });
     });
 
-    it('updating category should return 404 if category with categoryId does not exist', (done) => {
+    it('should return 404 while updating category if category with categoryId does not exist', (done) => {
         categoriesMock.get404CategoryUpdateNotFound('testId1');
         categoriesApi.updateCategory('testId1', { name: 'testName1' }).then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(404);
+                expect(error.status).equal(404);
                 done();
             }
         );
     });
 
-    it('updating category should return 403 if user has no rights to update', (done) => {
+    it('should return 403 while updating category if user has no rights to update', (done) => {
         categoriesMock.get403CategoryUpdatePermissionDenied('testId1');
         categoriesApi.updateCategory('testId1', { name: 'testName1' }).then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(403);
+                expect(error.status).equal(403);
                 done();
             }
         );
     });
 
-    it('create category should return 201 if all is ok', (done) => {
+    it('should return 201 while creating category if all is ok', (done) => {
         categoriesMock.get201ResponseCategoryCreated('testId1');
         categoriesApi.createSubcategory('testId1', [{ name: 'testName10' }]).then((response: CategoryEntry) => {
-            expect(response.entry.parentId).to.be.equal('testId1');
-            expect(response.entry.name).to.be.equal('testName10');
+            expect(response.entry.parentId).equal('testId1');
+            expect(response.entry.name).equal('testName10');
             done();
         });
     });
 
-    it('creating category should return 409 if subcategory already exists', (done) => {
+    it('should return 409 while creating subcategory if subcategory already exists', (done) => {
         categoriesMock.get409CategoryCreateAlreadyExists('testId1');
         categoriesApi.createSubcategory('testId1', [{ name: 'testName10' }]).then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(409);
+                expect(error.status).equal(409);
                 done();
             }
         );
     });
 
-    it('creating category should return 403 if user has no rights to create', (done) => {
+    it('should return 403 while creating category if user has no rights to create', (done) => {
         categoriesMock.get403CategoryCreatedPermissionDenied('testId1');
         categoriesApi.createSubcategory('testId1', [{ name: 'testName10' }]).then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(403);
+                expect(error.status).equal(403);
                 done();
             }
         );
     });
 
-    it('category link should return 201 if all is ok', (done) => {
-        categoriesMock.get201ResponseCategoryLinked('80a94ac8-3ece-47ad-864e-5d939424c47c');
-        categoriesApi.linkNodeToCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', [{ categoryId: 'testId1' }]).then((response: CategoryEntry) => {
-            expect(response.entry.id).to.be.equal('testId1');
-            expect(response.entry.name).to.be.equal('testName1');
+    it('should return 201 while linking category if all is ok', (done) => {
+        categoriesMock.get201ResponseCategoryLinked('testNode');
+        categoriesApi.linkNodeToCategory('testNode', [{ categoryId: 'testId1' }]).then((response: CategoryEntry) => {
+            expect(response.entry.id).equal('testId1');
+            expect(response.entry.name).equal('testName1');
             done();
         });
     });
 
-    it('linking category should return 404 if node with nodeId or category with categoryId does not exist', (done) => {
-        categoriesMock.get404CategoryLinkNotFound('80a94ac8-3ece-47ad-864e-5d939424c47c');
-        categoriesApi.linkNodeToCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', [{ categoryId: 'testId1' }]).then(
+    it('should return 404 while linking category if node with nodeId or category with categoryId does not exist', (done) => {
+        categoriesMock.get404CategoryLinkNotFound('testNode');
+        categoriesApi.linkNodeToCategory('testNode', [{ categoryId: 'testId1' }]).then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(404);
+                expect(error.status).equal(404);
                 done();
             }
         );
     });
 
-    it('linking category should return 403 if user has no rights to link', (done) => {
-        categoriesMock.get403CategoryLinkPermissionDenied('80a94ac8-3ece-47ad-864e-5d939424c47c');
-        categoriesApi.linkNodeToCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', [{ categoryId: 'testId1' }]).then(
+    it('should return 403 while linking category if user has no rights to link', (done) => {
+        categoriesMock.get403CategoryLinkPermissionDenied('testNode');
+        categoriesApi.linkNodeToCategory('testNode', [{ categoryId: 'testId1' }]).then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(403);
+                expect(error.status).equal(403);
                 done();
             }
         );
     });
 
-    it('linking category should return 405 if node of this type cannot be assigned to category', (done) => {
-        categoriesMock.get405CategoryLinkCannotAssign('80a94ac8-3ece-47ad-864e-5d939424c47c');
-        categoriesApi.linkNodeToCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', [{ categoryId: 'testId1' }]).then(
+    it('should return 405 while linking category if node of this type cannot be assigned to category', (done) => {
+        categoriesMock.get405CategoryLinkCannotAssign('testNode');
+        categoriesApi.linkNodeToCategory('testNode', [{ categoryId: 'testId1' }]).then(
             () => {},
             (error: any) => {
-                expect(error.status).to.be.equal(405);
+                expect(error.status).equal(405);
                 done();
             }
         );

--- a/test/content-services/categoriesApi.spec.ts
+++ b/test/content-services/categoriesApi.spec.ts
@@ -1,0 +1,237 @@
+import { expect } from 'chai';
+import { AlfrescoApiConfig } from '../../src/alfrescoApiConfig';
+import { AlfrescoApi } from '../../src/alfrescoApi';
+import { CategoriesApi } from '../../src/api/content-rest-api';
+import { EcmAuthMock } from '../../test/mockObjects';
+import { CategoriesMock } from '../mockObjects/content-services/categories.mock';
+import { CategoryPaging } from '../../src/api/content-rest-api/model/categoryPaging';
+import { CategoryEntry } from '../../src/api/content-rest-api/model/categoryEntry';
+
+describe('Categories', () => {
+    let authResponseMock: EcmAuthMock;
+    let categoriesMock: CategoriesMock;
+    let categoriesApi: CategoriesApi;
+
+    beforeEach((done) => {
+        const hostEcm = 'http://127.0.0.1:8080';
+
+        authResponseMock = new EcmAuthMock(hostEcm);
+        categoriesMock = new CategoriesMock();
+
+        authResponseMock.get201Response();
+        const alfrescoJsApi = new AlfrescoApi({
+            hostEcm
+        } as AlfrescoApiConfig);
+
+        alfrescoJsApi.login('admin', 'admin').then(() => done());
+        categoriesApi = new CategoriesApi(alfrescoJsApi);
+    });
+
+    it('get subcategories for category with categoryId should return 200 if all if ok', (done) => {
+        categoriesMock.get200ResponseSubcategories('-root-');
+        categoriesApi.getSubcategories('-root-').then((response: CategoryPaging) => {
+            expect(response.list.pagination.count).to.be.equal(2);
+            expect(response.list.entries[0].entry.parentId).to.be.equal('-root-');
+            expect(response.list.entries[0].entry.id).to.be.equal('testId1');
+            done();
+        });
+    });
+
+    it('get subcategories for not existing category should return 404', (done) => {
+        categoriesMock.get404SubcategoryNotExist('notExistingId');
+        categoriesApi.getSubcategories('notExistingId').then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(404);
+                done();
+            }
+        );
+    });
+
+    it('get category with nodeId should return 200 if category exists', (done) => {
+        categoriesMock.get200ResponseCategory('testId1');
+        categoriesApi.getCategory('testId1').then((response: CategoryEntry) => {
+            expect(response.entry.parentId).to.be.equal('-root-');
+            expect(response.entry.id).to.be.equal('testId1');
+            done();
+        });
+    });
+
+    it('get category for not existing category should return 404', (done) => {
+        categoriesMock.get404CategoryNotExist('notExistingId');
+        categoriesApi.getCategory('notExistingId').then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(404);
+                done();
+            }
+        );
+    });
+
+    it('get category linked to node with nodeId should return 200 if node has some categories assigned', (done) => {
+        categoriesMock.get200ResponseNodeCategoryLinks('80a94ac8-3ece-47ad-864e-5d939424c47c');
+        categoriesApi.getCategoryLinksForNode('80a94ac8-3ece-47ad-864e-5d939424c47c').then((response: CategoryPaging) => {
+            expect(response.list.entries[0].entry.parentId).to.be.equal('80a94ac8-3ece-47ad-864e-5d939424c47c');
+            expect(response.list.entries[0].entry.id).to.be.equal('testId1');
+            done();
+        });
+    });
+
+    it('getting categories linked to node should return 403 if current user does not have permission to get from node', (done) => {
+        categoriesMock.get403NodeCategoryLinksPermissionDenied('80a94ac8-3ece-47ad-864e-5d939424c47c');
+        categoriesApi.getCategoryLinksForNode('80a94ac8-3ece-47ad-864e-5d939424c47c').then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(403);
+                done();
+            }
+        );
+    });
+
+    it('getting categories linked to node should return 404 if node with nodeId does not exist', (done) => {
+        categoriesMock.get404NodeNotExist('80a94ac8-3ece-47ad-864e-5d939424c47c');
+        categoriesApi.getCategoryLinksForNode('80a94ac8-3ece-47ad-864e-5d939424c47c').then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(404);
+                done();
+            }
+        );
+    });
+
+    it('should return 204 after unlinking category', (done) => {
+        categoriesMock.get204CategoryUnlinked('80a94ac8-3ece-47ad-864e-5d939424c47c', 'testId1');
+        categoriesApi.unlinkNodeFromCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', 'testId1').then(
+            (response: any) => {
+                expect(response.noContent);
+                done();
+            }
+        );
+    });
+
+    it('unlinking category should return 404 if category with categoryId or node with nodeId does not exist', (done) => {
+        categoriesMock.get404CategoryUnlinkNotFound('80a94ac8-3ece-47ad-864e-5d939424c47c', 'testId1');
+        categoriesApi.unlinkNodeFromCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', 'testId1').then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(404);
+                done();
+            }
+        );
+    });
+
+    it('unlinking category should return 403 if user has no rights to unlink', (done) => {
+        categoriesMock.get403CategoryUnlinkPermissionDenied('80a94ac8-3ece-47ad-864e-5d939424c47c', 'testId1');
+        categoriesApi.unlinkNodeFromCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', 'testId1').then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(403);
+                done();
+            }
+        );
+    });
+
+    it('update category should return 200 if all is ok', (done) => {
+        categoriesMock.get200ResponseCategoryUpdated('testId1');
+        categoriesApi.updateCategory('testId1', { name: 'testName1' }).then((response: CategoryEntry) => {
+            expect(response.entry.id).to.be.equal('testId1');
+            expect(response.entry.name).to.be.equal('testName1');
+            done();
+        });
+    });
+
+    it('updating category should return 404 if category with categoryId does not exist', (done) => {
+        categoriesMock.get404CategoryUpdateNotFound('testId1');
+        categoriesApi.updateCategory('testId1', { name: 'testName1' }).then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(404);
+                done();
+            }
+        );
+    });
+
+    it('updating category should return 403 if user has no rights to update', (done) => {
+        categoriesMock.get403CategoryUpdatePermissionDenied('testId1');
+        categoriesApi.updateCategory('testId1', { name: 'testName1' }).then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(403);
+                done();
+            }
+        );
+    });
+
+    it('create category should return 201 if all is ok', (done) => {
+        categoriesMock.get201ResponseCategoryCreated('testId1');
+        categoriesApi.createSubcategory('testId1', [{ name: 'testName10' }]).then((response: CategoryEntry) => {
+            expect(response.entry.parentId).to.be.equal('testId1');
+            expect(response.entry.name).to.be.equal('testName10');
+            done();
+        });
+    });
+
+    it('creating category should return 409 if subcategory already exists', (done) => {
+        categoriesMock.get409CategoryCreateAlreadyExists('testId1');
+        categoriesApi.createSubcategory('testId1', [{ name: 'testName10' }]).then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(409);
+                done();
+            }
+        );
+    });
+
+    it('creating category should return 403 if user has no rights to create', (done) => {
+        categoriesMock.get403CategoryCreatedPermissionDenied('testId1');
+        categoriesApi.createSubcategory('testId1', [{ name: 'testName10' }]).then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(403);
+                done();
+            }
+        );
+    });
+
+    it('category link should return 201 if all is ok', (done) => {
+        categoriesMock.get201ResponseCategoryLinked('80a94ac8-3ece-47ad-864e-5d939424c47c');
+        categoriesApi.linkNodeToCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', [{ categoryId: 'testId1' }]).then((response: CategoryEntry) => {
+            expect(response.entry.id).to.be.equal('testId1');
+            expect(response.entry.name).to.be.equal('testName1');
+            done();
+        });
+    });
+
+    it('linking category should return 404 if node with nodeId or category with categoryId does not exist', (done) => {
+        categoriesMock.get404CategoryLinkNotFound('80a94ac8-3ece-47ad-864e-5d939424c47c');
+        categoriesApi.linkNodeToCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', [{ categoryId: 'testId1' }]).then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(404);
+                done();
+            }
+        );
+    });
+
+    it('linking category should return 403 if user has no rights to link', (done) => {
+        categoriesMock.get403CategoryLinkPermissionDenied('80a94ac8-3ece-47ad-864e-5d939424c47c');
+        categoriesApi.linkNodeToCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', [{ categoryId: 'testId1' }]).then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(403);
+                done();
+            }
+        );
+    });
+
+    it('linking category should return 405 if node of this type cannot be assigned to category', (done) => {
+        categoriesMock.get405CategoryLinkCannotAssign('80a94ac8-3ece-47ad-864e-5d939424c47c');
+        categoriesApi.linkNodeToCategory('80a94ac8-3ece-47ad-864e-5d939424c47c', [{ categoryId: 'testId1' }]).then(
+            () => {},
+            (error: any) => {
+                expect(error.status).to.be.equal(405);
+                done();
+            }
+        );
+    });
+});

--- a/test/mockObjects/content-services/categories.mock.ts
+++ b/test/mockObjects/content-services/categories.mock.ts
@@ -1,0 +1,288 @@
+import nock from 'nock';
+import { BaseMock } from '../base.mock';
+
+export class CategoriesMock extends BaseMock {
+    constructor(host?: string) {
+        super(host);
+    }
+
+    get200ResponseSubcategories(categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .get(`/alfresco/api/-default-/public/alfresco/versions/1/categories/${categoryId}/subcategories`)
+            .reply(200, {
+                list: {
+                    pagination: {
+                        count: 2,
+                        hasMoreItems: false,
+                        totalItems: 2,
+                        skipCount: 0,
+                        maxItems: 100,
+                    },
+                    entries: [
+                        {
+                            entry: {
+                                id: 'testId1',
+                                name: 'testName1',
+                                parentId: '-root-',
+                                hasChildren: true,
+                                count: 0
+                            },
+                        },
+                        {
+                            entry: {
+                                id: 'testId2',
+                                name: 'testName2',
+                                parentId: '-root-',
+                                hasChildren: true,
+                                count: 0
+                            },
+                        }
+                    ],
+                },
+            });
+    }
+
+    get404SubcategoryNotExist(categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .get(`/alfresco/api/-default-/public/alfresco/versions/1/categories/${categoryId}/subcategories`)
+            .reply(404, {
+                error: {
+                    errorKey: 'framework.exception.EntityNotFound',
+                    statusCode: 404,
+                    briefSummary: `05220073 The entity with id: ${categoryId} was not found`,
+                    stackTrace: 'For security reasons the stack trace is no longer displayed, but the property is kept for previous versions.',
+                    descriptionURL: 'https://api-explorer.alfresco.com',
+                },
+            });
+    }
+
+    get200ResponseCategory(categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .get(`/alfresco/api/-default-/public/alfresco/versions/1/categories/${categoryId}`)
+            .reply(200, {
+                entry: {
+                    id: 'testId1',
+                    name: 'testName1',
+                    parentId: '-root-',
+                    hasChildren: true,
+                    count: 0
+                },
+            });
+    }
+
+    get404CategoryNotExist(categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .get(`/alfresco/api/-default-/public/alfresco/versions/1/categories/${categoryId}`)
+            .reply(404, {
+                error: {
+                    errorKey: 'framework.exception.EntityNotFound',
+                    statusCode: 404,
+                    briefSummary: `05220073 The entity with id: ${categoryId} was not found`,
+                    stackTrace: 'For security reasons the stack trace is no longer displayed, but the property is kept for previous versions.',
+                    descriptionURL: 'https://api-explorer.alfresco.com',
+                },
+            });
+    }
+
+    get200ResponseNodeCategoryLinks(nodeId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .get(`/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/category-links`)
+            .reply(200, {
+                list: {
+                    pagination: {
+                        count: 1,
+                        hasMoreItems: false,
+                        totalItems: 1,
+                        skipCount: 0,
+                        maxItems: 100,
+                    },
+                    entries: [
+                        {
+                            entry: {
+                                id: 'testId1',
+                                name: 'testName1',
+                                parentId: '80a94ac8-3ece-47ad-864e-5d939424c47c',
+                                hasChildren: true,
+                                count: 0
+                            },
+                        }
+                    ],
+                },
+            });
+    }
+
+    get403NodeCategoryLinksPermissionDenied(nodeId: string): void {
+        nock(this.host, { encodedQueryParams: true }).get(`/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/category-links`)
+        .reply(403, {
+            error: {
+                statusCode: 403
+            }
+        });
+    }
+
+    get404NodeNotExist(nodeId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .get(`/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/category-links`)
+            .reply(404, {
+                error: {
+                    errorKey: 'framework.exception.EntityNotFound',
+                    statusCode: 404,
+                    briefSummary: `05220073 The entity with id: ${nodeId} was not found`,
+                    stackTrace: 'For security reasons the stack trace is no longer displayed, but the property is kept for previous versions.',
+                    descriptionURL: 'https://api-explorer.alfresco.com',
+                },
+            });
+    }
+
+    get204CategoryUnlinked(nodeId: string, categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true }).delete(`/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/category-links/${categoryId}`).reply(204);
+    }
+
+    get403CategoryUnlinkPermissionDenied(nodeId: string, categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true }).delete(`/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/category-links/${categoryId}`)
+        .reply(403, {
+            error: {
+                statusCode: 403
+            }
+        });
+    }
+
+    get404CategoryUnlinkNotFound(nodeId: string, categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .delete(`/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/category-links/${categoryId}`)
+            .reply(404, {
+                error: {
+                    errorKey: 'framework.exception.EntityNotFound',
+                    statusCode: 404,
+                    briefSummary: `05230078 The entity with id: ${nodeId} or ${categoryId} was not found`,
+                    stackTrace: 'For security reasons the stack trace is no longer displayed, but the property is kept for previous versions.',
+                    descriptionURL: 'https://api-explorer.alfresco.com',
+                },
+            });
+    }
+
+    get200ResponseCategoryUpdated(categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .put(`/alfresco/api/-default-/public/alfresco/versions/1/categories/${categoryId}`, { name: 'testName1' })
+            .reply(200, {
+                entry: {
+                    id: 'testId1',
+                    name: 'testName1',
+                    parentId: '-root-',
+                    hasChildren: true,
+                    count: 0
+                },
+            });
+    }
+
+    get403CategoryUpdatePermissionDenied(categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true }).put(`/alfresco/api/-default-/public/alfresco/versions/1/categories/${categoryId}`, { name: 'testName1' })
+        .reply(403, {
+            error: {
+                statusCode: 403
+            }
+        });
+    }
+
+    get404CategoryUpdateNotFound(categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .put(`/alfresco/api/-default-/public/alfresco/versions/1/categories/${categoryId}`, { name: 'testName1' })
+            .reply(404, {
+                error: {
+                    errorKey: 'framework.exception.EntityNotFound',
+                    statusCode: 404,
+                    briefSummary: `05230078 The entity with id: ${categoryId} was not found`,
+                    stackTrace: 'For security reasons the stack trace is no longer displayed, but the property is kept for previous versions.',
+                    descriptionURL: 'https://api-explorer.alfresco.com',
+                },
+            });
+    }
+
+    get201ResponseCategoryCreated(categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .post(`/alfresco/api/-default-/public/alfresco/versions/1/categories/${categoryId}/subcategories`, [{ name: 'testName10' }])
+            .reply(201, {
+                entry: {
+                    id: 'testId10',
+                    name: 'testName10',
+                    parentId: categoryId,
+                    hasChildren: true,
+                    count: 0
+                },
+            });
+    }
+
+    get403CategoryCreatedPermissionDenied(categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true }).post(`/alfresco/api/-default-/public/alfresco/versions/1/categories/${categoryId}/subcategories`, [{ name: 'testName10' }])
+        .reply(403, {
+            error: {
+                statusCode: 403
+            }
+        });
+    }
+
+    get409CategoryCreateAlreadyExists(categoryId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .post(`/alfresco/api/-default-/public/alfresco/versions/1/categories/${categoryId}/subcategories`, [{ name: 'testName10' }])
+            .reply(409, {
+                error: {
+                    errorKey: 'Duplicate child name not allowed: testName10',
+                    statusCode: 409,
+                    briefSummary: '06050055 Duplicate child name not allowed: testName10',
+                    stackTrace: 'For security reasons the stack trace is no longer displayed, but the property is kept for previous versions.',
+                    descriptionURL: 'https://api-explorer.alfresco.com',
+                },
+            });
+    }
+
+    get201ResponseCategoryLinked(nodeId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .post(`/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/category-links`, [{ categoryId: 'testId1' }])
+            .reply(201, {
+                entry: {
+                    id: 'testId1',
+                    name: 'testName1',
+                    parentId: nodeId,
+                    hasChildren: true,
+                    count: 0
+                },
+            });
+    }
+
+    get403CategoryLinkPermissionDenied(nodeId: string): void {
+        nock(this.host, { encodedQueryParams: true }).post(`/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/category-links`, [{ categoryId: 'testId1' }])
+        .reply(403, {
+            error: {
+                statusCode: 403
+            }
+        });
+    }
+
+    get404CategoryLinkNotFound(nodeId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .post(`/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/category-links`, [{ categoryId: 'testId1' }])
+            .reply(404, {
+                error: {
+                    errorKey: 'framework.exception.EntityNotFound',
+                    statusCode: 404,
+                    briefSummary: `05230078 The entity with id: ${nodeId} or testId1 was not found`,
+                    stackTrace: 'For security reasons the stack trace is no longer displayed, but the property is kept for previous versions.',
+                    descriptionURL: 'https://api-explorer.alfresco.com',
+                },
+            });
+    }
+
+    get405CategoryLinkCannotAssign(nodeId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .post(`/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/category-links`, [{ categoryId: 'testId1' }])
+            .reply(405, {
+                error: {
+                    errorKey: 'Cannot assign node of this type to a category',
+                    statusCode: 405,
+                    briefSummary: `05230078 Cannot assign a node of this type to a category`,
+                    stackTrace: 'For security reasons the stack trace is no longer displayed, but the property is kept for previous versions.',
+                    descriptionURL: 'https://api-explorer.alfresco.com',
+                },
+            });
+    }
+}

--- a/test/mockObjects/content-services/categories.mock.ts
+++ b/test/mockObjects/content-services/categories.mock.ts
@@ -101,7 +101,7 @@ export class CategoriesMock extends BaseMock {
                             entry: {
                                 id: 'testId1',
                                 name: 'testName1',
-                                parentId: '80a94ac8-3ece-47ad-864e-5d939424c47c',
+                                parentId: 'testNode',
                                 hasChildren: true,
                                 count: 0
                             },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Categories API was untested. https://alfresco.atlassian.net/browse/ACS-4231

**What is the new behavior?**

Unit tests covering each endpoint have been added.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
