### PR TITLE
[AAE-12502] Fix ticketEcm is not added to the alf_ticket moving basic auth in ADF

### DIFF
--- a/src/alfrescoApi.ts
+++ b/src/alfrescoApi.ts
@@ -65,7 +65,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
             config = {} as AlfrescoApiConfig;
         }
 
-        this.storage = new Storage();
+        this.storage = Storage.getInstance();
         this.storage.setDomainPrefix(config.domainPrefix);
 
         this.config = new AlfrescoApiConfig(config);

--- a/src/alfrescoApiClient.ts
+++ b/src/alfrescoApiClient.ts
@@ -21,6 +21,7 @@ import { Authentication } from './authentication/authentication';
 import { SuperagentHttpClient } from './superagentHttpClient';
 import { Emitters, HttpClient, RequestOptions, LegacyHttpClient, SecurityOptions } from './api-clients/http-client.interface';
 import { paramToString } from './utils';
+import { Storage } from './storage';
 
 declare const Buffer: any;
 
@@ -67,6 +68,7 @@ export class AlfrescoApiClient implements ee.Emitter, LegacyHttpClient {
     once: ee.EmitterMethod;
     emit: (type: string, ...args: any[]) => void;
 
+    storage: Storage;
     host: string;
     className: string;
     config: AlfrescoApiConfig;
@@ -103,6 +105,8 @@ export class AlfrescoApiClient implements ee.Emitter, LegacyHttpClient {
 
     constructor(host?: string, httpClient?: HttpClient) {
         this.host = host;
+
+        this.storage = Storage.getInstance();
 
         // fallback for backward compatibility
         this.httpClient = httpClient || new SuperagentHttpClient();
@@ -239,6 +243,8 @@ export class AlfrescoApiClient implements ee.Emitter, LegacyHttpClient {
             return ticketParam + ticket;
         } else if (this.config.ticketEcm) {
             return ticketParam + this.config.ticketEcm;
+        } else if (this.storage.getItem('ticket-ECM')) {
+            return ticketParam + this.storage.getItem('ticket-ECM');
         }
 
         return '';

--- a/src/authentication/contentAuth.ts
+++ b/src/authentication/contentAuth.ts
@@ -28,14 +28,13 @@ export class ContentAuth extends AlfrescoApiClient {
 
     ticketStorageLabel: string;
     ticket: string;
-    storage: Storage;
 
     authApi: AuthenticationApi;
 
     constructor(config: AlfrescoApiConfig, alfrescoApi: AlfrescoApiType, httpClient?: HttpClient) {
         super(undefined, httpClient);
         this.className = 'ContentAuth';
-        this.storage = new Storage();
+        this.storage = Storage.getInstance();
         this.storage.setDomainPrefix(config.domainPrefix);
 
         this.setConfig(config);

--- a/src/authentication/oauth2Auth.ts
+++ b/src/authentication/oauth2Auth.ts
@@ -48,7 +48,6 @@ export class Oauth2Auth extends AlfrescoApiClient {
     private refreshTokenIntervalPolling: any;
     private refreshTokenTimeoutIframe: any;
     private checkAccessToken = true;
-    storage: Storage;
 
     hashFragmentParams: any;
     token: string;
@@ -72,7 +71,7 @@ export class Oauth2Auth extends AlfrescoApiClient {
 
     constructor(config: AlfrescoApiConfig, alfrescoApi: AlfrescoApi, httpClient?: HttpClient) {
         super(undefined, httpClient);
-        this.storage = new Storage();
+        this.storage = Storage.getInstance();
 
         this.className = 'Oauth2Auth';
 

--- a/src/authentication/processAuth.ts
+++ b/src/authentication/processAuth.ts
@@ -26,7 +26,6 @@ import { isBrowser } from '../utils';
 export class ProcessAuth extends AlfrescoApiClient {
 
     ticket: string;
-    storage: Storage;
 
     authentications: Authentication = {
         'basicAuth': { ticket: '' }, type: 'activiti'
@@ -34,7 +33,7 @@ export class ProcessAuth extends AlfrescoApiClient {
 
     constructor(config: AlfrescoApiConfig, httpClient?: HttpClient) {
         super(undefined, httpClient);
-        this.storage = new Storage();
+        this.storage = Storage.getInstance();
         this.storage.setDomainPrefix(config.domainPrefix);
 
         this.className = 'ProcessAuth';

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -17,13 +17,22 @@
 
 export class Storage {
 
+    private static instance: Storage;
+
     _storage: any;
     prefix: string;
 
-    constructor() {
+    private constructor() {
         if (this.supportsStorage()) {
             this._storage = window.localStorage;
         }
+    }
+
+    public static getInstance(){
+        if(!Storage.instance){
+            Storage.instance = new Storage();
+        }
+        return Storage.instance;
     }
 
     supportsStorage() {

--- a/test/oauth2Auth.spec.ts
+++ b/test/oauth2Auth.spec.ts
@@ -19,7 +19,6 @@ import { AlfrescoApi } from '../src/alfrescoApi';
 import { AlfrescoApiConfig } from '../src/alfrescoApiConfig';
 import { Oauth2Auth } from '../src/authentication/oauth2Auth';
 import { ContentApi } from '../src/api/content-custom-api/api/content.api';
-import { Storage } from '../src/storage';
 
 const chai = require('chai');
 const expect = chai.expect;
@@ -39,14 +38,16 @@ describe('Oauth2  test', () => {
 
     beforeEach(() => {
         const hostOauth2 = 'http://myOauthUrl:30081';
+        const mockStorage = { getItem: () => {}, setItem: () => {}};
 
         oauth2Mock = new OAuthMock(hostOauth2);
         authResponseMock = new EcmAuthMock(hostOauth2);
 
-
         alfrescoJsApi = new AlfrescoApi({
             hostEcm: 'myecm'
         } as AlfrescoApiConfig);
+
+        alfrescoJsApi.storage.setStorage(mockStorage);
     });
 
     describe('Discovery urls', () => {
@@ -511,7 +512,6 @@ describe('Oauth2  test', () => {
         describe('With mocked DOM', () => {
             jsdom({ url: 'http://localhost' });
             it('a failed hash check calls the logout', () => {
-
                 const oauth2Auth = new Oauth2Auth(
                     <AlfrescoApiConfig> {
                         oauth2: {
@@ -527,7 +527,6 @@ describe('Oauth2  test', () => {
                     alfrescoJsApi
                 );
 
-                oauth2Auth.storage = new Storage();
                 oauth2Auth.createIframe();
 
                 const iframe = <HTMLIFrameElement> document.getElementById('silent_refresh_token_iframe');

--- a/test/oauth2AuthImplicitFlow.spec.ts
+++ b/test/oauth2AuthImplicitFlow.spec.ts
@@ -26,17 +26,23 @@ const globalAny: any = global;
 const chai = require('chai');
 const spies = require('chai-spies');
 chai.use(spies);
-import { Storage } from '../src/storage';
 
 describe('Oauth2 Implicit flow test', () => {
     let oauth2Auth: Oauth2Auth;
     let alfrescoJsApi: AlfrescoApi;
+    let setItemSpy: any;
 
     beforeEach(() => {
         alfrescoJsApi = new AlfrescoApi({
             hostEcm: ''
         } as AlfrescoApiConfig);
+
+        setItemSpy = chai.spy.on(alfrescoJsApi.storage, 'setItem');
     });
+
+    afterEach(()=>{
+        chai.spy.restore(alfrescoJsApi.storage, 'setItem');
+    })
 
     it('should throw an error if redirectUri is not present', (done) => {
         try {
@@ -110,12 +116,10 @@ describe('Oauth2 Implicit flow test', () => {
             alfrescoJsApi
         );
 
-        const redirectLoginSpy = chai.spy.on(oauth2Auth.storage, 'setItem');
-
         oauth2Auth.on('implicit_redirect', () => {
             expect(window.location.href).contain('http://myOauthUrl:30081/auth/realms/springboot/protocol/' +
                 'openid-connect/auth?');
-            expect(redirectLoginSpy).to.have.been.called(1);
+            expect(setItemSpy).to.have.been.called(1);
             done();
         });
 
@@ -192,8 +196,6 @@ describe('Oauth2 Implicit flow test', () => {
             } as AlfrescoApiConfig,
             alfrescoJsApi
         );
-        oauth2Auth.storage = new Storage();
-        const setItemSpy = chai.spy.on(oauth2Auth.storage, 'setItem');
 
         oauth2Auth.on('implicit_redirect', () => {
             expect(window.location.href).contain('http://myOauthUrl:30081/auth/realms/springboot/protocol/' +


### PR DESCRIPTION
…t in not added to the content api because config.ticketECM is undefined

**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-js-api/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-js-api/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Moving basic auth in ADF https://github.com/Alfresco/alfresco-ng2-components/pull/8689, the content authentication will be handled by the [content-auth.ts](https://github.com/Alfresco/alfresco-ng2-components/blob/dev-eromano-AAE-12501-2/lib/core/src/lib/auth/basic-auth/content-auth.ts#L91) and the e2e that open a file with the file-viewer failed because the alf_ticket is not added to the contentApi. Since the content-auth.ts can't update AlfrescoApiConfig, it's needed to get the ticketEcm from the Storage.


**What is the new behavior?**
The Storage is handled as Singleton, the instance is created by AlfrescoApi and the AlfrescoApiClient can access the Storage the ticketEcm https://github.com/Alfresco/alfresco-js-api/blob/dev-alepore-AAE-12502/src/alfrescoApiClient.ts#L246


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
