### PR TITLE
[AAE-12501] Align JS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ provider| (Optional value default value is ECM. This parameter can accept as val
 ticket| (Optional only if you want login with the ticket see example below)| |
 disableCsrf| To disable CSRF Token to be submitted. Only for Activiti call.| false |
 withCredentials| (Optional configuration for SSO, requires CORS on ECM) |false
+oauthInit|(Optional, if false skip the OAuth2 initialization) | true
 
 ### Login with Username and Password BPM and ECM
 

--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -42,7 +42,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
     oauth2Auth: Oauth2Auth;
     processAuth: ProcessAuth;
     contentAuth: ContentAuth;
-    alfrescoApiClient: AlfrescoApiClient;
+    private basicApiClient: AlfrescoApiClient;
 
     on: EmitterMethod;
     off: EmitterMethod;
@@ -53,12 +53,9 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
     emit: (type: string, ...args: any[]) => void;
 
     username: string;
-    oauthInit: boolean;
 
-    constructor(config?: AlfrescoApiConfig, public httpClient?: HttpClient, oauthInit = true) {
+    constructor(config?: AlfrescoApiConfig, public httpClient?: HttpClient, private oauthInit = true) {
         ee(this);
-
-        this.oauthInit = oauthInit;
 
         if (config) {
             this.setConfig(config);
@@ -78,7 +75,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
         this.clientsFactory();
 
         this.processClient = new ProcessClient(this.config, this.httpClient);
-        this.alfrescoApiClient = new AlfrescoApiClient(undefined, this.httpClient);
+        this.basicApiClient = new AlfrescoApiClient(undefined, this.httpClient);
 
         this.errorListeners();
         if(this.oauthInit){
@@ -90,6 +87,20 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
         }
 
         return config;
+    }
+
+    public callCustomApiWithoutAuth(...rest: Parameters<typeof this.basicApiClient.callCustomApi>) {
+        if (this.oauthInit) {
+            throw Error(`Is not possible to call custom api with oauthInit true, it's needed to instanciate AlfrescoApi with oauthInit false`);
+        }
+        return this.basicApiClient.callCustomApi(...rest);
+    }
+
+    public callApiWithoutAuth(...rest: Parameters<typeof this.basicApiClient.callApi>) {
+        if (this.oauthInit) {
+            throw Error(`Is not possible to call api with oauthInit true, it's needed to instanciate AlfrescoApi with oauthInit false`);
+        }
+        return this.basicApiClient.callApi(...rest);
     }
 
     private initAuth(config: AlfrescoApiConfig): void {

--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -74,7 +74,6 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
 
         this.clientsFactory();
 
-        this.processClient = new ProcessClient(this.config, this.httpClient);
         this.basicApiClient = new AlfrescoApiClient(undefined, this.httpClient);
 
         this.errorListeners();

--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -26,7 +26,6 @@ import { AlfrescoApiConfig } from './alfrescoApiConfig';
 import { Authentication } from './authentication/authentication';
 import { AlfrescoApiType } from './to-deprecate/alfresco-api-type';
 import { HttpClient } from './api-clients/http-client.interface';
-import { AlfrescoApiClient } from './alfrescoApiClient';
 
 export class AlfrescoApi implements Emitter, AlfrescoApiType {
     __type = 'legacy-client';
@@ -42,7 +41,6 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
     oauth2Auth: Oauth2Auth;
     processAuth: ProcessAuth;
     contentAuth: ContentAuth;
-    private basicApiClient: AlfrescoApiClient;
 
     on: EmitterMethod;
     off: EmitterMethod;
@@ -54,7 +52,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
 
     username: string;
 
-    constructor(config?: AlfrescoApiConfig, public httpClient?: HttpClient, private oauthInit = true) {
+    constructor(config?: AlfrescoApiConfig, public httpClient?: HttpClient) {
         ee(this);
 
         if (config) {
@@ -74,10 +72,8 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
 
         this.clientsFactory();
 
-        this.basicApiClient = new AlfrescoApiClient(undefined, this.httpClient);
-
         this.errorListeners();
-        if(this.oauthInit){
+        if(this.config.oauthInit){
             this.initAuth(config);
 
             if(this.isLoggedIn()){
@@ -86,20 +82,6 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
         }
 
         return config;
-    }
-
-    public callCustomApiWithoutAuth(...rest: Parameters<typeof this.basicApiClient.callCustomApi>) {
-        if (this.oauthInit) {
-            throw Error(`Is not possible to call custom api with oauthInit true, it's needed to instanciate AlfrescoApi with oauthInit false`);
-        }
-        return this.basicApiClient.callCustomApi(...rest);
-    }
-
-    public callApiWithoutAuth(...rest: Parameters<typeof this.basicApiClient.callApi>) {
-        if (this.oauthInit) {
-            throw Error(`Is not possible to call api with oauthInit true, it's needed to instanciate AlfrescoApi with oauthInit false`);
-        }
-        return this.basicApiClient.callApi(...rest);
     }
 
     private initAuth(config: AlfrescoApiConfig): void {

--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -26,6 +26,7 @@ import { AlfrescoApiConfig } from './alfrescoApiConfig';
 import { Authentication } from './authentication/authentication';
 import { AlfrescoApiType } from './to-deprecate/alfresco-api-type';
 import { HttpClient } from './api-clients/http-client.interface';
+import { AlfrescoApiClient } from './alfrescoApiClient';
 
 export class AlfrescoApi implements Emitter, AlfrescoApiType {
     __type = 'legacy-client';
@@ -41,6 +42,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
     oauth2Auth: Oauth2Auth;
     processAuth: ProcessAuth;
     contentAuth: ContentAuth;
+    alfrescoApiClient: AlfrescoApiClient;
 
     on: EmitterMethod;
     off: EmitterMethod;
@@ -51,9 +53,12 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
     emit: (type: string, ...args: any[]) => void;
 
     username: string;
+    oauthInit: boolean;
 
-    constructor(config?: AlfrescoApiConfig, public httpClient?: HttpClient) {
+    constructor(config?: AlfrescoApiConfig, public httpClient?: HttpClient, oauthInit = true) {
         ee(this);
+
+        this.oauthInit = oauthInit;
 
         if (config) {
             this.setConfig(config);
@@ -73,12 +78,15 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
         this.clientsFactory();
 
         this.processClient = new ProcessClient(this.config, this.httpClient);
+        this.alfrescoApiClient = new AlfrescoApiClient(undefined, this.httpClient);
 
         this.errorListeners();
-        this.initAuth(config);
+        if(this.oauthInit){
+            this.initAuth(config);
 
-        if(this.isLoggedIn()){
-            this.emitBuffer('logged-in');
+            if(this.isLoggedIn()){
+                this.emitBuffer('logged-in');
+            }
         }
 
         return config;

--- a/src/alfrescoApiConfig.ts
+++ b/src/alfrescoApiConfig.ts
@@ -34,6 +34,7 @@ export class AlfrescoApiConfig {
     accessToken?: string;
     disableCsrf?: boolean = false;
     withCredentials?: boolean = false;
+    oauthInit?: boolean = true;
 
     constructor(input: any = { oauth2: {} }) {
         Object.assign(this, input);


### PR DESCRIPTION
…when the new oidc auth is used on adf

**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-12501


**What is the new behavior?**
A new property `oauthInit` has been added to the `AlfrescoApiConfig` to bypass the `Oauth2Auth` initialization. The default value is `true` to avoid BCs.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
