### PR TITLE
[ACS-4753] list of tags is not rendered because of missing count field in backend response

### DIFF
--- a/src/api/content-rest-api/api/tags.api.ts
+++ b/src/api/content-rest-api/api/tags.api.ts
@@ -228,7 +228,6 @@ If not supplied then the default value is 0.
 If not supplied then the default value is 100.
  (default to 100)
     * @param opts.fields A list of field names.
-    * @param opts.name Name for which tag is returned.
 
 You can use this parameter to restrict the fields
 returned within a response if, for example, you want to save on overall bandwidth.
@@ -242,6 +241,8 @@ parameter are returned in addition to those specified in the **fields** paramete
 
     * @param opts.include Returns additional information about the tag. The following optional fields can be requested:
 * count
+    * @param opts.tag Name or pattern for which tag is returned. Example of pattern: *test* which returns tags like 'my test 1'
+    * @param opts.matching Switches filtering to pattern mode instead of exact mode.
 
     * @return Promise<TagPaging>
     */

--- a/src/api/content-rest-api/api/tags.api.ts
+++ b/src/api/content-rest-api/api/tags.api.ts
@@ -259,7 +259,7 @@ parameter are returned in addition to those specified in the **fields** paramete
             'maxItems': opts['maxItems'],
             'fields': buildCollectionParam(opts['fields'], 'csv'),
             'include': buildCollectionParam(opts['include'], 'csv'),
-            where: opts?.name ? `(name='${opts.name}')` : undefined
+            where: opts?.tags ? `(tag in ('${opts.tags.join("', '")}'))` : undefined
         };
 
         const headerParams = {

--- a/src/api/content-rest-api/api/tags.api.ts
+++ b/src/api/content-rest-api/api/tags.api.ts
@@ -254,12 +254,16 @@ parameter are returned in addition to those specified in the **fields** paramete
 
         };
 
+        let where: string;
+        if (opts?.tag) {
+            where = opts.matching ? `(tag matches ('${opts.tag}'))` : `(tag='${opts.tag}')`;
+        }
         const queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
             'fields': buildCollectionParam(opts['fields'], 'csv'),
             'include': buildCollectionParam(opts['include'], 'csv'),
-            where: opts?.tags ? `(tag in ('${opts.tags.join("', '")}'))` : undefined
+            where
         };
 
         const headerParams = {

--- a/test/content-services/tagApi.spec.ts
+++ b/test/content-services/tagApi.spec.ts
@@ -28,26 +28,50 @@ describe('Tags', () => {
         tagsApi = new TagsApi(alfrescoJsApi);
     });
 
-    it('tags', (done) => {
-        tagMock.get200Response();
+    describe('listTags', () => {
+        it('should load list of tags', (done) => {
+            tagMock.get200Response();
 
-        tagsApi.listTags().then((data) => {
-            expect(data.list.pagination.count).to.be.equal(2);
-            expect(data.list.entries[0].entry.tag).to.be.equal('tag-test-1');
-            expect(data.list.entries[1].entry.tag).to.be.equal('tag-test-2');
-            done();
-        });
-    });
-
-    it('Tags 401', (done) => {
-        tagMock.get401Response();
-
-        tagsApi.listTags().then(
-            () => {},
-            () => {
+            tagsApi.listTags().then((data) => {
+                expect(data.list.pagination.count).equal(2);
+                expect(data.list.entries[0].entry.tag).equal('tag-test-1');
+                expect(data.list.entries[1].entry.tag).equal('tag-test-2');
                 done();
-            }
-        );
+            });
+        });
+
+        it('should handle 401 error', (done) => {
+            tagMock.get401Response();
+
+            tagsApi.listTags().then(
+                () => {},
+                () => {
+                    done();
+                }
+            );
+        });
+
+        it('should return counts for specified tags', (done) => {
+            tagMock.getTagsByNamesIncludingCounters200Response();
+
+            tagsApi.listTags({
+                include: ['count'],
+                tags: ['tag-test-1', 'tag-test-2']
+            }).then((data) => {
+                expect(data.list.pagination.count).equal(2);
+                expect(data.list.entries[0].entry).deep.equal({
+                    tag: 'tag-test-1',
+                    id: '0d89aa82-f2b8-4a37-9a54-f4c5148174d6',
+                    count: 0
+                });
+                expect(data.list.entries[1].entry).deep.equal({
+                    tag: 'tag-test-2',
+                    id: 'd79bdbd0-9f55-45bb-9521-811e15bf48f6',
+                    count: 1
+                });
+                done();
+            });
+        });
     });
 
     describe('createTags', () => {

--- a/test/content-services/tagApi.spec.ts
+++ b/test/content-services/tagApi.spec.ts
@@ -51,23 +51,34 @@ describe('Tags', () => {
             );
         });
 
-        it('should return counts for specified tags', (done) => {
-            tagMock.getTagsByNamesIncludingCounters200Response();
+        it('should return specified tag', (done) => {
+            tagMock.getTagsByNamesFilterByExactTag200Response();
 
             tagsApi.listTags({
-                include: ['count'],
-                tags: ['tag-test-1', 'tag-test-2']
+                tag: 'tag-test-1'
             }).then((data) => {
-                expect(data.list.pagination.count).equal(2);
                 expect(data.list.entries[0].entry).deep.equal({
                     tag: 'tag-test-1',
-                    id: '0d89aa82-f2b8-4a37-9a54-f4c5148174d6',
-                    count: 0
+                    id: '0d89aa82-f2b8-4a37-9a54-f4c5148174d6'
+                });
+                done();
+            });
+        });
+
+        it('should return tags contained specified value', (done) => {
+            tagMock.getTagsByNameFilteredByMatching200Response();
+
+            tagsApi.listTags({
+                tag: '*tag-test*',
+                matching: true
+            }).then((data) => {
+                expect(data.list.entries[0].entry).deep.equal({
+                    tag: 'tag-test-1',
+                    id: '0d89aa82-f2b8-4a37-9a54-f4c5148174d6'
                 });
                 expect(data.list.entries[1].entry).deep.equal({
                     tag: 'tag-test-2',
-                    id: 'd79bdbd0-9f55-45bb-9521-811e15bf48f6',
-                    count: 1
+                    id: 'd79bdbd0-9f55-45bb-9521-811e15bf48f6'
                 });
                 done();
             });

--- a/test/mockObjects/content-services/tag.mock.ts
+++ b/test/mockObjects/content-services/tag.mock.ts
@@ -10,13 +10,13 @@ export class TagMock extends BaseMock {
     get200Response(): void {
         nock(this.host, { encodedQueryParams: true })
             .get('/alfresco/api/-default-/public/alfresco/versions/1/tags')
-            .reply(200, this.getPaginetedListOfTags());
+            .reply(200, this.getPaginatedListOfTags());
     }
 
     getTagsByNameFilteredByMatching200Response(): void {
         nock(this.host, { encodedQueryParams: true })
             .get('/alfresco/api/-default-/public/alfresco/versions/1/tags?where=(tag%20matches%20(%27*tag-test*%27))')
-            .reply(200, this.getPaginetedListOfTags());
+            .reply(200, this.getPaginatedListOfTags());
     }
 
     getTagsByNamesFilterByExactTag200Response(): void {
@@ -72,7 +72,7 @@ export class TagMock extends BaseMock {
             }]);
     }
 
-    private getPaginetedListOfTags(): TagPaging {
+    private getPaginatedListOfTags(): TagPaging {
         return {
             list: {
                 pagination: {

--- a/test/mockObjects/content-services/tag.mock.ts
+++ b/test/mockObjects/content-services/tag.mock.ts
@@ -13,10 +13,33 @@ export class TagMock extends BaseMock {
             .reply(200, this.getPaginetedListOfTags());
     }
 
-    getTagsByNamesIncludingCounters200Response(): void {
+    getTagsByNameFilteredByMatching200Response(): void {
         nock(this.host, { encodedQueryParams: true })
-            .get('/alfresco/api/-default-/public/alfresco/versions/1/tags?include=count&where=(tag%20in%20(%27tag-test-1%27%2C%20%27tag-test-2%27))')
-            .reply(200, this.getPaginetedListOfTags(true));
+            .get('/alfresco/api/-default-/public/alfresco/versions/1/tags?where=(tag%20matches%20(%27*tag-test*%27))')
+            .reply(200, this.getPaginetedListOfTags());
+    }
+
+    getTagsByNamesFilterByExactTag200Response(): void {
+        nock(this.host, { encodedQueryParams: true })
+            .get('/alfresco/api/-default-/public/alfresco/versions/1/tags?where=(tag%3D%27tag-test-1%27)')
+            .reply(200, {
+                list: {
+                    pagination: {
+                        count: 1,
+                        hasMoreItems: false,
+                        skipCount: 0,
+                        maxItems: 100
+                    },
+                    entries: [
+                        {
+                            entry: {
+                                tag: 'tag-test-1',
+                                id: '0d89aa82-f2b8-4a37-9a54-f4c5148174d6'
+                            },
+                        }
+                    ],
+                },
+            });
     }
 
     get401Response(): void {
@@ -49,7 +72,7 @@ export class TagMock extends BaseMock {
             }]);
     }
 
-    private getPaginetedListOfTags(includeCount?: boolean): TagPaging {
+    private getPaginetedListOfTags(): TagPaging {
         return {
             list: {
                 pagination: { count: 2, hasMoreItems: false, skipCount: 0, maxItems: 100 },
@@ -57,15 +80,13 @@ export class TagMock extends BaseMock {
                     {
                         entry: {
                             tag: 'tag-test-1',
-                            id: '0d89aa82-f2b8-4a37-9a54-f4c5148174d6',
-                            count: includeCount ? 0 : undefined
+                            id: '0d89aa82-f2b8-4a37-9a54-f4c5148174d6'
                         },
                     },
                     {
                         entry: {
                             tag: 'tag-test-2',
-                            id: 'd79bdbd0-9f55-45bb-9521-811e15bf48f6',
-                            count: includeCount ? 1 : undefined
+                            id: 'd79bdbd0-9f55-45bb-9521-811e15bf48f6'
                         },
                     },
                 ],

--- a/test/mockObjects/content-services/tag.mock.ts
+++ b/test/mockObjects/content-services/tag.mock.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import { BaseMock } from '../base.mock';
+import { TagPaging } from '../../../src/api/content-rest-api';
 
 export class TagMock extends BaseMock {
     constructor(host?: string) {
@@ -9,25 +10,13 @@ export class TagMock extends BaseMock {
     get200Response(): void {
         nock(this.host, { encodedQueryParams: true })
             .get('/alfresco/api/-default-/public/alfresco/versions/1/tags')
-            .reply(200, {
-                list: {
-                    pagination: { count: 2, hasMoreItems: false, skipCount: 0, maxItems: 100 },
-                    entries: [
-                        {
-                            entry: {
-                                tag: 'tag-test-1',
-                                id: '0d89aa82-f2b8-4a37-9a54-f4c5148174d6',
-                            },
-                        },
-                        {
-                            entry: {
-                                tag: 'tag-test-2',
-                                id: 'd79bdbd0-9f55-45bb-9521-811e15bf48f6',
-                            },
-                        },
-                    ],
-                },
-            });
+            .reply(200, this.getPaginetedListOfTags());
+    }
+
+    getTagsByNamesIncludingCounters200Response(): void {
+        nock(this.host, { encodedQueryParams: true })
+            .get('/alfresco/api/-default-/public/alfresco/versions/1/tags?include=count&where=(tag%20in%20(%27tag-test-1%27%2C%20%27tag-test-2%27))')
+            .reply(200, this.getPaginetedListOfTags(true));
     }
 
     get401Response(): void {
@@ -58,5 +47,29 @@ export class TagMock extends BaseMock {
                     id: 'd79bdbd0-9f55-45bb-9521-811e15bf48f6',
                 },
             }]);
+    }
+
+    private getPaginetedListOfTags(includeCount?: boolean): TagPaging {
+        return {
+            list: {
+                pagination: { count: 2, hasMoreItems: false, skipCount: 0, maxItems: 100 },
+                entries: [
+                    {
+                        entry: {
+                            tag: 'tag-test-1',
+                            id: '0d89aa82-f2b8-4a37-9a54-f4c5148174d6',
+                            count: includeCount ? 0 : undefined
+                        },
+                    },
+                    {
+                        entry: {
+                            tag: 'tag-test-2',
+                            id: 'd79bdbd0-9f55-45bb-9521-811e15bf48f6',
+                            count: includeCount ? 1 : undefined
+                        },
+                    },
+                ],
+            },
+        }
     }
 }

--- a/test/mockObjects/content-services/tag.mock.ts
+++ b/test/mockObjects/content-services/tag.mock.ts
@@ -75,7 +75,12 @@ export class TagMock extends BaseMock {
     private getPaginetedListOfTags(): TagPaging {
         return {
             list: {
-                pagination: { count: 2, hasMoreItems: false, skipCount: 0, maxItems: 100 },
+                pagination: {
+                    count: 2,
+                    hasMoreItems: false,
+                    skipCount: 0,
+                    maxItems: 100
+                },
                 entries: [
                     {
                         entry: {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-4753


**What is the new behavior?**
Added possibility to load tags not only by exact matching but also by pattern matching, thanks that we can get counters together with searching. 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
ADF PR: https://github.com/Alfresco/alfresco-ng2-components/pull/8346
alfresco-applications PR: https://github.com/Alfresco/alfresco-applications/pull/73