### PR TITLE
fix-js-api-upstream

### DIFF
--- a/scripts/update-project.sh
+++ b/scripts/update-project.sh
@@ -71,7 +71,7 @@ JS_VERSION=$(npm view @alfresco/js-api@$VERSION version)
 for i in $(find . ! -path "*/node_modules/*" -name "package-lock.json" | xargs grep -l 'js-api'); do
     directory=$(dirname $i)
     echo $directory
-    ( cd $directory ; npm i --save-exact --ignore-scripts @alfresco/js-api@$VERSION)
+    ( cd $directory ; npm i --lockfile-version 1 --save-exact --ignore-scripts @alfresco/js-api@$VERSION)
 done
 
 for i in $(find . ! -path "*/node_modules/*" -name "package.json" | xargs grep -l 'js-api'); do


### PR DESCRIPTION
When install the new version of the JS-API the lock file in ADF needs to be version 1

**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
