### PR TITLE
Fix GHA warnings for upcoming changes for setup-node action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/js-api-build.yml
+++ b/.github/workflows/js-api-build.yml
@@ -30,9 +30,9 @@ jobs:
                 fetch-depth: 2
 
             - name: node
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v3
               with:
-                node-version: '14'
+                node-version: 16
                 cache: 'npm'
             - run: npm ci
 
@@ -55,9 +55,9 @@ jobs:
                 fetch-depth: 2
 
             - name: node
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v3
               with:
-                node-version: '14'
+                node-version: 16
                 cache: 'npm'
             - run: npm ci
 
@@ -92,9 +92,9 @@ jobs:
                 fetch-depth: 2
 
             - name: node
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v3
               with:
-                node-version: '14'
+                node-version: 16
                 cache: 'npm'
             - run: npm ci
 

--- a/.github/workflows/js-api-build.yml
+++ b/.github/workflows/js-api-build.yml
@@ -67,7 +67,7 @@ jobs:
                 npm run test || exit 1
                 npm run coverage
 
-            - name: Perfomance
+            - name: Performance
               shell: bash
               run: ./scripts/test-performance.sh || exit 1
 

--- a/.github/workflows/js-api-build.yml
+++ b/.github/workflows/js-api-build.yml
@@ -25,7 +25,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3.0.0
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 2
 
@@ -50,7 +50,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v3.0.0
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 2
 
@@ -87,7 +87,7 @@ jobs:
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || github.event.schedule == '0 3 * * *'
         steps:
             - name: Checkout
-              uses: actions/checkout@v3.0.0
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 2
 

--- a/.github/workflows/trigger-upstream.yml
+++ b/.github/workflows/trigger-upstream.yml
@@ -24,7 +24,7 @@ jobs:
         if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
         steps:
             - name: Checkout
-              uses: actions/checkout@v3.0.0
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 2
 

--- a/.github/workflows/trigger-upstream.yml
+++ b/.github/workflows/trigger-upstream.yml
@@ -29,9 +29,9 @@ jobs:
                 fetch-depth: 2
 
             - name: node
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v3
               with:
-                node-version: '14'
+                node-version: 16
                 cache: 'npm'
             - run: npm ci
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

Switch to latest setup-node and node 16
Fix GHA warnings for the upcoming deprecations:

Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-node@v2.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
