### PR TITLE
[ACS-4966] Add path to category model

### DIFF
--- a/src/api/content-rest-api/api/categories.api.ts
+++ b/src/api/content-rest-api/api/categories.api.ts
@@ -58,6 +58,7 @@ export class CategoriesApi extends BaseApi {
 
         * @param opts.include Returns additional information about the category. The following optional fields can be requested:
             * count
+            * path
 
         * @return Promise<CategoryPaging>
     */
@@ -112,6 +113,7 @@ export class CategoriesApi extends BaseApi {
 
         * @param opts.include Returns additional information about the category. The following optional fields can be requested:
             * count
+            * path
 
         * @return Promise<CategoryEntry>
     */
@@ -162,6 +164,13 @@ export class CategoriesApi extends BaseApi {
     The list applies to a returned individual
     entity or entries within a collection.
 
+    If the API method also supports the **include**
+    parameter, then the fields specified in the **include**
+    parameter are returned in addition to those specified in the **fields** parameter.
+
+        * @param opts.include Returns additional information about the category. The following optional fields can be requested:
+            * path
+
         * @return Promise<CategoryPaging>
     */
     getCategoryLinksForNode(nodeId: string, opts?: any): Promise<CategoryPaging> {
@@ -176,7 +185,8 @@ export class CategoriesApi extends BaseApi {
         const queryParams = {
             'skipCount': opts['skipCount'],
             'maxItems': opts['maxItems'],
-            'fields': buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv')
         };
 
         const headerParams = {};
@@ -274,6 +284,10 @@ export class CategoriesApi extends BaseApi {
     parameter, then the fields specified in the **include**
     parameter are returned in addition to those specified in the **fields** parameter.
 
+    * @param opts.include Returns additional information about the category. The following optional fields can be requested:
+            * count
+            * path
+
     * @return Promise<CategoryEntry>
     */
     updateCategory(categoryId: string, categoryBodyUpdate: CategoryBody, opts?: any): Promise<CategoryEntry> {
@@ -289,7 +303,8 @@ export class CategoriesApi extends BaseApi {
         };
 
         const queryParams = {
-            'fields': buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv')
         };
 
         const headerParams = {};
@@ -372,6 +387,10 @@ export class CategoriesApi extends BaseApi {
     parameter, then the fields specified in the **include**
     parameter are returned in addition to those specified in the **fields** parameter.
 
+    * @param opts.include Returns additional information about the category. The following optional fields can be requested:
+            * count
+            * path
+
     * @return Promise<CategoryPaging | CategoryEntry>
     */
     createSubcategories(categoryId: string, categoryBodyCreate: CategoryBody[], opts?: any): Promise<CategoryPaging | CategoryEntry> {
@@ -387,7 +406,8 @@ export class CategoriesApi extends BaseApi {
         };
 
         const queryParams = {
-            'fields': buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv')
         };
 
         const headerParams = {};
@@ -468,6 +488,9 @@ export class CategoriesApi extends BaseApi {
     parameter, then the fields specified in the **include**
     parameter are returned in addition to those specified in the **fields** parameter.
 
+    * @param opts.include Returns additional information about the category. The following optional fields can be requested:
+            * path
+
     * @return Promise<CategoryPaging | CategoryEntry>
     */
     linkNodeToCategory(nodeId: string, categoryLinkBodyCreate: CategoryLinkBody[], opts?: any): Promise<CategoryPaging | CategoryEntry> {
@@ -483,7 +506,8 @@ export class CategoriesApi extends BaseApi {
         };
 
         const queryParams = {
-            'fields': buildCollectionParam(opts['fields'], 'csv')
+            'fields': buildCollectionParam(opts['fields'], 'csv'),
+            'include': buildCollectionParam(opts['include'], 'csv')
         };
 
         const headerParams = {};

--- a/src/api/content-rest-api/api/categories.api.ts
+++ b/src/api/content-rest-api/api/categories.api.ts
@@ -468,9 +468,9 @@ export class CategoriesApi extends BaseApi {
     parameter, then the fields specified in the **include**
     parameter are returned in addition to those specified in the **fields** parameter.
 
-    * @return Promise<CategoryEntry>
+    * @return Promise<CategoryPaging | CategoryEntry>
     */
-    linkNodeToCategory(nodeId: string, categoryLinkBodyCreate: CategoryLinkBody[], opts?: any): Promise<CategoryEntry> {
+    linkNodeToCategory(nodeId: string, categoryLinkBodyCreate: CategoryLinkBody[], opts?: any): Promise<CategoryPaging | CategoryEntry> {
 
         throwIfNotDefined(nodeId, 'nodeId');
         throwIfNotDefined(categoryLinkBodyCreate, 'categoryLinkBodyCreate');

--- a/src/api/content-rest-api/docs/Category.md
+++ b/src/api/content-rest-api/docs/Category.md
@@ -8,5 +8,6 @@ Name | Type | Description | Notes
 **parentId** | **string** |  | [optional] [default to null]
 **hasChildren** | **boolean** |  | [optional] [default to null]
 **count** | **number** |  | [optional] [default to null]
+**path** | **string** |  | [optional] [default to null]
 
 

--- a/src/api/content-rest-api/model/category.ts
+++ b/src/api/content-rest-api/model/category.ts
@@ -21,6 +21,7 @@ export class Category {
     parentId?: string;
     hasChildren?: boolean;
     count?: number;
+    path?: string;
 
     constructor(input?: any) {
         if (input) {

--- a/test/content-services/categoriesApi.spec.ts
+++ b/test/content-services/categoriesApi.spec.ts
@@ -6,6 +6,7 @@ import { EcmAuthMock } from '../../test/mockObjects';
 import { CategoriesMock } from '../mockObjects/content-services/categories.mock';
 import { CategoryPaging } from '../../src/api/content-rest-api/model/categoryPaging';
 import { CategoryEntry } from '../../src/api/content-rest-api/model/categoryEntry';
+import { fail } from 'assert';
 
 describe('Categories', () => {
     let authResponseMock: EcmAuthMock;
@@ -199,10 +200,22 @@ describe('Categories', () => {
             if (response instanceof CategoryEntry) {
                 expect(response.entry.id).equal('testId1');
                 expect(response.entry.name).equal('testName1');
+                done();
             } else {
-                expect(response.list.entries[0].entry.id).equal('testId1');
-                expect(response.list.entries[0].entry.name).equal('testName1');
+                fail();
             }
+        });
+    });
+
+    it('should return 201 while linking multiple categories if all is ok', (done) => {
+        categoriesMock.get201ResponseCategoryLinkedArray('testNodeArr');
+        categoriesApi.linkNodeToCategory('testNodeArr', [{ categoryId: 'testId1' }, { categoryId: 'testId2' }]).then((response) => {
+            const categoriesPaging = response as CategoryPaging;
+            expect(categoriesPaging.list.pagination.count).equal(2);
+            expect(categoriesPaging.list.entries[0].entry.id).equal('testId1');
+            expect(categoriesPaging.list.entries[0].entry.name).equal('testName1');
+            expect(categoriesPaging.list.entries[1].entry.id).equal('testId2');
+            expect(categoriesPaging.list.entries[1].entry.name).equal('testName2');
             done();
         });
     });

--- a/test/content-services/categoriesApi.spec.ts
+++ b/test/content-services/categoriesApi.spec.ts
@@ -195,9 +195,14 @@ describe('Categories', () => {
 
     it('should return 201 while linking category if all is ok', (done) => {
         categoriesMock.get201ResponseCategoryLinked('testNode');
-        categoriesApi.linkNodeToCategory('testNode', [{ categoryId: 'testId1' }]).then((response: CategoryEntry) => {
-            expect(response.entry.id).equal('testId1');
-            expect(response.entry.name).equal('testName1');
+        categoriesApi.linkNodeToCategory('testNode', [{ categoryId: 'testId1' }]).then((response) => {
+            if (response instanceof CategoryEntry) {
+                expect(response.entry.id).equal('testId1');
+                expect(response.entry.name).equal('testName1');
+            } else {
+                expect(response.list.entries[0].entry.id).equal('testId1');
+                expect(response.list.entries[0].entry.name).equal('testName1');
+            }
             done();
         });
     });

--- a/test/mockObjects/content-services/categories.mock.ts
+++ b/test/mockObjects/content-services/categories.mock.ts
@@ -249,6 +249,42 @@ export class CategoriesMock extends BaseMock {
             });
     }
 
+    get201ResponseCategoryLinkedArray(nodeId: string): void {
+        nock(this.host, { encodedQueryParams: true })
+            .post(`/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/category-links`, [{ categoryId: 'testId1' }, { categoryId: 'testId2' }])
+            .reply(201, {
+                list: {
+                    pagination: {
+                        count: 2,
+                        hasMoreItems: false,
+                        totalItems: 2,
+                        skipCount: 0,
+                        maxItems: 100,
+                    },
+                    entries: [
+                        {
+                            entry: {
+                                id: 'testId1',
+                                name: 'testName1',
+                                parentId: 'testNodeArr',
+                                hasChildren: true,
+                                count: 0
+                            }
+                        },
+                        {
+                            entry: {
+                                id: 'testId2',
+                                name: 'testName2',
+                                parentId: 'testNodeArr',
+                                hasChildren: true,
+                                count: 0
+                            }
+                        }
+                    ]
+                }
+            });
+    }
+
     get403CategoryLinkPermissionDenied(nodeId: string): void {
         nock(this.host, { encodedQueryParams: true }).post(`/alfresco/api/-default-/public/alfresco/versions/1/nodes/${nodeId}/category-links`, [{ categoryId: 'testId1' }])
         .reply(403, {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

There is not option to get path for categories. https://alfresco.atlassian.net/browse/ACS-4966

**What is the new behavior?**

Category model has been updated and there is an option to include path in categories requests.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
